### PR TITLE
feat(app): arena + app shell

### DIFF
--- a/.cursor/rules/ui-design-guidelines.mdc
+++ b/.cursor/rules/ui-design-guidelines.mdc
@@ -14,7 +14,7 @@ alwaysApply: true
 | Token | Value | Usage |
 |-------|-------|-------|
 | `--background` | `#0a0a0f` | App background |
-| `--primary` | `#ff4500` | CTAs, active states, highlights |
+| `--primary` | `#dc2626` | CTAs, active states, highlights |
 | `--accent` | `#ffb800` | Gold trophies, streak badges |
 | `--card` | `#111118` | Card backgrounds |
 | `--muted` | `#1c1c28` | Subtle surfaces |

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -372,6 +372,14 @@ Challenge feed (Trending, New). Challenge detail page with rules, equipment tags
 
 ### Tasks
 
+#### App shell (navigation needed for Arena)
+
+- [ ] 🔴 App header (TRUEGRYND left, lang/theme right)
+- [ ] 🔴 Bottom dock tab bar (mobile): Overview | Arena | Clan | Profile
+- [ ] 🔴 Routes exist for the 4 tabs (Clan/Profile can be placeholders until their issues)
+- [ ] 🔴 Route protection: redirect to login if unauthenticated, to onboarding if profile incomplete
+- [ ] 🔴 All labels/copy from i18n
+
 #### Challenge feed
 
 - [ ] 🔴 Scrollable list of challenges (from `challenges` where status = approved)
@@ -557,11 +565,10 @@ Authenticated layout with 4 tabs: Overview, Arena, Clan, Profile. Overview: dail
 
 #### Layout & navigation
 
-- [ ] 🔴 Main layout with content area + tab bar (mobile bottom, desktop top or sidebar)
-- [ ] 🔴 4 tabs: Overview | Arena | Clan | Profile
-- [ ] 🔴 Next.js routing: /app or /dashboard with segments per tab
-- [ ] 🔴 Route protection: redirect to login if unauthenticated, to onboarding if profile incomplete
-- [ ] 🔴 Tab labels from i18n
+- [ ] 🔴 Polish/extend app shell: desktop variant (top tabs or sidebar), safe-area, animations
+- [ ] 🔴 Ensure tab state + active route styling across nested routes (e.g. challenge detail)
+- [ ] 🔴 Refine route protection + redirects (edge cases, back button, deep links)
+- [ ] 🔴 Tab labels from i18n (audit + consistency)
 
 #### Overview tab
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -361,7 +361,7 @@ Sports identity card (username, sex, age, weight). Simplified initiation: 3 chal
 
 ## 🎯 Issue #5: Arena & challenges (feed, challenge page, leaderboard)
 
-**Status:** 🔴 **NOT STARTED**  
+**Status:** 🟡 **IN PROGRESS**  
 **Priority:** HIGH  
 **Phase:** Screen 3  
 **Dependencies:** Issue #1, #2, #3, #4
@@ -374,48 +374,50 @@ Challenge feed (Trending, New). Challenge detail page with rules, equipment tags
 
 #### App shell (navigation needed for Arena)
 
-- [ ] 🔴 App header (TRUEGRYND left, lang/theme right)
-- [ ] 🔴 Bottom dock tab bar (mobile): Overview | Arena | Clan | Profile
-- [ ] 🔴 Routes exist for the 4 tabs (Clan/Profile can be placeholders until their issues)
-- [ ] 🔴 Route protection: redirect to login if unauthenticated, to onboarding if profile incomplete
-- [ ] 🔴 All labels/copy from i18n
+- [x] 🟢 App header (TRUEGRYND left, lang/theme right)
+- [x] 🟢 Bottom dock tab bar (mobile): Overview | Arena | Clan | Profile
+- [x] 🟢 Top inline nav (desktop md+) inside the app header
+- [x] 🟢 Routes exist for the 4 tabs (Clan/Profile placeholders for now)
+- [x] 🟢 Route protection: redirect to login if unauthenticated, to onboarding if profile incomplete
+- [x] 🟢 All labels/copy from i18n
+- [x] 🟢 Brand primary switched from orange `#ff4500` to red `#dc2626` (Combat HUD)
 
 #### Challenge feed
 
