### PR TITLE
feat(profile): avatar upload

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -452,7 +452,7 @@ Submission form: score input (time MM:SS or reps by challenge). Users can submit
 
 - [x] 🟢 Insert into `scores`: challenge_id, user_id, value (seconds for time, int for reps), video_url (if any), is_validated
 - [x] 🟢 Error handling (RLS, invalid URL, etc.)
-- [ ] 🟡 On success: show Finisher Card (Issue #7)
+- [x] 🟢 On success: show Finisher Card (Issue #7)
 
 #### UX
 
@@ -464,20 +464,16 @@ Submission form: score input (time MM:SS or reps by challenge). Users can submit
 - [x] Score submission (time or reps) saved correctly
 - [x] Without video: score is saved but not shown in public leaderboard
 - [x] With video: score is validated and shown in public leaderboard
-- [ ] Finisher Card shown after submit (Issue #7)
+- [x] Finisher Card shown after submit (Issue #7)
 
 ---
 
 ## 🎯 Issue #7: Finisher Card (generation + share)
 
-**Status:** 🔴 **NOT STARTED**  
+**Status:** 🟢 **COMPLETED**  
 **Priority:** HIGH  
 **Phase:** Screen 5  
 **Dependencies:** Issue #6
-
-### Immediate next action
-
-- Build the Finisher Card screen shown right after a successful submission (Issue #6)
 
 ### Description
 
@@ -487,38 +483,42 @@ Generate image (client-side canvas): score, world rank (e.g. Top 12%), Faction, 
 
 #### Image generation
 
-- [ ] 🔴 Component or util that draws on canvas (or lib like html2canvas if needed)
-- [ ] 🔴 Content: score (formatted), rank (e.g. “Top 12% worldwide”), Faction name, Faction colors, Truegrynd logo
-- [ ] 🔴 Design per ui-design-guidelines (dark, high contrast); respect light/dark theme if applicable
-- [ ] 🔴 Export as PNG (blob or data URL)
+- [x] 🟢 Component/util draws on canvas (client-only)
+- [x] 🟢 Content: score (formatted), rank % (Top X%), Faction + branding
+- [x] 🟢 Design per ui-design-guidelines (dark, high contrast)
+- [x] 🟢 Export as PNG (blob)
 
 #### Display & download
 
-- [ ] 🔴 “Reward” screen or modal showing generated card
-- [ ] 🔴 “Download” button → trigger PNG download
-- [ ] 🔴 “Share to Story” or “Share”: Web Share API if available, else “Download” for manual Story upload
-- [ ] 🔴 Copy from i18n
+- [x] 🟢 Reward screen showing generated card
+- [x] 🟢 Download button (PNG)
+- [x] 🟢 Share (Web Share API when available) + fallback to download
+- [x] 🟢 Copy from i18n
 
 #### Data
 
-- [ ] 🔴 Score and challenge from the submission just made
-- [ ] 🔴 Rank computed after insert (position in leaderboard as %)
-- [ ] 🔴 Faction and username from profile
+- [x] 🟢 Score + challenge from the submission
+- [x] 🟢 Rank computed after insert (Top X% within validated leaderboard)
+- [x] 🟢 Faction + username from profile
 
 ### Acceptance criteria
 
-- [ ] Card generated with correct info (score, rank %, Faction, branding)
-- [ ] PNG download works
-- [ ] Share or download usable for Stories
+- [x] Card generated with correct info (score, rank %, Faction, branding)
+- [x] PNG download works
+- [x] Share or download usable for Stories
 
 ---
 
 ## 🎯 Issue #8: User profile
 
-**Status:** 🔴 **NOT STARTED**  
+**Status:** 🟡 **IN PROGRESS**  
 **Priority:** HIGH  
 **Phase:** Screen 6  
 **Dependencies:** Issue #3, #4
+
+### Immediate next action
+
+- Implement profile header + score history (no public profiles in MVP)
 
 ### Description
 

--- a/src/app/[locale]/app/profile/page.tsx
+++ b/src/app/[locale]/app/profile/page.tsx
@@ -2,19 +2,61 @@
 
 import { useTranslations } from 'next-intl';
 
+import { AvatarUploader } from '@/features/profile/components/AvatarUploader';
+import { useProfile } from '@/features/profile/hooks/useProfile';
+
 export default function ProfilePage() {
   const tabs = useTranslations('app.tabs');
-  const cs = useTranslations('app.comingSoon');
+  const t = useTranslations('profile');
+  const { state, refetch } = useProfile();
+
+  if (state.status === 'loading') {
+    return (
+      <section className="space-y-3">
+        <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
+          {tabs('profile')}
+        </h1>
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
+      </section>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="space-y-3">
+        <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
+          {tabs('profile')}
+        </h1>
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+            {t('errorTitle')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">{t('errorBody')}</p>
+          <p className="mt-2 text-xs text-muted-foreground">{state.error}</p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="mt-4 inline-flex items-center justify-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90"
+          >
+            {t('retry')}
+          </button>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="space-y-3">
       <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
         {tabs('profile')}
       </h1>
-      <div className="rounded-md border border-border bg-card p-4">
-        <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{cs('title')}</p>
-        <p className="mt-2 text-sm text-muted-foreground">{cs('body')}</p>
-      </div>
+
+      <AvatarUploader
+        userId={state.profile.id}
+        avatarUrl={state.profile.avatar_url}
+        username={state.profile.username}
+        onUpdated={refetch}
+      />
     </section>
   );
 }

--- a/src/features/profile/components/AvatarUploader.tsx
+++ b/src/features/profile/components/AvatarUploader.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useCallback, useId, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { uploadAvatar } from '@/features/profile/services/avatarUpload';
+import { updateAvatarUrl } from '@/features/profile/services/profile';
+
+type Props = {
+  userId: string;
+  avatarUrl: string | null;
+  username: string | null;
+  onUpdated: () => void;
+};
+
+const ACCEPT = 'image/png,image/jpeg,image/webp';
+const MAX_BYTES = 3 * 1024 * 1024;
+
+function initials(username: string | null): string {
+  const raw = (username ?? '').trim();
+  if (!raw) return 'TG';
+  const parts = raw.split(/\s+/).filter(Boolean);
+  const a = parts[0]?.[0] ?? raw[0] ?? 'T';
+  const b = parts[1]?.[0] ?? parts[0]?.[1] ?? 'G';
+  return `${a}${b}`.toUpperCase();
+}
+
+export function AvatarUploader({ userId, avatarUrl, username, onUpdated }: Props) {
+  const t = useTranslations('profile');
+  const inputId = useId();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onPickFile = useCallback(
+    async (file: File | null) => {
+      if (!file) return;
+      setError(null);
+
+      if (!ACCEPT.split(',').includes(file.type)) {
+        setError(t('avatar.errors.type'));
+        return;
+      }
+      if (file.size > MAX_BYTES) {
+        setError(t('avatar.errors.size'));
+        return;
+      }
+
+      setBusy(true);
+      try {
+        const publicUrl = await uploadAvatar({ userId, file });
+        await updateAvatarUrl({ userId, avatarUrl: publicUrl });
+        onUpdated();
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        setError(`${t('avatar.errors.upload')} (${message})`);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [onUpdated, t, userId],
+  );
+
+  const onRemove = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateAvatarUrl({ userId, avatarUrl: null });
+      onUpdated();
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'unknown';
+      setError(`${t('avatar.errors.remove')} (${message})`);
+    } finally {
+      setBusy(false);
+    }
+  }, [onUpdated, t, userId]);
+
+  return (
+    <div className="rounded-md border border-border bg-card p-4">
+      <div className="flex items-center gap-4">
+        <div className="relative h-16 w-16 overflow-hidden rounded-sm border border-border bg-muted">
+          {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={avatarUrl} alt={t('avatar.alt')} className="h-full w-full object-cover" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-lg font-black tracking-tight">
+              {initials(username)}
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 space-y-2">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('avatar.title')}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <label
+              htmlFor={inputId}
+              className="inline-flex cursor-pointer items-center justify-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 aria-disabled:opacity-50"
+              aria-disabled={busy}
+            >
+              {busy ? t('avatar.uploading') : t('avatar.change')}
+            </label>
+            <input
+              id={inputId}
+              type="file"
+              accept={ACCEPT}
+              className="hidden"
+              disabled={busy}
+              onChange={(e) => void onPickFile(e.target.files?.[0] ?? null)}
+            />
+
+            <button
+              type="button"
+              onClick={() => void onRemove()}
+              disabled={busy || !avatarUrl}
+              className="inline-flex items-center justify-center rounded-md border border-border bg-background px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted disabled:opacity-50"
+            >
+              {t('avatar.remove')}
+            </button>
+          </div>
+
+          {error ? <p className="text-xs font-semibold text-primary">{error}</p> : null}
+          <p className="text-xs text-muted-foreground">{t('avatar.hint')}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/profile/hooks/useProfile.ts
+++ b/src/features/profile/hooks/useProfile.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAuth } from '@/features/auth/AuthProvider';
+import { fetchOrEnsureProfile } from '@/features/onboarding/services/onboarding';
+import type { Profile } from '@/lib/types/database.types';
+
+type State =
+  | { status: 'loading'; profile: null; error: null }
+  | { status: 'error'; profile: null; error: string }
+  | { status: 'ready'; profile: Profile; error: null };
+
+const initial: State = { status: 'loading', profile: null, error: null };
+
+export function useProfile(): { state: State; refetch: () => void } {
+  const { user, initialized } = useAuth();
+  const [state, setState] = useState<State>(initial);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!initialized) return undefined;
+    if (!user) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const profile = await fetchOrEnsureProfile(user.id);
+        if (!cancelled) setState({ status: 'ready', profile, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', profile: null, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [initialized, user, reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState(initial);
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  return { state, refetch };
+}

--- a/src/features/profile/services/avatarUpload.ts
+++ b/src/features/profile/services/avatarUpload.ts
@@ -1,0 +1,33 @@
+import { supabase } from '@/lib/supabase';
+
+type Options = {
+  userId: string;
+  file: File;
+};
+
+const AVATAR_BUCKET = 'avatars';
+
+function extFromMime(file: File): string {
+  if (file.type === 'image/png') return 'png';
+  if (file.type === 'image/jpeg') return 'jpg';
+  if (file.type === 'image/webp') return 'webp';
+  return 'bin';
+}
+
+export async function uploadAvatar({ userId, file }: Options): Promise<string> {
+  const ext = extFromMime(file);
+  const filename = `${crypto.randomUUID()}.${ext}`;
+  const path = `${userId}/${filename}`;
+
+  const { error } = await supabase.storage.from(AVATAR_BUCKET).upload(path, file, {
+    upsert: true,
+    cacheControl: '3600',
+    contentType: file.type,
+  });
+
+  if (error) throw new Error(error.message);
+
+  const { data } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(path);
+  if (!data.publicUrl) throw new Error('public_url_missing');
+  return data.publicUrl;
+}

--- a/src/features/profile/services/profile.ts
+++ b/src/features/profile/services/profile.ts
@@ -1,0 +1,31 @@
+import { supabase } from '@/lib/supabase';
+import type { Profile } from '@/lib/types/database.types';
+
+const PROFILE_SELECT =
+  'id,username,sex,age,weight_kg,faction,initiation_completed,creator_score,streak_days,last_activity_at,avatar_url,created_at,updated_at';
+
+export async function getProfileById(userId: string): Promise<Profile> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select(PROFILE_SELECT)
+    .eq('id', userId)
+    .maybeSingle<Profile>();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('profile_not_found');
+  return data;
+}
+
+export async function updateAvatarUrl(input: {
+  userId: string;
+  avatarUrl: string | null;
+}): Promise<Profile> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .update({ avatar_url: input.avatarUrl })
+    .eq('id', input.userId)
+    .select(PROFILE_SELECT)
+    .maybeSingle<Profile>();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('profile_not_found');
+  return data;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -222,5 +222,25 @@
     "download": "DOWNLOAD",
     "share": "SHARE",
     "backToArena": "BACK TO ARENA"
+  },
+  "profile": {
+    "loading": "Loading profile...",
+    "errorTitle": "Could not load profile",
+    "errorBody": "Try again.",
+    "retry": "Retry",
+    "avatar": {
+      "title": "AVATAR",
+      "alt": "Profile avatar",
+      "change": "CHANGE",
+      "uploading": "UPLOADING...",
+      "remove": "REMOVE",
+      "hint": "PNG/JPG/WEBP · max 3MB",
+      "errors": {
+        "type": "Unsupported file type.",
+        "size": "File is too large.",
+        "upload": "Upload failed.",
+        "remove": "Could not remove avatar."
+      }
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -222,5 +222,25 @@
     "download": "TÉLÉCHARGER",
     "share": "PARTAGER",
     "backToArena": "RETOUR À L'ARÈNE"
+  },
+  "profile": {
+    "loading": "Chargement du profil...",
+    "errorTitle": "Impossible de charger le profil",
+    "errorBody": "Réessaie.",
+    "retry": "Réessayer",
+    "avatar": {
+      "title": "AVATAR",
+      "alt": "Avatar du profil",
+      "change": "MODIFIER",
+      "uploading": "UPLOAD...",
+      "remove": "SUPPRIMER",
+      "hint": "PNG/JPG/WEBP · max 3MB",
+      "errors": {
+        "type": "Type de fichier non supporté.",
+        "size": "Fichier trop volumineux.",
+        "upload": "Échec de l'upload.",
+        "remove": "Impossible de supprimer l'avatar."
+      }
+    }
   }
 }

--- a/supabase/migrations/005_storage_avatars.sql
+++ b/supabase/migrations/005_storage_avatars.sql
@@ -1,0 +1,48 @@
+-- Migration: 005_storage_avatars.sql
+-- Description: Public avatars bucket + strict write policies
+-- Notes:
+-- - Bucket is public (avatars are meant to be visible in leaderboards/profile).
+-- - Upload/write is restricted to the owner folder: `avatars/{userId}/...`
+
+-- Create the bucket if it doesn't exist.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO UPDATE
+SET public = EXCLUDED.public;
+
+-- RLS policies on storage.objects
+-- Allow anyone (anon/auth) to read avatar objects.
+CREATE POLICY "Public can read avatars"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'avatars');
+
+-- Only the authenticated user can write to their own folder.
+-- Objects must be stored under `{auth.uid()}/...`
+CREATE POLICY "Users can upload own avatar"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+CREATE POLICY "Users can update own avatar"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+CREATE POLICY "Users can delete own avatar"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+


### PR DESCRIPTION
## Summary
- Adds Profile page avatar uploader (PNG/JPG/WEBP, max 3MB) and basic profile loading states.
- Uploads avatar to Supabase Storage bucket `avatars` under `{userId}/{uuid}.{ext}`.
- Stores the public URL in `profiles.avatar_url`.
- Adds migration to create the public `avatars` bucket with strict owner write policies.

## Test plan
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm e2e`

## Supabase note
- Requires running `supabase/migrations/005_storage_avatars.sql` (bucket + policies). User confirmed it was applied.

Made with [Cursor](https://cursor.com)