### PR TITLE
feat(finisher-card): finisher card canvas + share

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -38,3 +38,8 @@ test('score submit redirects to auth when logged out', async ({ page }) => {
   await page.goto('/en/app/arena/some-id/submit');
   await expect(page).toHaveURL(/\/en\/auth$/);
 });
+
+test('finish redirects to auth when logged out', async ({ page }) => {
+  await page.goto('/en/app/finish');
+  await expect(page).toHaveURL(/\/en\/auth$/);
+});

--- a/src/app/[locale]/app/finish/page.tsx
+++ b/src/app/[locale]/app/finish/page.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useRequireAppAccess } from '@/features/appshell';
+import { getApprovedChallengeById } from '@/features/challenges/services/challenges';
+import { formatTopPercent, percentileFromCounts } from '@/features/finisher-card/lib/percentile';
+import { drawFinisherCard } from '@/features/finisher-card/lib/drawCard';
+import { getRankCounts } from '@/features/finisher-card/services/rank';
+import { getScoreById } from '@/features/finisher-card/services/scores';
+import type { Challenge, Score } from '@/lib/types/database.types';
+
+type SearchParams = {
+  challengeId?: string;
+  ranked?: string;
+  scoreId?: string;
+};
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; score: Score; challenge: Challenge; topPercent: number | null };
+
+export default function FinishPage({ searchParams }: { searchParams: SearchParams }) {
+  const t = useTranslations('finisher');
+  const locale = useLocale();
+  const access = useRequireAppAccess();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [state, setState] = useState<LoadState>({ status: 'loading' });
+
+  const ranked = searchParams.ranked === 'true';
+  const scoreId = searchParams.scoreId ?? null;
+  const challengeId = searchParams.challengeId ?? null;
+  const hasParams = !!scoreId && !!challengeId;
+
+  useEffect(() => {
+    if (access.status !== 'ready') return undefined;
+    if (!hasParams) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [score, challenge] = await Promise.all([
+          getScoreById(scoreId),
+          getApprovedChallengeById(challengeId),
+        ]);
+        if (cancelled) return;
+        if (!score || !challenge) {
+          setState({ status: 'error', message: 'not_found' });
+          return;
+        }
+
+        let topPercent: number | null = null;
+        if (ranked && score.is_validated) {
+          const counts = await getRankCounts({
+            challengeId: score.challenge_id,
+            scoreType: challenge.score_type,
+            value: score.value,
+          });
+          const pct = percentileFromCounts(counts.total, counts.better);
+          topPercent = pct ? formatTopPercent(pct.percentile) : null;
+        }
+
+        setState({ status: 'ready', score, challenge, topPercent });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [access.status, challengeId, hasParams, ranked, scoreId]);
+
+  const canExport = state.status === 'ready';
+
+  const cardOptions = useMemo(() => {
+    if (state.status !== 'ready' || access.status !== 'ready') return null;
+    const accessProfile = access.profile;
+    const { username, faction } = accessProfile;
+    if (!username || !faction) return null;
+
+    return {
+      width: 1080,
+      height: 1920,
+      faction,
+      username,
+      challengeTitle: state.challenge.title,
+      scoreType: state.challenge.score_type,
+      scoreValue: state.score.value,
+      topPercent: state.topPercent,
+    };
+  }, [access.profile, access.status, state]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    if (!cardOptions) return;
+    drawFinisherCard(canvas, cardOptions);
+  }, [cardOptions]);
+
+  async function onDownload() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const blob: Blob | null = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'truegrynd-finisher.png';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  async function onShare() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const blob: Blob | null = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+    if (!blob) return;
+    const file = new File([blob], 'truegrynd-finisher.png', { type: 'image/png' });
+
+    if (typeof navigator === 'undefined') return;
+    const nav = navigator as Navigator & {
+      share?: (data: ShareData) => Promise<void>;
+      canShare?: (data: ShareData) => boolean;
+    };
+    if (!nav.share) return;
+
+    const data: ShareData = { files: [file], title: 'Truegrynd' };
+    const canShareFiles = typeof nav.canShare === 'function' ? nav.canShare(data) : false;
+    await nav.share(canShareFiles ? data : { title: 'Truegrynd' });
+  }
+
+  if (access.status !== 'ready') {
+    return (
+      <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+        {t('loading')}
+      </p>
+    );
+  }
+
+  if (!hasParams) {
+    return (
+      <section className="space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('error')}</p>
+        </header>
+        <p className="text-xs text-muted-foreground">missing_params</p>
+        <Link
+          href={`/${locale}/app/arena`}
+          className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted"
+        >
+          {t('backToArena')}
+        </Link>
+      </section>
+    );
+  }
+
+  if (state.status === 'loading') {
+    return (
+      <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+        {t('loading')}
+      </p>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('error')}</p>
+        </header>
+        <p className="text-xs text-muted-foreground">{state.message}</p>
+        <Link
+          href={`/${locale}/app/arena${challengeId ? `/${challengeId}` : ''}`}
+          className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted"
+        >
+          {t('backToArena')}
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{ranked ? t('rankedBody') : t('savedBody')}</p>
+      </header>
+
+      <div className="rounded-md border border-border bg-card p-3">
+        <canvas ref={canvasRef} className="w-full h-auto block" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          onClick={() => void onDownload()}
+          disabled={!canExport}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {t('download')}
+        </button>
+        <button
+          type="button"
+          onClick={() => void onShare()}
+          disabled={!canExport}
+          className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted disabled:opacity-50"
+        >
+          {t('share')}
+        </button>
+      </div>
+
+      <Link
+        href={`/${locale}/app/arena/${state.challenge.id}`}
+        className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted"
+      >
+        {t('backToArena')}
+      </Link>
+    </section>
+  );
+}

