### PR TITLE
feat(submission): score submission (optional proof)

### DIFF
--- a/.cursor/rules/truegrynd-product-rules.mdc
+++ b/.cursor/rules/truegrynd-product-rules.mdc
@@ -17,7 +17,7 @@ A B2C web app for async fitness competition. Users submit scores on standardized
 1. Auth (Google / Apple / Email via Supabase)
 2. Onboarding: biometric profile + simplified initiation (3 easy challenges) + faction choice
 3. Challenge feed with leaderboard per challenge
-4. Score submission with Smart Proof (video URL if Top 10%)
+4. Score submission (optional proof; required to rank)
 5. Finisher Card generation (canvas image) + native share
 6. User profile with history and trophies
 
@@ -27,9 +27,11 @@ Three factions: `nomads`, `horde`, `iron_alliance`
 - Faction score = sum of individual member scores
 
 ## Smart Proof Logic
-- If submitted score places user in top 10% of leaderboard → video URL is required
+- Users can submit scores **with or without** a video URL
 - Video URL must be a YouTube or TikTok link (non-listed accepted)
-- Scores without required video are marked `is_validated: false` and hidden from leaderboard
+- **Leaderboard shows only validated scores** (`is_validated: true`)
+- A score is **validated** (and ranked) only when a valid video URL is provided
+- Scores without video are saved but **not ranked** (`is_validated: false`)
 
 ## Leaderboard Filters
 - Global (all users)

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -417,13 +417,13 @@ Challenge feed (Trending, New). Challenge detail page with rules, equipment tags
 - [x] Feed shows available challenges
 - [x] Challenge page shows full info + leaderboard
 - [x] Leaderboard filterable (global, age, sex, faction)