-- [ ] 🔴 Scrollable list of challenges (from `challenges` where status = approved)
-- [ ] 🔴 Sections/tabs: “Trending”, “New”
-- [ ] 🔴 Challenge card: title, short summary, tags (#Bodyweight, #Dumbbells, etc.), score_type
-- [ ] 🔴 Click card → challenge detail page
-- [ ] 🔴 Empty, loading, error states
-- [ ] 🔴 All labels/copy from i18n
+- [x] 🟢 Scrollable list of challenges (from `challenges` where status = approved)
+- [ ] 🔴 Sections/tabs: “Trending”, “New” (deferred — single feed for MVP)
+- [x] 🟢 Challenge card: title, short summary, tags, score_type, OFFICIAL badge
+- [x] 🟢 Click card → challenge detail page
+- [x] 🟢 Empty, loading, error states
+- [x] 🟢 All labels/copy from i18n
 
 #### Challenge page
 
-- [ ] 🔴 Display: title, description, full rules, equipment tags, score_type
-- [ ] 🔴 “Official” badge if is_official
-- [ ] 🔴 Leaderboard for this challenge (below)
-- [ ] 🔴 Primary CTA “I’m in / Start” → leads to score submission (Issue #6)
+- [x] 🟢 Display: title, description, full rules, equipment tags, score_type
+- [x] 🟢 “Official” badge if is_official
+- [x] 🟢 Leaderboard for this challenge (below)
+- [ ] 🟡 Primary CTA “I’m in / Start” (placeholder, score submission lands in Issue #6)
 
 #### Leaderboard per challenge
 
-- [ ] 🔴 Fetch validated scores for this challenge_id (sort: time asc or reps desc by score_type)
-- [ ] 🔴 Columns: rank, user (username), score (formatted), Faction (optional)
-- [ ] 🔴 Filters: Global | By age bracket | By sex | By Faction
-- [ ] 🔴 Pagination or lazy load if needed
+- [x] 🟢 Fetch validated scores for this challenge_id (sort: time asc or reps desc by score_type)
+- [x] 🟢 Columns: rank, user (username), score (formatted)
+- [x] 🟢 Filters: Global | By age bracket | By sex | By Faction
+- [ ] 🔴 Pagination or lazy load if needed (capped at 100 for now)
 - [ ] 🔴 (Optional) “Respect” 👊 button (post-MVP)
-- [ ] 🔴 Copy from i18n
+- [x] 🟢 Copy from i18n
 
 #### Data
 
-- [ ] 🔴 Use seeded challenges (Issue #1)
-- [ ] 🔴 Supabase calls from features/challenges (services or hooks)
+- [ ] 🟡 Use seeded challenges (Issue #1) — schema/seed will be added with Issue #1; queries already target the `challenges` table.
+- [x] 🟢 Supabase calls from `features/challenges/services/`
 
 ### Acceptance criteria
 
-- [ ] Feed shows available challenges
-- [ ] Challenge page shows full info + leaderboard
-- [ ] Leaderboard filterable (global, age, sex, faction)
-- [ ] CTA leads to score submission
+- [x] Feed shows available challenges
+- [x] Challenge page shows full info + leaderboard
+- [x] Leaderboard filterable (global, age, sex, faction)
+- [ ] CTA leads to score submission (Issue #6)
 
 ---
 
@@ -672,14 +674,14 @@ To be done after MVP ship.
 | #2 i18n & theme             | 🟡 In Progress | 70%  |
 | #3 Auth                     | 🟡 In Progress | 90%  |
 | #4 Onboarding               | 🟢 Completed   | 100% |
-| #5 Arena & challenges       | 🔴 Not Started | 0%   |
+| #5 Arena & challenges       | 🟡 In Progress | 65%  |
 | #6 Submission & Smart Proof | 🔴 Not Started | 0%   |
 | #7 Finisher Card            | 🔴 Not Started | 0%   |
 | #8 Profile                  | 🔴 Not Started | 0%   |
 | #9 Navigation & layout      | 🔴 Not Started | 0%   |
 | #10 Polish & deployment     | 🔴 Not Started | 0%   |
 
-**Overall MVP:** ~25% (foundation done, auth + onboarding largely done, rest to do).
+**Overall MVP:** ~32% (foundation done, auth + onboarding largely done, app shell + Arena/leaderboard scaffold landed, rest to do).
 
 ---
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -23,3 +23,13 @@ test('onboarding redirects to auth when logged out', async ({ page }) => {
   await expect(page).toHaveURL(/\/en\/auth$/);
   await expect(page.getByRole('heading', { name: /truegrynd/i })).toBeVisible();
 });
+
+test('arena redirects to auth when logged out', async ({ page }) => {
+  await page.goto('/en/app/arena');
+  await expect(page).toHaveURL(/\/en\/auth$/);
+});
+
+test('challenge detail redirects to auth when logged out', async ({ page }) => {
+  await page.goto('/en/app/arena/some-id');
+  await expect(page).toHaveURL(/\/en\/auth$/);
+});

--- a/src/app/[locale]/app/arena/[challengeId]/page.tsx
+++ b/src/app/[locale]/app/arena/[challengeId]/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { use } from 'react';
+
+import { ChallengeDetail } from '@/features/challenges/components/ChallengeDetail';
+
+type Params = { challengeId: string; locale: string };
+
+export default function ChallengeDetailPage({ params }: { params: Promise<Params> }) {
+  const { challengeId } = use(params);
+  return <ChallengeDetail challengeId={challengeId} />;
+}

--- a/src/app/[locale]/app/arena/page.tsx
+++ b/src/app/[locale]/app/arena/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ArenaScreen } from '@/features/challenges/components/ArenaScreen';
+
+export default function ArenaPage() {
+  return <ArenaScreen />;
+}

--- a/src/app/[locale]/app/clan/page.tsx
+++ b/src/app/[locale]/app/clan/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export default function ClanPage() {
+  const tabs = useTranslations('app.tabs');
+  const cs = useTranslations('app.comingSoon');
+
+  return (
+    <section className="space-y-3">
+      <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{tabs('clan')}</h1>
+      <div className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{cs('title')}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{cs('body')}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/[locale]/app/layout.tsx
+++ b/src/app/[locale]/app/layout.tsx
@@ -1,0 +1,5 @@
+import { AppShell } from '@/features/appshell';
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return <AppShell>{children}</AppShell>;
+}

--- a/src/app/[locale]/app/overview/page.tsx
+++ b/src/app/[locale]/app/overview/page.tsx
@@ -1,14 +1,14 @@
+'use client';
+
 import { useTranslations } from 'next-intl';
 
 export default function OverviewPage() {
   const t = useTranslations('app');
 
   return (
-    <main className="min-h-screen bg-background text-foreground px-4 py-10">
-      <div className="mx-auto w-full max-w-lg">
-        <h1 className="text-3xl font-black tracking-tight">{t('overviewTitle')}</h1>
-        <p className="mt-3 text-sm text-muted-foreground">{t('overviewBody')}</p>
-      </div>
-    </main>
+    <section className="space-y-3">
+      <h1 className="text-2xl md:text-3xl font-black tracking-tight">{t('overviewTitle')}</h1>
+      <p className="text-sm text-muted-foreground">{t('overviewBody')}</p>
+    </section>
   );
 }

--- a/src/app/[locale]/app/profile/page.tsx
+++ b/src/app/[locale]/app/profile/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export default function ProfilePage() {
+  const tabs = useTranslations('app.tabs');
+  const cs = useTranslations('app.comingSoon');
+
+  return (
+    <section className="space-y-3">
+      <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
+        {tabs('profile')}
+      </h1>
+      <div className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{cs('title')}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{cs('body')}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,15 +7,15 @@
     --foreground: #050509;
     --card: #ffffff;
     --card-foreground: #050509;
-    --primary: #ff4500;
-    --primary-foreground: #050509;
+    --primary: #dc2626;
+    --primary-foreground: #f9fafb;
     --accent: #ffb800;
     --accent-foreground: #050509;
     --muted: #f3f4f6;
     --muted-foreground: #6b7280;
     --border: #e5e7eb;
     --input: #ffffff;
-    --ring: #ff4500;
+    --ring: #dc2626;
 
     /* Factions */
     --faction-nomads: #4a9e6f;
@@ -29,15 +29,15 @@
     --foreground: #f9fafb;
     --card: #111118;
     --card-foreground: #f9fafb;
-    --primary: #ff4500;
-    --primary-foreground: #050509;
+    --primary: #dc2626;
+    --primary-foreground: #f9fafb;
     --accent: #ffb800;
     --accent-foreground: #050509;
     --muted: #1c1c28;
     --muted-foreground: #9ca3af;
     --border: #2a2a3a;
     --input: #2a2a3a;
-    --ring: #ff4500;
+    --ring: #dc2626;
 
     --faction-nomads: #4a9e6f;
     --faction-horde: #c0392b;

--- a/src/features/appshell/components/AppHeader.tsx
+++ b/src/features/appshell/components/AppHeader.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale } from 'next-intl';
+
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { DesktopNav } from '@/features/appshell/components/DesktopNav';
+
+export function AppHeader() {
+  const locale = useLocale();
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-border bg-background/85 backdrop-blur supports-[backdrop-filter]:bg-background/65">
+      <div className="mx-auto flex h-14 w-full max-w-5xl items-center justify-between gap-4 px-4">
+        <Link
+          href={`/${locale}/app/overview`}
+          className="text-sm font-black uppercase tracking-[0.18em] text-foreground"
+        >
+          TRUEGRYND
+        </Link>
+
+        <DesktopNav />
+
+        <div className="flex items-center gap-1.5">
+          <ThemeToggle size="sm" />
+          <LanguageSwitcher variant="dropdown" size="sm" />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/features/appshell/components/AppShell.tsx
+++ b/src/features/appshell/components/AppShell.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { AppHeader } from '@/features/appshell/components/AppHeader';
+import { BottomDock } from '@/features/appshell/components/BottomDock';
+import { useRequireAppAccess } from '@/features/appshell/hooks/useRequireAppAccess';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function AppShellLoading() {
+  const t = useTranslations('app');
+  return (
+    <main
+      role="status"
+      aria-live="polite"
+      className="min-h-screen bg-background text-foreground px-4 pt-24"
+    >
+      <p className="text-sm text-muted-foreground">{t('loading')}</p>
+    </main>
+  );
+}
+
+export function AppShell({ children }: Props) {
+  const access = useRequireAppAccess();
+
+  if (access.status !== 'ready') {
+    return <AppShellLoading />;
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <AppHeader />
+      <main className="mx-auto w-full max-w-5xl px-4 pt-4 pb-24 md:pb-10">{children}</main>
+      <BottomDock />
+    </div>
+  );
+}

--- a/src/features/appshell/components/BottomDock.tsx
+++ b/src/features/appshell/components/BottomDock.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { APP_TABS, isTabActive, type AppTab } from '@/features/appshell/lib/tabs';
+
+type DockItemProps = {
+  tab: AppTab;
+  isActive: boolean;
+  href: string;
+  label: string;
+};
+
+function DockItem({ tab, isActive, href, label }: DockItemProps) {
+  const Icon = tab.icon;
+  return (
+    <li className="flex-1">
+      <Link
+        href={href}
+        className="relative flex h-full flex-col items-center justify-center gap-1 px-1 py-2"
+        aria-current={isActive ? 'page' : undefined}
+        aria-label={label}
+      >
+        {isActive ? (
+          <span
+            aria-hidden="true"
+            className="absolute top-0 left-1/2 h-[2px] w-10 -translate-x-1/2 bg-primary"
+          />
+        ) : null}
+        <Icon
+          className={`h-5 w-5 ${isActive ? 'text-primary' : 'text-muted-foreground'}`}
+          strokeWidth={isActive ? 2.4 : 1.8}
+        />
+        <span
+          className={`text-[10px] font-black uppercase tracking-[0.18em] ${
+            isActive ? 'text-primary' : 'text-muted-foreground'
+          }`}
+        >
+          {label}
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+export function BottomDock() {
+  const pathname = usePathname();
+  const locale = useLocale();
+  const t = useTranslations('app.tabs');
+
+  return (
+    <nav
+      aria-label="Primary mobile"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-card/85 backdrop-blur supports-[backdrop-filter]:bg-card/70 md:hidden"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      <ul className="mx-auto flex h-16 w-full max-w-md items-stretch">
+        {APP_TABS.map((tab) => (
+          <DockItem
+            key={tab.id}
+            tab={tab}
+            isActive={isTabActive(pathname, locale, tab)}
+            href={`/${locale}${tab.path}`}
+            label={t(tab.labelKey)}
+          />
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/features/appshell/components/DesktopNav.tsx
+++ b/src/features/appshell/components/DesktopNav.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { APP_TABS, isTabActive } from '@/features/appshell/lib/tabs';
+
+function activeClassName(isActive: boolean): string {
+  return [
+    'relative px-1 py-2 text-xs font-black uppercase tracking-[0.18em] transition-colors',
+    isActive ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+  ].join(' ');
+}
+
+export function DesktopNav() {
+  const pathname = usePathname();
+  const locale = useLocale();
+  const t = useTranslations('app.tabs');
+
+  return (
+    <nav className="hidden md:flex items-center gap-7" aria-label="Primary">
+      {APP_TABS.map((tab) => {
+        const active = isTabActive(pathname, locale, tab);
+        return (
+          <Link
+            key={tab.id}
+            href={`/${locale}${tab.path}`}
+            className={activeClassName(active)}
+            aria-current={active ? 'page' : undefined}
+          >
+            {t(tab.labelKey)}
+            {active ? (
+              <span
+                aria-hidden="true"
+                className="absolute -bottom-[5px] left-0 right-0 h-[2px] bg-primary"
+              />
+            ) : null}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/features/appshell/hooks/useRequireAppAccess.ts
+++ b/src/features/appshell/hooks/useRequireAppAccess.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useLocale } from 'next-intl';
+import { useRouter } from 'next/navigation';
+
+import { useAuth } from '@/features/auth/AuthProvider';
+import { fetchOrEnsureProfile } from '@/features/onboarding/services/onboarding';
+import { isProfileComplete, type CompleteProfile, type Profile } from '@/lib/types/database.types';
+
+type State =
+  | { status: 'loading'; profile: null }
+  | { status: 'redirecting'; profile: null }
+  | { status: 'ready'; profile: CompleteProfile };
+
+const loadingState: State = { status: 'loading', profile: null };
+const redirectingState: State = { status: 'redirecting', profile: null };
+
+/**
+ * Gates `/app/*` routes:
+ * - not initialized / no user -> redirect to `/auth`
+ * - profile incomplete -> redirect to `/onboarding`
+ * - otherwise -> resolved profile + status `ready`.
+ */
+export function useRequireAppAccess(): State {
+  const { user, initialized } = useAuth();
+  const router = useRouter();
+  const locale = useLocale();
+  const [state, setState] = useState<State>(loadingState);
+
+  useEffect(() => {
+    if (!initialized) return undefined;
+
+    if (!user) {
+      router.replace(`/${locale}/auth`);
+      return undefined;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const profile: Profile = await fetchOrEnsureProfile(user.id);
+        if (cancelled) return;
+
+        if (!isProfileComplete(profile)) {
+          setState(redirectingState);
+          router.replace(`/${locale}/onboarding`);
+          return;
+        }
+
+        setState({ status: 'ready', profile });
+      } catch {
+        if (cancelled) return;
+        setState(redirectingState);
+        router.replace(`/${locale}/auth`);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [initialized, user, router, locale]);
+
+  return state;
+}

--- a/src/features/appshell/index.ts
+++ b/src/features/appshell/index.ts
@@ -1,0 +1,4 @@
+export { AppShell } from '@/features/appshell/components/AppShell';
+export { useRequireAppAccess } from '@/features/appshell/hooks/useRequireAppAccess';
+export { APP_TABS, isTabActive } from '@/features/appshell/lib/tabs';
+export type { AppTab, AppTabId } from '@/features/appshell/lib/tabs';

--- a/src/features/appshell/lib/tabs.ts
+++ b/src/features/appshell/lib/tabs.ts
@@ -1,0 +1,24 @@
+import { Activity, Swords, ShieldHalf, UserRound, type LucideIcon } from 'lucide-react';
+
+export type AppTabId = 'overview' | 'arena' | 'clan' | 'profile';
+
+export type AppTab = {
+  id: AppTabId;
+  /** Path under /{locale}, starting with `/app/...` */
+  path: `/app/${string}`;
+  icon: LucideIcon;
+  /** i18n key under the `app.tabs` namespace. */
+  labelKey: AppTabId;
+};
+
+export const APP_TABS: readonly AppTab[] = [
+  { id: 'overview', path: '/app/overview', icon: Activity, labelKey: 'overview' },
+  { id: 'arena', path: '/app/arena', icon: Swords, labelKey: 'arena' },
+  { id: 'clan', path: '/app/clan', icon: ShieldHalf, labelKey: 'clan' },
+  { id: 'profile', path: '/app/profile', icon: UserRound, labelKey: 'profile' },
+] as const;
+
+export function isTabActive(pathname: string, locale: string, tab: AppTab): boolean {
+  const localized = `/${locale}${tab.path}`;
+  return pathname === localized || pathname.startsWith(`${localized}/`);
+}

--- a/src/features/challenges/components/ArenaScreen.tsx
+++ b/src/features/challenges/components/ArenaScreen.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { ChallengeList } from '@/features/challenges/components/ChallengeList';
 import { useChallenges } from '@/features/challenges/hooks/useChallenges';
+import { rankChallenges, type ArenaTab } from '@/features/challenges/lib/arenaRanking';
 
 function ArenaHeader() {
   const t = useTranslations('arena');
@@ -52,12 +54,60 @@ function ArenaError({ onRetry }: { onRetry: () => void }) {
   );
 }
 
+type TabButtonProps = {
+  tab: ArenaTab;
+  active: boolean;
+  label: string;
+  onSelect: (tab: ArenaTab) => void;
+};
+
+function TabButton({ tab, active, label, onSelect }: TabButtonProps) {
+  const className = [
+    'rounded-sm border px-2 py-1 text-[11px] font-black uppercase tracking-[0.14em] transition-colors',
+    active
+      ? 'border-primary bg-primary/15 text-primary'
+      : 'border-border bg-background text-muted-foreground hover:text-foreground',
+  ].join(' ');
+
+  return (
+    <button type="button" className={className} onClick={() => onSelect(tab)}>
+      {label}
+    </button>
+  );
+}
+
+function ArenaTabs({
+  activeTab,
+  onChange,
+}: {
+  activeTab: ArenaTab;
+  onChange: (tab: ArenaTab) => void;
+}) {
+  const t = useTranslations('arena.tabs');
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <TabButton
+        tab="trending"
+        active={activeTab === 'trending'}
+        label={t('trending')}
+        onSelect={onChange}
+      />
+      <TabButton tab="new" active={activeTab === 'new'} label={t('new')} onSelect={onChange} />
+    </div>
+  );
+}
+
 export function ArenaScreen() {
   const { data, loading, error, refetch } = useChallenges();
+  const [tab, setTab] = useState<ArenaTab>('trending');
+
+  const ranked = useMemo(() => rankChallenges(data, tab), [data, tab]);
 
   return (
     <section className="space-y-5">
       <ArenaHeader />
+      <ArenaTabs activeTab={tab} onChange={setTab} />
 
       {loading ? <ArenaLoading /> : null}
 
@@ -65,7 +115,7 @@ export function ArenaScreen() {
 
       {!loading && !error && data.length === 0 ? <ArenaEmpty /> : null}
 
-      {!loading && !error && data.length > 0 ? <ChallengeList challenges={data} /> : null}
+      {!loading && !error && ranked.length > 0 ? <ChallengeList challenges={ranked} /> : null}
     </section>
   );
 }

--- a/src/features/challenges/components/ArenaScreen.tsx
+++ b/src/features/challenges/components/ArenaScreen.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { ChallengeList } from '@/features/challenges/components/ChallengeList';
+import { useChallenges } from '@/features/challenges/hooks/useChallenges';
+
+function ArenaHeader() {
+  const t = useTranslations('arena');
+  return (
+    <header className="space-y-1">
+      <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+      <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+    </header>
+  );
+}
+
+function ArenaLoading() {
+  const t = useTranslations('arena');
+  return (
+    <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+      {t('loading')}
+    </p>
+  );
+}
+
+function ArenaEmpty() {
+  const t = useTranslations('arena');
+  return (
+    <div className="rounded-md border border-border bg-card p-6 text-center">
+      <p className="text-sm text-muted-foreground">{t('empty')}</p>
+    </div>
+  );
+}
+
+function ArenaError({ onRetry }: { onRetry: () => void }) {
+  const t = useTranslations('arena');
+  return (
+    <div className="rounded-md border border-primary/40 bg-primary/10 p-4">
+      <p className="text-sm font-black uppercase tracking-[0.18em] text-primary">
+        {t('errorTitle')}
+      </p>
+      <p className="mt-1 text-sm text-foreground/80">{t('errorBody')}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 inline-flex items-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t('retry')}
+      </button>
+    </div>
+  );
+}
+
+export function ArenaScreen() {
+  const { data, loading, error, refetch } = useChallenges();
+
+  return (
+    <section className="space-y-5">
+      <ArenaHeader />
+
+      {loading ? <ArenaLoading /> : null}
+
+      {!loading && error ? <ArenaError onRetry={() => void refetch()} /> : null}
+
+      {!loading && !error && data.length === 0 ? <ArenaEmpty /> : null}
+
+      {!loading && !error && data.length > 0 ? <ChallengeList challenges={data} /> : null}
+    </section>
+  );
+}

--- a/src/features/challenges/components/ChallengeCard.tsx
+++ b/src/features/challenges/components/ChallengeCard.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import type { Challenge } from '@/lib/types/database.types';
+
+type Props = {
+  challenge: Challenge;
+};
+
+function ScoreTypeBadge({ scoreType }: { scoreType: Challenge['score_type'] }) {
+  const t = useTranslations('arena.scoreType');
+  return (
+    <span className="inline-flex items-center rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+      {t(scoreType)}
+    </span>
+  );
+}
+
+function OfficialBadge() {
+  const t = useTranslations('arena');
+  return (
+    <span className="inline-flex items-center rounded-sm bg-primary/15 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-primary">
+      {t('officialBadge')}
+    </span>
+  );
+}
+
+export function ChallengeCard({ challenge }: Props) {
+  const locale = useLocale();
+  const href = `/${locale}/app/arena/${challenge.id}`;
+
+  return (
+    <Link
+      href={href}
+      className="group relative flex h-full flex-col overflow-hidden rounded-md border border-border bg-card p-4 transition-colors hover:border-primary/60 focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span
+        aria-hidden="true"
+        className="absolute inset-y-0 left-0 w-[3px] bg-transparent transition-colors group-hover:bg-primary"
+      />
+
+      <div className="flex items-center gap-2">
+        <ScoreTypeBadge scoreType={challenge.score_type} />
+        {challenge.is_official ? <OfficialBadge /> : null}
+      </div>
+
+      <h3 className="mt-3 text-base font-black uppercase tracking-tight text-foreground">
+        {challenge.title}
+      </h3>
+      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{challenge.description}</p>
+
+      {challenge.equipment_tags.length > 0 ? (
+        <ul className="mt-3 flex flex-wrap gap-1.5">
+          {challenge.equipment_tags.map((tag) => (
+            <li
+              key={tag}
+              className="rounded-sm border border-border bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+            >
+              #{tag}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </Link>
+  );
+}

--- a/src/features/challenges/components/ChallengeDetail.tsx
+++ b/src/features/challenges/components/ChallengeDetail.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { Leaderboard } from '@/features/challenges/components/Leaderboard';
+import { useChallenge } from '@/features/challenges/hooks/useChallenge';
+
+type Props = {
+  challengeId: string;
+};
+
+function BackLink() {
+  const locale = useLocale();
+  const t = useTranslations('challenge');
+  return (
+    <Link
+      href={`/${locale}/app/arena`}
+      className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-3.5 w-3.5" />
+      {t('back')}
+    </Link>
+  );
+}
+
+function NotFound() {
+  const t = useTranslations('challenge');
+  return (
+    <section className="space-y-3">
+      <BackLink />
+      <h1 className="text-2xl font-black uppercase tracking-tight">{t('notFoundTitle')}</h1>
+      <p className="text-sm text-muted-foreground">{t('notFoundBody')}</p>
+    </section>
+  );
+}
+
+export function ChallengeDetail({ challengeId }: Props) {
+  const t = useTranslations('challenge');
+  const tArena = useTranslations('arena');
+  const { data: challenge, loading, error } = useChallenge(challengeId);
+
+  if (loading) {
+    return (
+      <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+        {t('loading')}
+      </p>
+    );
+  }
+
+  if (error || !challenge) return <NotFound />;
+
+  return (
+    <section className="space-y-6">
+      <BackLink />
+
+      <header className="space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {tArena(`scoreType.${challenge.score_type}`)}
+          </span>
+          {challenge.is_official ? (
+            <span className="inline-flex items-center rounded-sm bg-primary/15 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-primary">
+              {tArena('officialBadge')}
+            </span>
+          ) : null}
+        </div>
+        <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
+          {challenge.title}
+        </h1>
+        <p className="text-sm text-foreground/80">{challenge.description}</p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <article className="space-y-2 rounded-md border border-border bg-card p-4">
+          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('rulesHeading')}
+          </h2>
+          <p className="whitespace-pre-line text-sm text-foreground/90">{challenge.rules}</p>
+        </article>
+
+        <article className="space-y-2 rounded-md border border-border bg-card p-4">
+          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('equipmentHeading')}
+          </h2>
+          {challenge.equipment_tags.length > 0 ? (
+            <ul className="flex flex-wrap gap-1.5">
+              {challenge.equipment_tags.map((tag) => (
+                <li
+                  key={tag}
+                  className="rounded-sm border border-border bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+                >
+                  #{tag}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">{t('noEquipment')}</p>
+          )}
+        </article>
+      </div>
+
+      <div className="rounded-md border border-border bg-card p-4">
+        <button
+          type="button"
+          disabled
+          aria-disabled="true"
+          className="w-full rounded-md bg-primary/40 px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground cursor-not-allowed"
+          title={t('ctaComingSoon')}
+        >
+          {t('ctaStart')}
+        </button>
+        <p className="mt-2 text-center text-xs text-muted-foreground">{t('ctaComingSoon')}</p>
+      </div>
+
+      <Leaderboard challengeId={challenge.id} scoreType={challenge.score_type} />
+    </section>
+  );
+}

--- a/src/features/challenges/components/ChallengeList.tsx
+++ b/src/features/challenges/components/ChallengeList.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ChallengeCard } from '@/features/challenges/components/ChallengeCard';
+import type { Challenge } from '@/lib/types/database.types';
+
+type Props = {
+  challenges: readonly Challenge[];
+};
+
+export function ChallengeList({ challenges }: Props) {
+  return (
+    <ul className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+      {challenges.map((challenge) => (
+        <li key={challenge.id} className="h-full">
+          <ChallengeCard challenge={challenge} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/challenges/components/Leaderboard.tsx
+++ b/src/features/challenges/components/Leaderboard.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { LeaderboardFiltersBar } from '@/features/challenges/components/LeaderboardFilters';
+import { applyLeaderboardFilters } from '@/features/challenges/lib/applyFilters';
+import { formatScore } from '@/features/challenges/lib/scoreFormat';
+import { sortScoresByType } from '@/features/challenges/lib/leaderboardSort';
+import {
+  EMPTY_FILTERS,
+  type LeaderboardEntry,
+  type LeaderboardFilters,
+} from '@/features/challenges/lib/types';
+import { useChallengeLeaderboard } from '@/features/challenges/hooks/useChallengeLeaderboard';
+import type { ScoreType } from '@/lib/types/database.types';
+
+type Props = {
+  challengeId: string;
+  scoreType: ScoreType;
+};
+
+function LeaderboardRow({
+  rank,
+  entry,
+  scoreType,
+}: {
+  rank: number;
+  entry: LeaderboardEntry;
+  scoreType: ScoreType;
+}) {
+  const username = entry.profile?.username ?? '—';
+  return (
+    <li className="grid grid-cols-[3rem_1fr_auto] items-center gap-3 border-b border-border px-3 py-2 last:border-b-0">
+      <span className="font-mono text-sm tabular-nums text-muted-foreground">#{rank}</span>
+      <span className="truncate text-sm font-bold text-foreground">{username}</span>
+      <span className="font-mono text-sm tabular-nums text-foreground">
+        {formatScore(entry.value, scoreType)}
+      </span>
+    </li>
+  );
+}
+
+export function Leaderboard({ challengeId, scoreType }: Props) {
+  const t = useTranslations('leaderboard');
+  const { data, loading, error, refetch } = useChallengeLeaderboard({
+    challengeId,
+    scoreType,
+  });
+  const [filters, setFilters] = useState<LeaderboardFilters>(EMPTY_FILTERS);
+
+  const sorted = useMemo(
+    () => sortScoresByType(applyLeaderboardFilters(data, filters), scoreType),
+    [data, filters, scoreType],
+  );
+
+  return (
+    <section className="space-y-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-lg font-black uppercase tracking-tight">{t('title')}</h2>
+      </header>
+
+      <LeaderboardFiltersBar filters={filters} onChange={setFilters} />
+
+      {loading ? (
+        <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+          {t('loading')}
+        </p>
+      ) : null}
+
+      {!loading && error ? (
+        <div className="rounded-md border border-primary/40 bg-primary/10 p-4">
+          <p className="text-sm font-black uppercase tracking-[0.18em] text-primary">
+            {t('errorTitle')}
+          </p>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            className="mt-3 inline-flex items-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('retry')}
+          </button>
+        </div>
+      ) : null}
+
+      {!loading && !error && sorted.length === 0 ? (
+        <div className="rounded-md border border-border bg-card p-6 text-center">
+          <p className="text-sm text-muted-foreground">{t('empty')}</p>
+        </div>
+      ) : null}
+
+      {!loading && !error && sorted.length > 0 ? (
+        <ol className="overflow-hidden rounded-md border border-border bg-card">
+          {sorted.map((entry, index) => (
+            <LeaderboardRow key={entry.id} rank={index + 1} entry={entry} scoreType={scoreType} />
+          ))}
+        </ol>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/challenges/components/LeaderboardFilters.tsx
+++ b/src/features/challenges/components/LeaderboardFilters.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { AGE_BRACKETS, type AgeBracket } from '@/features/challenges/lib/ageBracket';
+import type { LeaderboardFilters } from '@/features/challenges/lib/types';
+import type { Faction, Sex } from '@/lib/types/database.types';
+
+const SEXES: readonly Sex[] = ['male', 'female', 'other'];
+const FACTIONS: readonly Faction[] = ['nomads', 'horde', 'iron_alliance'];
+
+type Props = {
+  filters: LeaderboardFilters;
+  onChange: (next: LeaderboardFilters) => void;
+};
+
+function chipClass(active: boolean): string {
+  return [
+    'rounded-sm border px-2 py-1 text-[11px] font-black uppercase tracking-[0.14em] transition-colors',
+    active
+      ? 'border-primary bg-primary/15 text-primary'
+      : 'border-border bg-background text-muted-foreground hover:text-foreground',
+  ].join(' ');
+}
+
+function FilterRow({ legend, children }: { legend: string; children: React.ReactNode }) {
+  return (
+    <fieldset className="flex flex-wrap items-center gap-2">
+      <legend className="mr-1 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {legend}
+      </legend>
+      {children}
+    </fieldset>
+  );
+}
+
+export function LeaderboardFiltersBar({ filters, onChange }: Props) {
+  const t = useTranslations('leaderboard.filters');
+  const tFactions = useTranslations('factions');
+  const tSex = useTranslations('onboarding.identity.sexes');
+
+  return (
+    <div className="space-y-2">
+      <FilterRow legend={t('sex')}>
+        <button
+          type="button"
+          onClick={() => onChange({ ...filters, sex: null })}
+          className={chipClass(filters.sex === null)}
+        >
+          {t('all')}
+        </button>
+        {SEXES.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => onChange({ ...filters, sex: s })}
+            className={chipClass(filters.sex === s)}
+          >
+            {tSex(s)}
+          </button>
+        ))}
+      </FilterRow>
+
+      <FilterRow legend={t('age')}>
+        <button
+          type="button"
+          onClick={() => onChange({ ...filters, ageBracket: null })}
+          className={chipClass(filters.ageBracket === null)}
+        >
+          {t('all')}
+        </button>
+        {AGE_BRACKETS.map((b: AgeBracket) => (
+          <button
+            key={b}
+            type="button"
+            onClick={() => onChange({ ...filters, ageBracket: b })}
+            className={chipClass(filters.ageBracket === b)}
+          >
+            {t(`ageBrackets.${b}`)}
+          </button>
+        ))}
+      </FilterRow>
+
+      <FilterRow legend={t('faction')}>
+        <button
+          type="button"
+          onClick={() => onChange({ ...filters, faction: null })}
+          className={chipClass(filters.faction === null)}
+        >
+          {t('all')}
+        </button>
+        {FACTIONS.map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => onChange({ ...filters, faction: f })}
+            className={chipClass(filters.faction === f)}
+          >
+            {tFactions(f)}
+          </button>
+        ))}
+      </FilterRow>
+    </div>
+  );
+}

--- a/src/features/challenges/hooks/useChallenge.ts
+++ b/src/features/challenges/hooks/useChallenge.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { getApprovedChallengeById } from '@/features/challenges/services/challenges';
+import type { Challenge } from '@/lib/types/database.types';
+
+type State = {
+  data: Challenge | null;
+  loading: boolean;
+  error: string | null;
+};
+
+const initialState: State = { data: null, loading: true, error: null };
+
+export function useChallenge(challengeId: string | null) {
+  const [state, setState] = useState<State>(initialState);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!challengeId) return undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await getApprovedChallengeById(challengeId);
+        if (!cancelled) setState({ data, loading: false, error: null });
+      } catch (e: unknown) {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : 'unknown';
+          setState({ data: null, loading: false, error: message });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [challengeId, reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  return { ...state, refetch };
+}

--- a/src/features/challenges/hooks/useChallengeLeaderboard.ts
+++ b/src/features/challenges/hooks/useChallengeLeaderboard.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { listLeaderboardScores } from '@/features/challenges/services/leaderboard';
+import type { ScoreType } from '@/lib/types/database.types';
+import type { LeaderboardEntry } from '@/features/challenges/lib/types';
+
+type State = {
+  data: LeaderboardEntry[];
+  loading: boolean;
+  error: string | null;
+};
+
+const initialState: State = { data: [], loading: true, error: null };
+
+type Options = {
+  challengeId: string | null;
+  scoreType: ScoreType | null;
+};
+
+export function useChallengeLeaderboard({ challengeId, scoreType }: Options) {
+  const [state, setState] = useState<State>(initialState);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!challengeId || !scoreType) return undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await listLeaderboardScores({ challengeId, scoreType });
+        if (!cancelled) setState({ data, loading: false, error: null });
+      } catch (e: unknown) {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : 'unknown';
+          setState({ data: [], loading: false, error: message });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [challengeId, scoreType, reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  return { ...state, refetch };
+}

--- a/src/features/challenges/hooks/useChallenges.ts
+++ b/src/features/challenges/hooks/useChallenges.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { listApprovedChallenges } from '@/features/challenges/services/challenges';
+import type { Challenge } from '@/lib/types/database.types';
+
+type State = {
+  data: Challenge[];
+  loading: boolean;
+  error: string | null;
+};
+
+const initialState: State = { data: [], loading: true, error: null };
+
+export function useChallenges() {
+  const [state, setState] = useState<State>(initialState);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await listApprovedChallenges();
+        if (!cancelled) setState({ data, loading: false, error: null });
+      } catch (e: unknown) {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : 'unknown';
+          setState({ data: [], loading: false, error: message });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  return { ...state, refetch };
+}

--- a/src/features/challenges/index.ts
+++ b/src/features/challenges/index.ts
@@ -1,0 +1,24 @@
+export { ArenaScreen } from '@/features/challenges/components/ArenaScreen';
+export { ChallengeDetail } from '@/features/challenges/components/ChallengeDetail';
+export { ChallengeCard } from '@/features/challenges/components/ChallengeCard';
+export { ChallengeList } from '@/features/challenges/components/ChallengeList';
+export { Leaderboard } from '@/features/challenges/components/Leaderboard';
+
+export { useChallenges } from '@/features/challenges/hooks/useChallenges';
+export { useChallenge } from '@/features/challenges/hooks/useChallenge';
+export { useChallengeLeaderboard } from '@/features/challenges/hooks/useChallengeLeaderboard';
+
+export { formatScore, formatTime, formatReps } from '@/features/challenges/lib/scoreFormat';
+export { sortScoresByType } from '@/features/challenges/lib/leaderboardSort';
+export {
+  AGE_BRACKETS,
+  ageBracketFromAge,
+  isInBracket,
+  type AgeBracket,
+} from '@/features/challenges/lib/ageBracket';
+
+export type {
+  LeaderboardEntry,
+  LeaderboardFilters,
+  LeaderboardProfileSlim,
+} from '@/features/challenges/lib/types';

--- a/src/features/challenges/lib/ageBracket.test.ts
+++ b/src/features/challenges/lib/ageBracket.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { ageBracketFromAge, isInBracket } from '@/features/challenges/lib/ageBracket';
+
+describe('ageBracketFromAge', () => {
+  it('returns the right bracket for boundary ages', () => {
+    expect(ageBracketFromAge(18)).toBe('18-29');
+    expect(ageBracketFromAge(29)).toBe('18-29');
+    expect(ageBracketFromAge(30)).toBe('30-39');
+    expect(ageBracketFromAge(39)).toBe('30-39');
+    expect(ageBracketFromAge(40)).toBe('40-49');
+    expect(ageBracketFromAge(49)).toBe('40-49');
+    expect(ageBracketFromAge(50)).toBe('50+');
+    expect(ageBracketFromAge(99)).toBe('50+');
+  });
+
+  it('returns null for null or sub-18 ages', () => {
+    expect(ageBracketFromAge(null)).toBeNull();
+    expect(ageBracketFromAge(17)).toBeNull();
+  });
+});
+
+describe('isInBracket', () => {
+  it('matches when bracket is null (no filter)', () => {
+    expect(isInBracket(25, null)).toBe(true);
+    expect(isInBracket(null, null)).toBe(true);
+  });
+
+  it('matches only when the age is in the bracket', () => {
+    expect(isInBracket(25, '18-29')).toBe(true);
+    expect(isInBracket(35, '18-29')).toBe(false);
+    expect(isInBracket(50, '50+')).toBe(true);
+  });
+});

--- a/src/features/challenges/lib/ageBracket.ts
+++ b/src/features/challenges/lib/ageBracket.ts
@@ -1,0 +1,16 @@
+export type AgeBracket = '18-29' | '30-39' | '40-49' | '50+';
+
+export const AGE_BRACKETS: readonly AgeBracket[] = ['18-29', '30-39', '40-49', '50+'] as const;
+
+export function ageBracketFromAge(age: number | null): AgeBracket | null {
+  if (age == null || age < 18) return null;
+  if (age < 30) return '18-29';
+  if (age < 40) return '30-39';
+  if (age < 50) return '40-49';
+  return '50+';
+}
+
+export function isInBracket(age: number | null, bracket: AgeBracket | null): boolean {
+  if (!bracket) return true;
+  return ageBracketFromAge(age) === bracket;
+}

--- a/src/features/challenges/lib/applyFilters.test.ts
+++ b/src/features/challenges/lib/applyFilters.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyLeaderboardFilters } from '@/features/challenges/lib/applyFilters';
+import { EMPTY_FILTERS, type LeaderboardEntry } from '@/features/challenges/lib/types';
+
+const entry = (
+  id: string,
+  overrides: Partial<LeaderboardEntry['profile']> = {},
+): LeaderboardEntry => ({
+  id,
+  challenge_id: 'c1',
+  user_id: id,
+  value: 60,
+  video_url: null,
+  is_validated: true,
+  submitted_at: '2025-01-01T00:00:00Z',
+  profile: {
+    id: `p-${id}`,
+    username: id,
+    sex: 'male',
+    age: 25,
+    faction: 'horde',
+    ...overrides,
+  },
+});
+
+describe('applyLeaderboardFilters', () => {
+  it('returns all entries when filters are empty', () => {
+    const list = [entry('a'), entry('b')];
+    expect(applyLeaderboardFilters(list, EMPTY_FILTERS)).toHaveLength(2);
+  });
+
+  it('filters by sex', () => {
+    const list = [entry('a', { sex: 'male' }), entry('b', { sex: 'female' })];
+    expect(
+      applyLeaderboardFilters(list, { ...EMPTY_FILTERS, sex: 'female' }).map((e) => e.id),
+    ).toEqual(['b']);
+  });
+
+  it('filters by faction', () => {
+    const list = [
+      entry('a', { faction: 'horde' }),
+      entry('b', { faction: 'nomads' }),
+      entry('c', { faction: 'iron_alliance' }),
+    ];
+    expect(
+      applyLeaderboardFilters(list, { ...EMPTY_FILTERS, faction: 'nomads' }).map((e) => e.id),
+    ).toEqual(['b']);
+  });
+
+  it('filters by age bracket', () => {
+    const list = [entry('a', { age: 22 }), entry('b', { age: 35 }), entry('c', { age: 55 })];
+    expect(
+      applyLeaderboardFilters(list, { ...EMPTY_FILTERS, ageBracket: '30-39' }).map((e) => e.id),
+    ).toEqual(['b']);
+  });
+
+  it('drops entries without an attached profile', () => {
+    const list: LeaderboardEntry[] = [entry('a'), { ...entry('b'), profile: null }];
+    expect(applyLeaderboardFilters(list, EMPTY_FILTERS).map((e) => e.id)).toEqual(['a']);
+  });
+});

--- a/src/features/challenges/lib/applyFilters.ts
+++ b/src/features/challenges/lib/applyFilters.ts
@@ -1,0 +1,16 @@
+import { isInBracket } from '@/features/challenges/lib/ageBracket';
+import type { LeaderboardEntry, LeaderboardFilters } from '@/features/challenges/lib/types';
+
+export function applyLeaderboardFilters(
+  entries: readonly LeaderboardEntry[],
+  filters: LeaderboardFilters,
+): LeaderboardEntry[] {
+  return entries.filter((entry) => {
+    const profile = entry.profile;
+    if (!profile) return false;
+    if (filters.sex && profile.sex !== filters.sex) return false;
+    if (filters.faction && profile.faction !== filters.faction) return false;
+    if (filters.ageBracket && !isInBracket(profile.age, filters.ageBracket)) return false;
+    return true;
+  });
+}

--- a/src/features/challenges/lib/arenaRanking.test.ts
+++ b/src/features/challenges/lib/arenaRanking.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { rankChallenges } from '@/features/challenges/lib/arenaRanking';
+import type { Challenge } from '@/lib/types/database.types';
+
+const c = (id: string, opts: Partial<Challenge> = {}): Challenge => ({
+  id,
+  title: id,
+  description: 'd',
+  rules: 'r',
+  score_type: 'time',
+  equipment_tags: [],
+  is_official: false,
+  status: 'approved',
+  creator_id: null,
+  created_at: '2025-01-01T00:00:00Z',
+  ...opts,
+});
+
+describe('rankChallenges', () => {
+  it('sorts new by created_at desc', () => {
+    const list = [
+      c('a', { created_at: '2025-01-01T00:00:00Z' }),
+      c('b', { created_at: '2025-02-01T00:00:00Z' }),
+    ];
+    expect(rankChallenges(list, 'new').map((x) => x.id)).toEqual(['b', 'a']);
+  });
+
+  it('sorts trending by official first, then created_at desc', () => {
+    const list = [
+      c('a', { is_official: false, created_at: '2025-03-01T00:00:00Z' }),
+      c('b', { is_official: true, created_at: '2025-01-01T00:00:00Z' }),
+      c('c', { is_official: true, created_at: '2025-04-01T00:00:00Z' }),
+    ];
+    expect(rankChallenges(list, 'trending').map((x) => x.id)).toEqual(['c', 'b', 'a']);
+  });
+});

--- a/src/features/challenges/lib/arenaRanking.ts
+++ b/src/features/challenges/lib/arenaRanking.ts
@@ -1,0 +1,25 @@
+import type { Challenge } from '@/lib/types/database.types';
+
+export type ArenaTab = 'trending' | 'new';
+
+export function rankChallenges(challenges: readonly Challenge[], tab: ArenaTab): Challenge[] {
+  if (tab === 'new') return sortNew(challenges);
+  return sortTrending(challenges);
+}
+
+function sortNew(challenges: readonly Challenge[]): Challenge[] {
+  return [...challenges].sort((a, b) => dateKey(b.created_at) - dateKey(a.created_at));
+}
+
+function sortTrending(challenges: readonly Challenge[]): Challenge[] {
+  return [...challenges].sort((a, b) => {
+    const byOfficial = Number(b.is_official) - Number(a.is_official);
+    if (byOfficial !== 0) return byOfficial;
+    return dateKey(b.created_at) - dateKey(a.created_at);
+  });
+}
+
+function dateKey(iso: string): number {
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : 0;
+}

--- a/src/features/challenges/lib/leaderboardSort.test.ts
+++ b/src/features/challenges/lib/leaderboardSort.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { sortScoresByType } from '@/features/challenges/lib/leaderboardSort';
+
+const make = (id: string, value: number) => ({ id, value });
+
+describe('sortScoresByType', () => {
+  it('sorts time scores ascending (lower is better)', () => {
+    const input = [make('a', 90), make('b', 30), make('c', 60)];
+    expect(sortScoresByType(input, 'time').map((s) => s.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts reps scores descending (higher is better)', () => {
+    const input = [make('a', 10), make('b', 30), make('c', 20)];
+    expect(sortScoresByType(input, 'reps').map((s) => s.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [make('a', 30), make('b', 10)];
+    const snapshot = input.map((s) => s.id);
+    sortScoresByType(input, 'reps');
+    expect(input.map((s) => s.id)).toEqual(snapshot);
+  });
+});

--- a/src/features/challenges/lib/leaderboardSort.ts
+++ b/src/features/challenges/lib/leaderboardSort.ts
@@ -1,0 +1,14 @@
+import type { ScoreType } from '@/lib/types/database.types';
+
+export function sortScoresByType<T extends { value: number }>(
+  scores: readonly T[],
+  type: ScoreType,
+): T[] {
+  const copy = [...scores];
+  if (type === 'time') {
+    copy.sort((a, b) => a.value - b.value);
+  } else {
+    copy.sort((a, b) => b.value - a.value);
+  }
+  return copy;
+}

--- a/src/features/challenges/lib/scoreFormat.test.ts
+++ b/src/features/challenges/lib/scoreFormat.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatReps, formatScore, formatTime } from '@/features/challenges/lib/scoreFormat';
+
+describe('formatTime', () => {
+  it('pads minutes and seconds to two digits', () => {
+    expect(formatTime(0)).toBe('00:00');
+    expect(formatTime(5)).toBe('00:05');
+    expect(formatTime(65)).toBe('01:05');
+    expect(formatTime(125)).toBe('02:05');
+  });
+
+  it('handles long durations beyond 60 minutes', () => {
+    expect(formatTime(3725)).toBe('62:05');
+  });
+
+  it('floors fractional seconds (no rounding up)', () => {
+    expect(formatTime(59.999)).toBe('00:59');
+  });
+
+  it('returns a placeholder for invalid input', () => {
+    expect(formatTime(-1)).toBe('--:--');
+    expect(formatTime(Number.NaN)).toBe('--:--');
+    expect(formatTime(Number.POSITIVE_INFINITY)).toBe('--:--');
+  });
+});
+
+describe('formatReps', () => {
+  it('returns localized integer string', () => {
+    expect(formatReps(0)).toBe('0');
+    expect(formatReps(99)).toBe('99');
+  });
+
+  it('floors decimals and protects against negatives', () => {
+    expect(formatReps(12.9)).toBe('12');
+    expect(formatReps(-3)).toBe('0');
+  });
+});
+
+describe('formatScore', () => {
+  it('routes time scores to MM:SS', () => {
+    expect(formatScore(125, 'time')).toBe('02:05');
+  });
+
+  it('routes reps scores to an integer string', () => {
+    expect(formatScore(42, 'reps')).toBe('42');
+  });
+});

--- a/src/features/challenges/lib/scoreFormat.ts
+++ b/src/features/challenges/lib/scoreFormat.ts
@@ -1,0 +1,23 @@
+import type { ScoreType } from '@/lib/types/database.types';
+
+export function formatScore(value: number, type: ScoreType): string {
+  if (type === 'time') return formatTime(value);
+  return formatReps(value);
+}
+
+export function formatTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '--:--';
+  const total = Math.floor(seconds);
+  const minutes = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${pad2(minutes)}:${pad2(secs)}`;
+}
+
+export function formatReps(reps: number): string {
+  if (!Number.isFinite(reps) || reps < 0) return '0';
+  return Math.floor(reps).toLocaleString();
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}

--- a/src/features/challenges/lib/types.ts
+++ b/src/features/challenges/lib/types.ts
@@ -1,0 +1,32 @@
+import type { Faction, Sex } from '@/lib/types/database.types';
+
+export type LeaderboardProfileSlim = {
+  id: string;
+  username: string | null;
+  sex: Sex | null;
+  age: number | null;
+  faction: Faction | null;
+};
+
+export type LeaderboardEntry = {
+  id: string;
+  challenge_id: string;
+  user_id: string;
+  value: number;
+  video_url: string | null;
+  is_validated: boolean;
+  submitted_at: string;
+  profile: LeaderboardProfileSlim | null;
+};
+
+export type LeaderboardFilters = {
+  sex: Sex | null;
+  ageBracket: import('@/features/challenges/lib/ageBracket').AgeBracket | null;
+  faction: Faction | null;
+};
+
+export const EMPTY_FILTERS: LeaderboardFilters = {
+  sex: null,
+  ageBracket: null,
+  faction: null,
+};

--- a/src/features/challenges/services/challenges.ts
+++ b/src/features/challenges/services/challenges.ts
@@ -1,0 +1,26 @@
+import { supabase } from '@/lib/supabase';
+import type { Challenge } from '@/lib/types/database.types';
+
+const CHALLENGE_SELECT =
+  'id,title,description,rules,score_type,equipment_tags,is_official,status,creator_id,created_at';
+
+export async function listApprovedChallenges(): Promise<Challenge[]> {
+  const { data, error } = await supabase
+    .from('challenges')
+    .select(CHALLENGE_SELECT)
+    .eq('status', 'approved')
+    .order('created_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as Challenge[];
+}
+
+export async function getApprovedChallengeById(id: string): Promise<Challenge | null> {
+  const { data, error } = await supabase
+    .from('challenges')
+    .select(CHALLENGE_SELECT)
+    .eq('status', 'approved')
+    .eq('id', id)
+    .maybeSingle<Challenge>();
+  if (error) throw new Error(error.message);
+  return data ?? null;
+}

--- a/src/features/challenges/services/leaderboard.ts
+++ b/src/features/challenges/services/leaderboard.ts
@@ -1,0 +1,28 @@
+import { supabase } from '@/lib/supabase';
+import type { ScoreType } from '@/lib/types/database.types';
+import type { LeaderboardEntry } from '@/features/challenges/lib/types';
+
+const LEADERBOARD_SELECT =
+  'id,challenge_id,user_id,value,video_url,is_validated,submitted_at,profile:profiles!scores_user_id_fkey(id,username,sex,age,faction)';
+
+type Options = {
+  challengeId: string;
+  scoreType: ScoreType;
+  limit?: number;
+};
+
+export async function listLeaderboardScores({
+  challengeId,
+  scoreType,
+  limit = 100,
+}: Options): Promise<LeaderboardEntry[]> {
+  const { data, error } = await supabase
+    .from('scores')
+    .select(LEADERBOARD_SELECT)
+    .eq('challenge_id', challengeId)
+    .eq('is_validated', true)
+    .order('value', { ascending: scoreType === 'time' })
+    .limit(limit);
+  if (error) throw new Error(error.message);
+  return (data ?? []) as unknown as LeaderboardEntry[];
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,7 +112,74 @@
     "body": "Finish Issue #4 to collect biometrics, initiation, and faction."
   },
   "app": {
+    "loading": "Loading...",
     "overviewTitle": "OVERVIEW",
-    "overviewBody": "Placeholder. Auth redirect target is wired."
+    "overviewBody": "Welcome back. Pick a challenge in the Arena and post a score.",
+    "tabs": {
+      "overview": "Overview",
+      "arena": "Arena",
+      "clan": "Clan",
+      "profile": "Profile"
+    },
+    "comingSoon": {
+      "title": "Coming soon",
+      "body": "This section is on the roadmap."
+    }
+  },
+  "arena": {
+    "title": "ARENA",
+    "subtitle": "Pick your challenge. Post your score.",
+    "loading": "Loading challenges...",
+    "empty": "No challenges yet. Check back soon.",
+    "errorTitle": "Something went wrong",
+    "errorBody": "We could not load the challenges.",
+    "retry": "Retry",
+    "officialBadge": "OFFICIAL",
+    "scoreType": {
+      "time": "TIME",
+      "reps": "REPS"
+    },
+    "tags": {
+      "bodyweight": "Bodyweight"
+    }
+  },
+  "challenge": {
+    "loading": "Loading challenge...",
+    "notFoundTitle": "Challenge not found",
+    "notFoundBody": "It may have been removed or unapproved.",
+    "back": "Back to Arena",
+    "rulesHeading": "Rules",
+    "equipmentHeading": "Equipment",
+    "noEquipment": "Bodyweight only",
+    "ctaStart": "I'M IN",
+    "ctaComingSoon": "Score submission lands next."
+  },
+  "leaderboard": {
+    "title": "Leaderboard",
+    "loading": "Loading leaderboard...",
+    "empty": "No validated scores yet. Be the first.",
+    "errorTitle": "Could not load leaderboard",
+    "retry": "Retry",
+    "columnRank": "RANK",
+    "columnUser": "USER",
+    "columnScore": "SCORE",
+    "filters": {
+      "title": "Filters",
+      "all": "All",
+      "sex": "Sex",
+      "age": "Age",
+      "faction": "Faction",
+      "ageBrackets": {
+        "18-29": "18–29",
+        "30-39": "30–39",
+        "40-49": "40–49",
+        "50+": "50+"
+      }
+    }
+  },
+  "factions": {
+    "nomads": "Nomads",
+    "horde": "Horde",
+    "iron_alliance": "Iron Alliance"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -129,6 +129,10 @@
   "arena": {
     "title": "ARENA",
     "subtitle": "Pick your challenge. Post your score.",
+    "tabs": {
+      "trending": "Trending",
+      "new": "New"
+    },
     "loading": "Loading challenges...",
     "empty": "No challenges yet. Check back soon.",
     "errorTitle": "Something went wrong",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -129,6 +129,10 @@
   "arena": {
     "title": "ARÈNE",
     "subtitle": "Choisis ton défi. Poste ton score.",
+    "tabs": {
+      "trending": "Tendance",
+      "new": "Nouveaux"
+    },
     "loading": "Chargement des défis...",
     "empty": "Aucun défi pour l'instant. Reviens bientôt.",
     "errorTitle": "Une erreur est survenue",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -112,7 +112,74 @@
     "body": "Finis l’Issue #4 pour les biométriques, l’initiation et la faction."
   },
   "app": {
+    "loading": "Chargement...",
     "overviewTitle": "APERÇU",
-    "overviewBody": "Placeholder. La cible de redirect après login est câblée."
+    "overviewBody": "Bon retour. Choisis un défi dans l'Arène et poste un score.",
+    "tabs": {
+      "overview": "Aperçu",
+      "arena": "Arène",
+      "clan": "Clan",
+      "profile": "Profil"
+    },
+    "comingSoon": {
+      "title": "Bientôt",
+      "body": "Cette section arrive bientôt."
+    }
+  },
+  "arena": {
+    "title": "ARÈNE",
+    "subtitle": "Choisis ton défi. Poste ton score.",
+    "loading": "Chargement des défis...",
+    "empty": "Aucun défi pour l'instant. Reviens bientôt.",
+    "errorTitle": "Une erreur est survenue",
+    "errorBody": "Impossible de charger les défis.",
+    "retry": "Réessayer",
+    "officialBadge": "OFFICIEL",
+    "scoreType": {
+      "time": "TEMPS",
+      "reps": "REPS"
+    },
+    "tags": {
+      "bodyweight": "Poids du corps"
+    }
+  },
+  "challenge": {
+    "loading": "Chargement du défi...",
+    "notFoundTitle": "Défi introuvable",
+    "notFoundBody": "Il a peut-être été supprimé ou n'est pas approuvé.",
+    "back": "Retour à l'Arène",
+    "rulesHeading": "Règles",
+    "equipmentHeading": "Équipement",
+    "noEquipment": "Poids du corps uniquement",
+    "ctaStart": "JE M'INSCRIS",
+    "ctaComingSoon": "La soumission de score arrive bientôt."
+  },
+  "leaderboard": {
+    "title": "Classement",
+    "loading": "Chargement du classement...",
+    "empty": "Aucun score validé pour l'instant. Sois le premier.",
+    "errorTitle": "Impossible de charger le classement",
+    "retry": "Réessayer",
+    "columnRank": "RANG",
+    "columnUser": "JOUEUR",
+    "columnScore": "SCORE",
+    "filters": {
+      "title": "Filtres",
+      "all": "Tous",
+      "sex": "Sexe",
+      "age": "Âge",
+      "faction": "Faction",
+      "ageBrackets": {
+        "18-29": "18–29",
+        "30-39": "30–39",
+        "40-49": "40–49",
+        "50+": "50+"
+      }
+    }
+  },
+  "factions": {
+    "nomads": "Nomades",
+    "horde": "Horde",
+    "iron_alliance": "Alliance de Fer"
   }
 }


### PR DESCRIPTION
## Summary
- Add app shell: sticky header (desktop top nav), mobile bottom dock (Combat HUD style), and /app route gating (logged out -> /auth, onboarding incomplete -> /onboarding).
- Implement Arena: challenge feed (approved challenges), challenge detail (rules/equipment) and per-challenge leaderboard (validated scores) with filters (sex/age bracket/faction).
- Switch brand primary from orange to red and add i18n (en+fr). Add unit tests + e2e smokes.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:run`
- [x] `pnpm e2e`
- [ ] Manual: login -> `/app/arena` renders + tabs switch; open challenge detail -> leaderboard filters work.


Made with [Cursor](https://cursor.com)