--- a/src/app/[locale]/app/finish/page.tsx
+++ b/src/app/[locale]/app/finish/page.tsx
@@ -2,15 +2,11 @@
 
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
-import { useRequireAppAccess } from '@/features/appshell';
-import { getApprovedChallengeById } from '@/features/challenges/services/challenges';
-import { formatTopPercent, percentileFromCounts } from '@/features/finisher-card/lib/percentile';
+import { FinisherCardActions } from '@/features/finisher-card/components/FinisherCardActions';
 import { drawFinisherCard } from '@/features/finisher-card/lib/drawCard';
-import { getRankCounts } from '@/features/finisher-card/services/rank';
-import { getScoreById } from '@/features/finisher-card/services/scores';
-import type { Challenge, Score } from '@/lib/types/database.types';
+import { useFinisherCard } from '@/features/finisher-card/hooks/useFinisherCard';
 
 type SearchParams = {
   challengeId?: string;
@@ -18,82 +14,29 @@ type SearchParams = {
   scoreId?: string;
 };
 
-type LoadState =
-  | { status: 'loading' }
-  | { status: 'error'; message: string }
-  | { status: 'ready'; score: Score; challenge: Challenge; topPercent: number | null };
-
 export default function FinishPage({ searchParams }: { searchParams: SearchParams }) {
   const t = useTranslations('finisher');
   const locale = useLocale();
-  const access = useRequireAppAccess();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const [state, setState] = useState<LoadState>({ status: 'loading' });
 
   const ranked = searchParams.ranked === 'true';
   const scoreId = searchParams.scoreId ?? null;
   const challengeId = searchParams.challengeId ?? null;
-  const hasParams = !!scoreId && !!challengeId;
-
-  useEffect(() => {
-    if (access.status !== 'ready') return undefined;
-    if (!hasParams) return undefined;
-
-    let cancelled = false;
-    void (async () => {
-      try {
-        const [score, challenge] = await Promise.all([
-          getScoreById(scoreId),
-          getApprovedChallengeById(challengeId),
-        ]);
-        if (cancelled) return;
-        if (!score || !challenge) {
-          setState({ status: 'error', message: 'not_found' });
-          return;
-        }
-
-        let topPercent: number | null = null;
-        if (ranked && score.is_validated) {
-          const counts = await getRankCounts({
-            challengeId: score.challenge_id,
-            scoreType: challenge.score_type,
-            value: score.value,
-          });
-          const pct = percentileFromCounts(counts.total, counts.better);
-          topPercent = pct ? formatTopPercent(pct.percentile) : null;
-        }
-
-        setState({ status: 'ready', score, challenge, topPercent });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [access.status, challengeId, hasParams, ranked, scoreId]);
-
-  const canExport = state.status === 'ready';
+  const state = useFinisherCard({ ranked, scoreId, challengeId });
 
   const cardOptions = useMemo(() => {
-    if (state.status !== 'ready' || access.status !== 'ready') return null;
-    const accessProfile = access.profile;
-    const { username, faction } = accessProfile;
-    if (!username || !faction) return null;
-
+    if (state.status !== 'ready') return null;
     return {
       width: 1080,
       height: 1920,
-      faction,
-      username,
+      faction: state.faction,
+      username: state.username,
       challengeTitle: state.challenge.title,
       scoreType: state.challenge.score_type,
       scoreValue: state.score.value,
       topPercent: state.topPercent,
     };
-  }, [access.profile, access.status, state]);
+  }, [state]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -102,41 +45,7 @@ export default function FinishPage({ searchParams }: { searchParams: SearchParam
     drawFinisherCard(canvas, cardOptions);
   }, [cardOptions]);
 
-  async function onDownload() {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const blob: Blob | null = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
-    if (!blob) return;
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'truegrynd-finisher.png';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  }
-
-  async function onShare() {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const blob: Blob | null = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
-    if (!blob) return;
-    const file = new File([blob], 'truegrynd-finisher.png', { type: 'image/png' });
-
-    if (typeof navigator === 'undefined') return;
-    const nav = navigator as Navigator & {
-      share?: (data: ShareData) => Promise<void>;
-      canShare?: (data: ShareData) => boolean;
-    };
-    if (!nav.share) return;
-
-    const data: ShareData = { files: [file], title: 'Truegrynd' };
-    const canShareFiles = typeof nav.canShare === 'function' ? nav.canShare(data) : false;
-    await nav.share(canShareFiles ? data : { title: 'Truegrynd' });
-  }
-
-  if (access.status !== 'ready') {
+  if (state.status === 'gated') {
     return (
       <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
         {t('loading')}
@@ -144,14 +53,13 @@ export default function FinishPage({ searchParams }: { searchParams: SearchParam
     );
   }
 
-  if (!hasParams) {
+  if (state.status === 'missing_params') {
     return (
       <section className="space-y-6">
         <header className="space-y-2">
           <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
           <p className="text-sm text-muted-foreground">{t('error')}</p>
         </header>
-        <p className="text-xs text-muted-foreground">missing_params</p>
         <Link
           href={`/${locale}/app/arena`}
           className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted"
@@ -199,24 +107,7 @@ export default function FinishPage({ searchParams }: { searchParams: SearchParam
         <canvas ref={canvasRef} className="w-full h-auto block" />
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <button
-          type="button"
-          onClick={() => void onDownload()}
-          disabled={!canExport}
-          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
-        >
-          {t('download')}
-        </button>
-        <button
-          type="button"
-          onClick={() => void onShare()}
-          disabled={!canExport}
-          className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted disabled:opacity-50"
-        >
-          {t('share')}
-        </button>
-      </div>
+      <FinisherCardActions canvasRef={canvasRef} disabled={!cardOptions} />
 
       <Link
         href={`/${locale}/app/arena/${state.challenge.id}`}

--- a/src/features/finisher-card/components/FinisherCardActions.tsx
+++ b/src/features/finisher-card/components/FinisherCardActions.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import {
+  canvasToPngBlob,
+  downloadBlob,
+  sharePngBlob,
+} from '@/features/finisher-card/lib/canvasPng';
+
+type Props = {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  disabled?: boolean;
+};
+
+export function FinisherCardActions({ canvasRef, disabled }: Props) {
+  const t = useTranslations('finisher');
+  const [working, setWorking] = useState(false);
+
+  const canUse = !disabled && !working;
+
+  const getBlob = useCallback(async () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+    return await canvasToPngBlob(canvas);
+  }, [canvasRef]);
+
+  const onDownload = useCallback(async () => {
+    if (!canUse) return;
+    setWorking(true);
+    try {
+      const blob = await getBlob();
+      if (!blob) return;
+      downloadBlob(blob, 'truegrynd-finisher.png');
+    } finally {
+      setWorking(false);
+    }
+  }, [canUse, getBlob]);
+
+  const onShare = useCallback(async () => {
+    if (!canUse) return;
+    setWorking(true);
+    try {
+      const blob = await getBlob();
+      if (!blob) return;
+      await sharePngBlob(blob, 'truegrynd-finisher.png');
+    } finally {
+      setWorking(false);
+    }
+  }, [canUse, getBlob]);
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <button
+        type="button"
+        onClick={() => void onDownload()}
+        disabled={!canUse}
+        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+      >
+        {t('download')}
+      </button>
+      <button
+        type="button"
+        onClick={() => void onShare()}
+        disabled={!canUse}
+        className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted disabled:opacity-50"
+      >
+        {t('share')}
+      </button>
+    </div>
+  );
+}

--- a/src/features/finisher-card/hooks/useFinisherCard.ts
+++ b/src/features/finisher-card/hooks/useFinisherCard.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useRequireAppAccess } from '@/features/appshell';
+import { getApprovedChallengeById } from '@/features/challenges/services/challenges';
+import { formatTopPercent, percentileFromCounts } from '@/features/finisher-card/lib/percentile';
+import { getRankCounts } from '@/features/finisher-card/services/rank';
+import { getScoreById } from '@/features/finisher-card/services/scores';
+import type { Challenge, Faction, Score } from '@/lib/types/database.types';
+
+type Params = {
+  challengeId: string | null;
+  scoreId: string | null;
+  ranked: boolean;
+};
+
+export type FinisherCardState =
+  | { status: 'gated' }
+  | { status: 'missing_params' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | {
+      status: 'ready';
+      score: Score;
+      challenge: Challenge;
+      topPercent: number | null;
+      username: string;
+      faction: Faction;
+    };
+
+type InnerState = Exclude<FinisherCardState, { status: 'gated' } | { status: 'missing_params' }>;
+
+export function useFinisherCard(params: Params): FinisherCardState {
+  const access = useRequireAppAccess();
+  const [state, setState] = useState<InnerState>({ status: 'loading' });
+
+  const hasParams = !!params.challengeId && !!params.scoreId;
+
+  useEffect(() => {
+    if (access.status !== 'ready') return undefined;
+    if (!hasParams) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [score, challenge] = await Promise.all([
+          getScoreById(params.scoreId!),
+          getApprovedChallengeById(params.challengeId!),
+        ]);
+        if (cancelled) return;
+        if (!score || !challenge) {
+          setState({ status: 'error', message: 'not_found' });
+          return;
+        }
+
+        let topPercent: number | null = null;
+        if (params.ranked && score.is_validated) {
+          const counts = await getRankCounts({
+            challengeId: score.challenge_id,
+            scoreType: challenge.score_type,
+            value: score.value,
+          });
+          const pct = percentileFromCounts(counts.total, counts.better);
+          topPercent = pct ? formatTopPercent(pct.percentile) : null;
+        }
+
+        const { username, faction } = access.profile;
+        if (!username || !faction) {
+          setState({ status: 'error', message: 'profile_incomplete' });
+          return;
+        }
+
+        setState({ status: 'ready', score, challenge, topPercent, username, faction });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [access.status, access.profile, hasParams, params.challengeId, params.ranked, params.scoreId]);
+
+  return useMemo(() => {
+    if (access.status !== 'ready') return { status: 'gated' };
+    if (!hasParams) return { status: 'missing_params' };
+    return state;
+  }, [access.status, hasParams, state]);
+}

--- a/src/features/finisher-card/lib/canvasPng.ts
+++ b/src/features/finisher-card/lib/canvasPng.ts
@@ -1,0 +1,27 @@
+export async function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
+  return await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export async function sharePngBlob(blob: Blob, filename: string): Promise<void> {
+  const file = new File([blob], filename, { type: 'image/png' });
+  const nav = navigator as Navigator & {
+    share?: (data: ShareData) => Promise<void>;
+    canShare?: (data: ShareData) => boolean;
+  };
+  if (!nav.share) return;
+
+  const data: ShareData = { files: [file], title: 'Truegrynd' };
+  const canShareFiles = typeof nav.canShare === 'function' ? nav.canShare(data) : false;
+  await nav.share(canShareFiles ? data : { title: 'Truegrynd' });
+}

--- a/src/features/finisher-card/lib/drawCard.ts
+++ b/src/features/finisher-card/lib/drawCard.ts
@@ -1,0 +1,104 @@
+import type { Faction, ScoreType } from '@/lib/types/database.types';
+
+type Options = {
+  width: number;
+  height: number;
+  faction: Faction;
+  username: string;
+  challengeTitle: string;
+  scoreType: ScoreType;
+  scoreValue: number;
+  topPercent: number | null;
+};
+
+function factionColor(faction: Faction): string {
+  if (faction === 'nomads') return '#4a9e6f';
+  if (faction === 'horde') return '#c0392b';
+  return '#7f8c8d';
+}
+
+export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): void {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  canvas.width = options.width;
+  canvas.height = options.height;
+
+  const bg = '#0a0a0f';
+  const card = '#111118';
+  const border = '#2a2a3a';
+  const fg = '#f9fafb';
+  const muted = '#9ca3af';
+  const accent = factionColor(options.faction);
+
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const pad = Math.floor(canvas.width * 0.06);
+  const innerX = pad;
+  const innerY = pad;
+  const innerW = canvas.width - pad * 2;
+  const innerH = canvas.height - pad * 2;
+
+  // main panel
+  ctx.fillStyle = card;
+  ctx.fillRect(innerX, innerY, innerW, innerH);
+
+  // border
+  ctx.strokeStyle = border;
+  ctx.lineWidth = 4;
+  ctx.strokeRect(innerX, innerY, innerW, innerH);
+
+  // faction slash
+  ctx.fillStyle = accent;
+  ctx.fillRect(innerX, innerY, Math.floor(innerW * 0.02), innerH);
+
+  // header branding
+  ctx.fillStyle = fg;
+  ctx.font = '900 54px system-ui, -apple-system, Segoe UI, sans-serif';
+  ctx.textBaseline = 'top';
+  ctx.fillText('TRUEGRYND', innerX + 30, innerY + 28);
+
+  ctx.fillStyle = muted;
+  ctx.font = '900 22px system-ui, -apple-system, Segoe UI, sans-serif';
+  ctx.fillText(options.challengeTitle.toUpperCase(), innerX + 30, innerY + 96);
+
+  // main score
+  ctx.fillStyle = fg;
+  ctx.font = '900 160px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+  const scoreText =
+    options.scoreType === 'time' ? formatSeconds(options.scoreValue) : String(options.scoreValue);
+  ctx.fillText(scoreText, innerX + 30, innerY + 190);
+
+  ctx.fillStyle = muted;
+  ctx.font = '900 26px system-ui, -apple-system, Segoe UI, sans-serif';
+  const label = options.scoreType === 'time' ? 'TIME (MM:SS)' : 'REPS';
+  ctx.fillText(label, innerX + 30, innerY + 370);
+
+  // rank
+  ctx.fillStyle = fg;
+  ctx.font = '900 72px system-ui, -apple-system, Segoe UI, sans-serif';
+  const rankText = options.topPercent ? `TOP ${options.topPercent}%` : 'SAVED';
+  ctx.fillText(rankText, innerX + 30, innerY + 470);
+
+  ctx.fillStyle = muted;
+  ctx.font = '900 22px system-ui, -apple-system, Segoe UI, sans-serif';
+  const rankSub = options.topPercent ? 'WORLDWIDE (VALIDATED)' : 'NOT RANKED (NO VIDEO)';
+  ctx.fillText(rankSub, innerX + 30, innerY + 560);
+
+  // footer identity
+  ctx.fillStyle = accent;
+  ctx.font = '900 26px system-ui, -apple-system, Segoe UI, sans-serif';
+  ctx.fillText(options.username.toUpperCase(), innerX + 30, innerY + innerH - 70);
+
+  ctx.fillStyle = muted;
+  ctx.font = '900 22px system-ui, -apple-system, Segoe UI, sans-serif';
+  ctx.fillText(options.faction.replace('_', ' ').toUpperCase(), innerX + 30, innerY + innerH - 40);
+}
+
+function formatSeconds(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${String(m).padStart(2, '0')}:${String(r).padStart(2, '0')}`;
+}

--- a/src/features/finisher-card/lib/percentile.test.ts
+++ b/src/features/finisher-card/lib/percentile.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatTopPercent, percentileFromCounts } from '@/features/finisher-card/lib/percentile';
+
+describe('percentileFromCounts', () => {
+  it('returns null for invalid totals', () => {
+    expect(percentileFromCounts(0, 0)).toBeNull();
+    expect(percentileFromCounts(-1, 0)).toBeNull();
+  });
+
+  it('computes rank and percentile (best is 1.0)', () => {
+    const r1 = percentileFromCounts(100, 0);
+    expect(r1).toEqual({ rank: 1, total: 100, percentile: 1 });
+
+    const r11 = percentileFromCounts(100, 10);
+    expect(r11).toEqual({ rank: 11, total: 100, percentile: 0.9 });
+  });
+});
+
+describe('formatTopPercent', () => {
+  it('formats percentile into Top X%', () => {
+    expect(formatTopPercent(1)).toBe(1);
+    expect(formatTopPercent(0.9)).toBe(10);
+    expect(formatTopPercent(0.88)).toBe(12);
+  });
+});

--- a/src/features/finisher-card/lib/percentile.ts
+++ b/src/features/finisher-card/lib/percentile.ts
@@ -1,0 +1,26 @@
+export type PercentileResult = {
+  /** 1-based rank where 1 is best. */
+  rank: number;
+  /** Total ranked population. */
+  total: number;
+  /** Percentile where 1.0 means "best/top" and 0.0 means "bottom". */
+  percentile: number;
+};
+
+export function percentileFromCounts(total: number, betterCount: number): PercentileResult | null {
+  if (!Number.isFinite(total) || !Number.isFinite(betterCount)) return null;
+  if (total <= 0) return null;
+  if (betterCount < 0) return null;
+
+  const rank = betterCount + 1;
+  const clampedRank = Math.min(Math.max(rank, 1), total);
+  const percentile = 1 - (clampedRank - 1) / total;
+
+  return { rank: clampedRank, total, percentile };
+}
+
+export function formatTopPercent(percentile: number): number | null {
+  if (!Number.isFinite(percentile)) return null;
+  const p = Math.min(Math.max(percentile, 0), 1);
+  return Math.max(1, Math.ceil((1 - p) * 100));
+}

--- a/src/features/finisher-card/services/rank.ts
+++ b/src/features/finisher-card/services/rank.ts
@@ -1,0 +1,43 @@
+import { supabase } from '@/lib/supabase';
+import type { ScoreType } from '@/lib/types/database.types';
+
+type Options = {
+  challengeId: string;
+  scoreType: ScoreType;
+  value: number;
+};
+
+export type RankCounts = {
+  total: number;
+  better: number;
+};
+
+export async function getRankCounts({
+  challengeId,
+  scoreType,
+  value,
+}: Options): Promise<RankCounts> {
+  const totalRes = await supabase
+    .from('scores')
+    .select('id', { head: true, count: 'exact' })
+    .eq('challenge_id', challengeId)
+    .eq('is_validated', true);
+  if (totalRes.error) throw new Error(totalRes.error.message);
+
+  const total = totalRes.count ?? 0;
+
+  const betterQuery = supabase
+    .from('scores')
+    .select('id', { head: true, count: 'exact' })
+    .eq('challenge_id', challengeId)
+    .eq('is_validated', true);
+
+  const betterRes =
+    scoreType === 'time'
+      ? await betterQuery.lt('value', value)
+      : await betterQuery.gt('value', value);
+  if (betterRes.error) throw new Error(betterRes.error.message);
+
+  const better = betterRes.count ?? 0;
+  return { total, better };
+}

--- a/src/features/finisher-card/services/scores.ts
+++ b/src/features/finisher-card/services/scores.ts
@@ -1,0 +1,14 @@
+import { supabase } from '@/lib/supabase';
+import type { Score } from '@/lib/types/database.types';
+
+const SCORE_SELECT = 'id,challenge_id,user_id,value,video_url,is_validated,submitted_at';
+
+export async function getScoreById(scoreId: string): Promise<Score | null> {
+  const { data, error } = await supabase
+    .from('scores')
+    .select(SCORE_SELECT)
+    .eq('id', scoreId)
+    .maybeSingle<Score>();
+  if (error) throw new Error(error.message);
+  return data ?? null;
+}

--- a/src/features/submission/components/ScoreSubmissionForm.tsx
+++ b/src/features/submission/components/ScoreSubmissionForm.tsx
@@ -21,7 +21,7 @@ type FormValues = {
 type Props = {
   challengeId: string;
   scoreType: ScoreType;
-  onSubmitted: (result: { ranked: boolean }) => void;
+  onSubmitted: (result: { ranked: boolean; insertedId: string }) => void;
 };
 
 function createSchema(t: (key: string) => string, scoreType: ScoreType) {
@@ -99,7 +99,7 @@ export function ScoreSubmissionForm({ challengeId, scoreType, onSubmitted }: Pro
           value,
           videoUrl: values.videoUrl,
         });
-        onSubmitted({ ranked: res.ranked });
+        onSubmitted({ ranked: res.ranked, insertedId: res.insertedId });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : 'unknown';
         if (message === SUBMISSION_ERRORS.VIDEO_INVALID) {

--- a/src/features/submission/components/ScoreSubmissionScreen.tsx
+++ b/src/features/submission/components/ScoreSubmissionScreen.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { useChallenge } from '@/features/challenges/hooks/useChallenge';
 import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
@@ -12,7 +13,7 @@ type Props = {
   challengeId: string;
 };
 
-type Result = { ranked: boolean };
+type Result = { ranked: boolean; insertedId: string };
 
 function ResultCard({ ranked }: { ranked: boolean }) {
   const t = useTranslations('submission');
@@ -30,6 +31,7 @@ export function ScoreSubmissionScreen({ challengeId }: Props) {
   const t = useTranslations('submission');
   const tArena = useTranslations('arena');
   const locale = useLocale();
+  const router = useRouter();
   const { data: challenge, loading, error } = useChallenge(challengeId);
   const [result, setResult] = useState<Result | null>(null);
 
@@ -87,7 +89,14 @@ export function ScoreSubmissionScreen({ challengeId }: Props) {
       <ScoreSubmissionForm
         challengeId={challenge.id}
         scoreType={challenge.score_type}
-        onSubmitted={(r) => setResult(r)}
+        onSubmitted={(r) => {
+          setResult(r);
+          router.push(
+            `/${locale}/app/finish?challengeId=${challenge.id}&ranked=${String(r.ranked)}&scoreId=${encodeURIComponent(
+              r.insertedId,
+            )}`,
+          );
+        }}
       />
     </section>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,5 +212,15 @@
       "videoInvalid": "Video URL must be a YouTube or TikTok link.",
       "submitFailed": "Could not submit your score."
     }
+  },
+  "finisher": {
+    "title": "FINISHER CARD",
+    "loading": "Loading...",
+    "error": "Could not load your finisher card.",
+    "rankedBody": "Certified. You're ranked.",
+    "savedBody": "Saved. Not ranked (no video).",
+    "download": "DOWNLOAD",
+    "share": "SHARE",
+    "backToArena": "BACK TO ARENA"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -212,5 +212,15 @@
       "videoInvalid": "Le lien doit être YouTube ou TikTok.",
       "submitFailed": "Impossible d'envoyer ton score."
     }
+  },
+  "finisher": {
+    "title": "FINISHER CARD",
+    "loading": "Chargement...",
+    "error": "Impossible de charger ta Finisher Card.",
+    "rankedBody": "Certifié. Tu es classé.",
+    "savedBody": "Sauvegardé. Non classé (pas de vidéo).",
+    "download": "TÉLÉCHARGER",
+    "share": "PARTAGER",
+    "backToArena": "RETOUR À L'ARÈNE"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `/app/finish` finisher screen shown after score submission.
- Generates a canvas-based Finisher Card (dark + faction accent) and supports PNG download + Web Share API.
- Computes Top X% for validated (ranked) scores using validated-only leaderboard counts.

## Test plan
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm build`
- `pnpm e2e`

## Notes
- Unranked submissions (no video) show a non-ranked variant.

Made with [Cursor](https://cursor.com)