-- [ ] CTA leads to score submission (Issue #6)
+- [x] CTA leads to score submission (Issue #6)
 
 ---
 
 ## 🎯 Issue #6: Score submission & Smart Proof
 
-**Status:** 🔴 **NOT STARTED**  
+**Status:** 🟢 **COMPLETED**  
 **Priority:** HIGH  
 **Phase:** Screen 4  
 **Dependencies:** Issue #5
@@ -436,35 +436,35 @@ Submission form: score input (time MM:SS or reps by challenge). Users can submit
 
 #### Submission form
 
-- [ ] 🔴 Main field: Time (MM:SS or seconds) or Reps (number) by challenge.score_type
-- [ ] 🔴 Validation (Zod): format and ranges
-- [ ] 🔴 “Submit” / “Validate” button (i18n)
-- [ ] 🔴 Copy from i18n
+- [x] 🟢 Main field: Time (MM:SS or seconds) or Reps (number) by challenge.score_type
+- [x] 🟢 Validation (Zod): format and ranges
+- [x] 🟢 “Submit” button (i18n)
+- [x] 🟢 Copy from i18n
 
 #### Smart Proof logic
 
-- [ ] 🔴 Video URL is optional: without video -> save as `is_validated=false` (not ranked)
-- [ ] 🔴 With a valid YouTube/TikTok URL -> save as `is_validated=true` (ranked)
-- [ ] 🔴 URL validation: YouTube/TikTok format
-- [ ] 🔴 (Optional) “Check my rank” preview + Elite badge (no blocking)
+- [x] 🟢 Video URL is optional: without video -> save as `is_validated=false` (not ranked)
+- [x] 🟢 With a valid YouTube/TikTok URL -> save as `is_validated=true` (ranked)
+- [x] 🟢 URL validation: YouTube/TikTok format
+- [ ] 🟡 (Optional) “Check my rank” preview + Elite badge (no blocking)
 
 #### DB write
 
-- [ ] 🔴 Insert into `scores`: challenge_id, user_id, value (seconds for time, int for reps), video_url (if any), is_validated, submitted_at
-- [ ] 🔴 Error handling (duplicate, RLS, etc.)
-- [ ] 🔴 On success: redirect or show Finisher Card (Issue #7)
+- [x] 🟢 Insert into `scores`: challenge_id, user_id, value (seconds for time, int for reps), video_url (if any), is_validated
+- [x] 🟢 Error handling (RLS, invalid URL, etc.)
+- [ ] 🟡 On success: show Finisher Card (Issue #7)
 
 #### UX
 
-- [ ] 🔴 Clear message when “Elite score detected. Paste your YouTube/TikTok link to validate.” (i18n)
-- [ ] 🔴 Loading, success, error states
+- [x] 🟢 Clear message: no video = saved but not ranked; with video = ranked (i18n)
+- [x] 🟢 Loading, success, error states
 
 ### Acceptance criteria
 
-- [ ] Score submission (time or reps) saved correctly
-- [ ] Without video: score is saved but not shown in public leaderboard
-- [ ] With video: score is validated and shown in public leaderboard
-- [ ] After submit, user sees Finisher Card
+- [x] Score submission (time or reps) saved correctly
+- [x] Without video: score is saved but not shown in public leaderboard
+- [x] With video: score is validated and shown in public leaderboard
+- [ ] Finisher Card shown after submit (Issue #7)
 
 ---
 
@@ -474,6 +474,10 @@ Submission form: score input (time MM:SS or reps by challenge). Users can submit
 **Priority:** HIGH  
 **Phase:** Screen 5  
 **Dependencies:** Issue #6
+
+### Immediate next action
+
+- Build the Finisher Card screen shown right after a successful submission (Issue #6)
 
 ### Description
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -430,7 +430,7 @@ Challenge feed (Trending, New). Challenge detail page with rules, equipment tags
 
 ### Description
 
-Submission form: score input (time MM:SS or reps by challenge). If score places user in Top 10% of leaderboard, show required “Video URL” (YouTube or TikTok). Validation, save to DB. Score without video if outside Top 10%; “elite” score requires video.
+Submission form: score input (time MM:SS or reps by challenge). Users can submit without proof (saved, not ranked), or submit with a YouTube/TikTok link (validated + ranked on the public leaderboard).
 
 ### Tasks
 
@@ -443,11 +443,10 @@ Submission form: score input (time MM:SS or reps by challenge). If score places 
 
 #### Smart Proof logic
 
-- [ ] 🔴 Before save: compute whether entered score places user in Top 10% for this challenge
-- [ ] 🔴 If yes (Top 10%): show required “Video URL” field (YouTube or TikTok)
-- [ ] 🔴 If no: no video field
+- [ ] 🔴 Video URL is optional: without video -> save as `is_validated=false` (not ranked)
+- [ ] 🔴 With a valid YouTube/TikTok URL -> save as `is_validated=true` (ranked)
 - [ ] 🔴 URL validation: YouTube/TikTok format
-- [ ] 🔴 Save: scores.is_validated = true if (outside Top 10%) or (Top 10% and URL provided); else reject or is_validated = false per business rule
+- [ ] 🔴 (Optional) “Check my rank” preview + Elite badge (no blocking)
 
 #### DB write
 
@@ -463,8 +462,8 @@ Submission form: score input (time MM:SS or reps by challenge). If score places 
 ### Acceptance criteria
 
 - [ ] Score submission (time or reps) saved correctly
-- [ ] Top 10% triggers required video URL
-- [ ] Scores outside Top 10% saved without video
+- [ ] Without video: score is saved but not shown in public leaderboard
+- [ ] With video: score is validated and shown in public leaderboard
 - [ ] After submit, user sees Finisher Card
 
 ---

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -33,3 +33,8 @@ test('challenge detail redirects to auth when logged out', async ({ page }) => {
   await page.goto('/en/app/arena/some-id');
   await expect(page).toHaveURL(/\/en\/auth$/);
 });
+
+test('score submit redirects to auth when logged out', async ({ page }) => {
+  await page.goto('/en/app/arena/some-id/submit');
+  await expect(page).toHaveURL(/\/en\/auth$/);
+});

--- a/src/app/[locale]/app/arena/[challengeId]/submit/page.tsx
+++ b/src/app/[locale]/app/arena/[challengeId]/submit/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { use } from 'react';
+
+import { ScoreSubmissionScreen } from '@/features/submission/components/ScoreSubmissionScreen';
+
+type Params = { challengeId: string; locale: string };
+
+export default function SubmitScorePage({ params }: { params: Promise<Params> }) {
+  const { challengeId } = use(params);
+  return <ScoreSubmissionScreen challengeId={challengeId} />;
+}

--- a/src/features/challenges/components/ChallengeDetail.tsx
+++ b/src/features/challenges/components/ChallengeDetail.tsx
@@ -39,6 +39,7 @@ function NotFound() {
 export function ChallengeDetail({ challengeId }: Props) {
   const t = useTranslations('challenge');
   const tArena = useTranslations('arena');
+  const locale = useLocale();
   const { data: challenge, loading, error } = useChallenge(challengeId);
 
   if (loading) {
@@ -102,15 +103,12 @@ export function ChallengeDetail({ challengeId }: Props) {
       </div>
 
       <div className="rounded-md border border-border bg-card p-4">
-        <button
-          type="button"
-          disabled
-          aria-disabled="true"
-          className="w-full rounded-md bg-primary/40 px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground cursor-not-allowed"
-          title={t('ctaComingSoon')}
+        <Link
+          href={`/${locale}/app/arena/${challenge.id}/submit`}
+          className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {t('ctaStart')}
-        </button>
+        </Link>
         <p className="mt-2 text-center text-xs text-muted-foreground">{t('ctaComingSoon')}</p>
       </div>
 

--- a/src/features/submission/components/ScoreSubmissionForm.tsx
+++ b/src/features/submission/components/ScoreSubmissionForm.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslations } from 'next-intl';
+
+import { useRequireAppAccess } from '@/features/appshell';
+import { parseTimeInput } from '@/features/submission/lib/parseTime';
+import { isAllowedVideoUrl } from '@/features/submission/lib/videoUrl';
+import { submitScore, SUBMISSION_ERRORS } from '@/features/submission/services/submitScore';
+import type { ScoreType } from '@/lib/types/database.types';
+
+type FormValues = {
+  time: string;
+  reps: number;
+  videoUrl: string;
+};
+
+type Props = {
+  challengeId: string;
+  scoreType: ScoreType;
+  onSubmitted: (result: { ranked: boolean }) => void;
+};
+
+function createSchema(t: (key: string) => string, scoreType: ScoreType) {
+  return z.object({
+    time:
+      scoreType === 'time'
+        ? z.string().refine((v) => parseTimeInput(v) !== null, { message: t('errors.invalidTime') })
+        : z.string(),
+    reps:
+      scoreType === 'reps'
+        ? z
+            .number()
+            .int()
+            .min(1, { message: t('errors.invalidReps') })
+        : z.number(),
+    videoUrl: z.string().refine((v) => v.trim().length === 0 || isAllowedVideoUrl(v), {
+      message: t('errors.videoInvalid'),
+    }),
+  });
+}
+
+function parseScoreValue(values: FormValues, scoreType: ScoreType): number | null {
+  if (scoreType === 'time') return parseTimeInput(values.time);
+  if (!Number.isFinite(values.reps) || values.reps < 1) return null;
+  return Math.floor(values.reps);
+}
+
+export function ScoreSubmissionForm({ challengeId, scoreType, onSubmitted }: Props) {
+  const t = useTranslations('submission');
+  const access = useRequireAppAccess();
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const schema = useMemo(() => createSchema((k) => t(k), scoreType), [t, scoreType]);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { time: '', reps: 0, videoUrl: '' },
+    mode: 'onChange',
+  });
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isValid },
+  } = form;
+
+  const canInteract = access.status === 'ready' && !submitting;
+  const canSubmit = canInteract && isValid;
+
+  const setScoreError = useCallback(() => {
+    if (scoreType === 'time')
+      setError('time', { type: 'validate', message: t('errors.invalidTime') });
+    else setError('reps', { type: 'validate', message: t('errors.invalidReps') });
+  }, [scoreType, setError, t]);
+
+  const onSubmit: SubmitHandler<FormValues> = useCallback(
+    async (values) => {
+      if (access.status !== 'ready') return;
+      setSubmitting(true);
+      setSubmitError(null);
+
+      const value = parseScoreValue(values, scoreType);
+      if (value === null) {
+        setSubmitting(false);
+        setScoreError();
+        return;
+      }
+
+      try {
+        const res = await submitScore({
+          challengeId,
+          userId: access.profile.id,
+          value,
+          videoUrl: values.videoUrl,
+        });
+        onSubmitted({ ranked: res.ranked });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (message === SUBMISSION_ERRORS.VIDEO_INVALID) {
+          setError('videoUrl', { type: 'validate', message: t('errors.videoInvalid') });
+          return;
+        }
+        setSubmitError(`${t('errors.submitFailed')} (${message})`);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [access, challengeId, onSubmitted, scoreType, setError, setScoreError, t],
+  );
+
+  if (access.status !== 'ready') {
+    return (
+      <div className="rounded-md border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  const scoreLabel = scoreType === 'time' ? t('yourScoreTime') : t('yourScoreReps');
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="rounded-md border border-border bg-card p-4 space-y-3">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {scoreLabel}
+        </p>
+
+        {scoreType === 'time' ? (
+          <div>
+            <input
+              {...register('time')}
+              placeholder={t('timePlaceholder')}
+              inputMode="numeric"
+              className="w-full rounded-md border border-border bg-background px-4 py-3 text-sm outline-none focus:ring-2 focus:ring-ring font-mono tabular-nums"
+              aria-invalid={!!errors.time}
+            />
+            {errors.time ? (
+              <p className="mt-1 text-xs font-semibold text-primary">{errors.time.message}</p>
+            ) : null}
+          </div>
+        ) : (
+          <div>
+            <input
+              {...register('reps', { valueAsNumber: true })}
+              type="number"
+              placeholder={t('repsPlaceholder')}
+              inputMode="numeric"
+              min={1}
+              className="w-full rounded-md border border-border bg-background px-4 py-3 text-sm outline-none focus:ring-2 focus:ring-ring font-mono tabular-nums"
+              aria-invalid={!!errors.reps}
+            />
+            {errors.reps ? (
+              <p className="mt-1 text-xs font-semibold text-primary">{errors.reps.message}</p>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-md border border-border bg-card p-4 space-y-2">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('proofTitle')}
+        </p>
+        <p className="text-sm text-muted-foreground">{t('proofBody')}</p>
+
+        <label className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('videoLabelOptional')}
+        </label>
+        <input
+          {...register('videoUrl')}
+          className="mt-2 w-full rounded-md border border-border bg-background px-4 py-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+          placeholder="youtube.com/watch?v=..."
+          aria-invalid={!!errors.videoUrl}
+        />
+        <p className="mt-1 text-xs text-muted-foreground">{t('videoHelper')}</p>
+        {errors.videoUrl ? (
+          <p className="mt-1 text-xs font-semibold text-primary">{errors.videoUrl.message}</p>
+        ) : null}
+      </div>
+
+      {submitError ? (
+        <div className="rounded-md border border-primary/40 bg-primary/10 p-4">
+          <p className="text-sm font-semibold text-primary">{submitError}</p>
+        </div>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="w-full rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        aria-label={submitting ? t('submitting') : t('submit')}
+      >
+        {submitting ? t('submitting') : t('submit')}
+      </button>
+    </form>
+  );
+}

--- a/src/features/submission/components/ScoreSubmissionScreen.tsx
+++ b/src/features/submission/components/ScoreSubmissionScreen.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+import { useChallenge } from '@/features/challenges/hooks/useChallenge';
+import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
+
+type Props = {
+  challengeId: string;
+};
+
+type Result = { ranked: boolean };
+
+function ResultCard({ ranked }: { ranked: boolean }) {
+  const t = useTranslations('submission');
+  const title = ranked ? t('resultRankedTitle') : t('resultSavedTitle');
+  const body = ranked ? t('resultRankedBody') : t('resultSavedBody');
+  return (
+    <div className="rounded-md border border-border bg-card p-4">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{title}</p>
+      <p className="mt-2 text-sm text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+export function ScoreSubmissionScreen({ challengeId }: Props) {
+  const t = useTranslations('submission');
+  const tArena = useTranslations('arena');
+  const locale = useLocale();
+  const { data: challenge, loading, error } = useChallenge(challengeId);
+  const [result, setResult] = useState<Result | null>(null);
+
+  if (loading) {
+    return (
+      <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+        {t('loading')}
+      </p>
+    );
+  }
+
+  if (error || !challenge) {
+    return (
+      <section className="space-y-3">
+        <Link
+          href={`/${locale}/app/arena/${challengeId}`}
+          className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {t('back')}
+        </Link>
+        <h1 className="text-2xl font-black uppercase tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('errors.submitFailed')}</p>
+      </section>
+    );
+  }
+
+  const challengeLineKey =
+    challenge.score_type === 'time' ? 'challengeLineTime' : 'challengeLineReps';
+
+  return (
+    <section className="space-y-6">
+      <Link
+        href={`/${locale}/app/arena/${challenge.id}`}
+        className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {t('back')}
+      </Link>
+
+      <header className="space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {tArena(`scoreType.${challenge.score_type}`)}
+          </span>
+        </div>
+        <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">
+          {t(challengeLineKey, { title: challenge.title })}
+        </p>
+      </header>
+
+      {result ? <ResultCard ranked={result.ranked} /> : null}
+
+      <ScoreSubmissionForm
+        challengeId={challenge.id}
+        scoreType={challenge.score_type}
+        onSubmitted={(r) => setResult(r)}
+      />
+    </section>
+  );
+}

--- a/src/features/submission/index.ts
+++ b/src/features/submission/index.ts
@@ -1,0 +1,7 @@
+export { ScoreSubmissionScreen } from '@/features/submission/components/ScoreSubmissionScreen';
+export { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
+
+export { parseTimeInput, isValidTimeInput } from '@/features/submission/lib/parseTime';
+export { isAllowedVideoUrl } from '@/features/submission/lib/videoUrl';
+
+export { submitScore, SUBMISSION_ERRORS } from '@/features/submission/services/submitScore';

--- a/src/features/submission/lib/parseTime.test.ts
+++ b/src/features/submission/lib/parseTime.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isValidTimeInput, parseTimeInput } from '@/features/submission/lib/parseTime';
+
+describe('parseTimeInput', () => {
+  it('parses MM:SS into seconds', () => {
+    expect(parseTimeInput('00:00')).toBe(0);
+    expect(parseTimeInput('00:05')).toBe(5);
+    expect(parseTimeInput('02:04')).toBe(124);
+    expect(parseTimeInput('62:05')).toBe(3725);
+  });
+
+  it('trims whitespace', () => {
+    expect(parseTimeInput(' 01:05 ')).toBe(65);
+  });
+
+  it('rejects invalid formats', () => {
+    expect(parseTimeInput('1:5')).toBeNull();
+    expect(parseTimeInput('aa:bb')).toBeNull();
+    expect(parseTimeInput('')).toBeNull();
+  });
+
+  it('rejects seconds >= 60', () => {
+    expect(parseTimeInput('01:60')).toBeNull();
+    expect(parseTimeInput('01:99')).toBeNull();
+  });
+});
+
+describe('isValidTimeInput', () => {
+  it('returns true for valid time strings', () => {
+    expect(isValidTimeInput('12:34')).toBe(true);
+  });
+
+  it('returns false for invalid time strings', () => {
+    expect(isValidTimeInput('12:99')).toBe(false);
+  });
+});

--- a/src/features/submission/lib/parseTime.ts
+++ b/src/features/submission/lib/parseTime.ts
@@ -1,0 +1,18 @@
+const TIME_RE = /^(\d{1,3}):([0-5]\d)$/;
+
+export function parseTimeInput(value: string): number | null {
+  const trimmed = value.trim();
+  const match = TIME_RE.exec(trimmed);
+  if (!match) return null;
+
+  const minutes = Number(match[1]);
+  const seconds = Number(match[2]);
+  if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) return null;
+  if (minutes < 0) return null;
+
+  return minutes * 60 + seconds;
+}
+
+export function isValidTimeInput(value: string): boolean {
+  return parseTimeInput(value) !== null;
+}

--- a/src/features/submission/lib/videoUrl.test.ts
+++ b/src/features/submission/lib/videoUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAllowedVideoUrl } from '@/features/submission/lib/videoUrl';
+
+describe('isAllowedVideoUrl', () => {
+  it('accepts YouTube watch URLs', () => {
+    expect(isAllowedVideoUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true);
+  });
+
+  it('accepts youtu.be and shorts URLs', () => {
+    expect(isAllowedVideoUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true);
+    expect(isAllowedVideoUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe(true);
+  });
+
+  it('accepts TikTok URLs', () => {
+    expect(isAllowedVideoUrl('https://www.tiktok.com/@user/video/123')).toBe(true);
+    expect(isAllowedVideoUrl('https://m.tiktok.com/v/123.html')).toBe(true);
+  });
+
+  it('rejects non-http(s) and unsupported hosts', () => {
+    expect(isAllowedVideoUrl('ftp://youtube.com/watch?v=123')).toBe(false);
+    expect(isAllowedVideoUrl('not a url')).toBe(false);
+    expect(isAllowedVideoUrl('javascript:alert(1)')).toBe(false);
+    expect(isAllowedVideoUrl('https://example.com/video/123')).toBe(false);
+  });
+});

--- a/src/features/submission/lib/videoUrl.ts
+++ b/src/features/submission/lib/videoUrl.ts
@@ -1,0 +1,32 @@
+function safeParseUrl(raw: string): URL | null {
+  try {
+    const url = new URL(raw.trim());
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function isYouTubeUrl(url: URL): boolean {
+  const host = url.hostname.replace(/^www\./, '').toLowerCase();
+  if (host === 'youtu.be') return url.pathname.length > 1;
+  if (host !== 'youtube.com') return false;
+
+  if (url.pathname === '/watch') return !!url.searchParams.get('v');
+  if (url.pathname.startsWith('/shorts/')) return url.pathname.length > '/shorts/'.length;
+  if (url.pathname.startsWith('/embed/')) return url.pathname.length > '/embed/'.length;
+  return false;
+}
+
+function isTikTokUrl(url: URL): boolean {
+  const host = url.hostname.replace(/^www\./, '').toLowerCase();
+  if (host !== 'tiktok.com' && host !== 'm.tiktok.com') return false;
+  return url.pathname.length > 1;
+}
+
+export function isAllowedVideoUrl(rawUrl: string): boolean {
+  const url = safeParseUrl(rawUrl);
+  if (!url) return false;
+  return isYouTubeUrl(url) || isTikTokUrl(url);
+}

--- a/src/features/submission/services/submitScore.ts
+++ b/src/features/submission/services/submitScore.ts
@@ -1,0 +1,49 @@
+import { supabase } from '@/lib/supabase';
+
+import { isAllowedVideoUrl } from '@/features/submission/lib/videoUrl';
+
+type Options = {
+  challengeId: string;
+  userId: string;
+  value: number;
+  videoUrl?: string | null;
+};
+
+type Result = {
+  insertedId: string;
+  ranked: boolean;
+};
+
+const VIDEO_INVALID_ERROR = 'video_invalid';
+
+export async function submitScore(options: Options): Promise<Result> {
+  const trimmedVideo = options.videoUrl?.trim() ?? '';
+  const hasVideo = trimmedVideo.length > 0;
+
+  if (hasVideo && !isAllowedVideoUrl(trimmedVideo)) throw new Error(VIDEO_INVALID_ERROR);
+
+  const ranked = hasVideo;
+  const is_validated = ranked;
+  const video_url = ranked ? trimmedVideo : null;
+
+  const { data, error } = await supabase
+    .from('scores')
+    .insert({
+      challenge_id: options.challengeId,
+      user_id: options.userId,
+      value: options.value,
+      video_url,
+      is_validated,
+    })
+    .select('id')
+    .maybeSingle<{ id: string }>();
+
+  if (error) throw new Error(error.message);
+  if (!data?.id) throw new Error('insert_failed');
+
+  return { insertedId: data.id, ranked };
+}
+
+export const SUBMISSION_ERRORS = {
+  VIDEO_INVALID: VIDEO_INVALID_ERROR,
+} as const;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -185,5 +185,32 @@
     "nomads": "Nomads",
     "horde": "Horde",
     "iron_alliance": "Iron Alliance"
+  },
+  "submission": {
+    "title": "SUBMIT YOUR SCORE",
+    "loading": "Loading...",
+    "back": "Back",
+    "challengeLineTime": "{title} · ⏱ Time",
+    "challengeLineReps": "{title} · 🔁 Reps",
+    "yourScoreTime": "YOUR TIME",
+    "yourScoreReps": "YOUR REPS",
+    "timePlaceholder": "MM:SS",
+    "repsPlaceholder": "Reps",
+    "proofTitle": "PROOF (OPTIONAL)",
+    "proofBody": "No video = saved but not ranked. Add a YouTube/TikTok link to get ranked.",
+    "videoLabelOptional": "VIDEO URL (OPTIONAL)",
+    "videoHelper": "YouTube or TikTok only",
+    "submit": "SUBMIT",
+    "submitting": "SUBMITTING...",
+    "resultSavedTitle": "SAVED (NOT RANKED)",
+    "resultSavedBody": "Your score is saved. Add a video next time to appear on the leaderboard.",
+    "resultRankedTitle": "RANKED",
+    "resultRankedBody": "Your score is validated and ranked on the leaderboard.",
+    "errors": {
+      "invalidTime": "Enter a valid time (MM:SS).",
+      "invalidReps": "Enter a valid rep count.",
+      "videoInvalid": "Video URL must be a YouTube or TikTok link.",
+      "submitFailed": "Could not submit your score."
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -185,5 +185,32 @@
     "nomads": "Nomades",
     "horde": "Horde",
     "iron_alliance": "Alliance de Fer"
+  },
+  "submission": {
+    "title": "SOUMETTRE TON SCORE",
+    "loading": "Chargement...",
+    "back": "Retour",
+    "challengeLineTime": "{title} · ⏱ Temps",
+    "challengeLineReps": "{title} · 🔁 Reps",
+    "yourScoreTime": "TON TEMPS",
+    "yourScoreReps": "TES REPS",
+    "timePlaceholder": "MM:SS",
+    "repsPlaceholder": "Reps",
+    "proofTitle": "PREUVE (OPTIONNELLE)",
+    "proofBody": "Sans vidéo = sauvegardé mais non classé. Ajoute un lien YouTube/TikTok pour être classé.",
+    "videoLabelOptional": "LIEN VIDÉO (OPTIONNEL)",
+    "videoHelper": "YouTube ou TikTok uniquement",
+    "submit": "ENVOYER",
+    "submitting": "EN COURS...",
+    "resultSavedTitle": "SAUVEGARDÉ (NON CLASSÉ)",
+    "resultSavedBody": "Ton score est sauvegardé. Ajoute une vidéo la prochaine fois pour apparaître dans le classement.",
+    "resultRankedTitle": "CLASSÉ",
+    "resultRankedBody": "Ton score est validé et classé dans le leaderboard.",
+    "errors": {
+      "invalidTime": "Entre un temps valide (MM:SS).",
+      "invalidReps": "Entre un nombre de reps valide.",
+      "videoInvalid": "Le lien doit être YouTube ou TikTok.",
+      "submitFailed": "Impossible d'envoyer ton score."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `/app/arena/[challengeId]/submit` with time/reps input based on challenge type.
- Implements **Option A**: score can be saved without video (not ranked); with YouTube/TikTok URL it becomes validated + ranked.
- Updates docs/rules to match the new Smart Proof model.

## Test plan
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm build`
- `pnpm e2e`

## Notes
- Leaderboard already filters `scores.is_validated = true`, so non-video submissions never appear publicly.

Made with [Cursor](https://cursor.com)