### PR TITLE
feat(profile): score history

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -43,3 +43,8 @@ test('finish redirects to auth when logged out', async ({ page }) => {
   await page.goto('/en/app/finish');
   await expect(page).toHaveURL(/\/en\/auth$/);
 });
+
+test('profile redirects to auth when logged out', async ({ page }) => {
+  await page.goto('/en/app/profile');
+  await expect(page).toHaveURL(/\/en\/auth$/);
+});

--- a/src/app/[locale]/app/profile/page.tsx
+++ b/src/app/[locale]/app/profile/page.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 import { AvatarUploader } from '@/features/profile/components/AvatarUploader';
+import { ScoreHistory } from '@/features/profile/components/ScoreHistory';
 import { useProfile } from '@/features/profile/hooks/useProfile';
 
 export default function ProfilePage() {
@@ -46,7 +47,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <section className="space-y-3">
+    <section className="space-y-6">
       <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
         {tabs('profile')}
       </h1>
@@ -57,6 +58,8 @@ export default function ProfilePage() {
         username={state.profile.username}
         onUpdated={refetch}
       />
+
+      <ScoreHistory userId={state.profile.id} />
     </section>
   );
 }

--- a/src/features/profile/components/ScoreHistory.tsx
+++ b/src/features/profile/components/ScoreHistory.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { formatScore } from '@/features/challenges/lib/scoreFormat';
+import { useMyScores } from '@/features/profile/hooks/useMyScores';
+
+type Props = {
+  userId: string;
+};
+
+function Badge({ children, tone }: { children: string; tone: 'ranked' | 'saved' }) {
+  const className =
+    tone === 'ranked'
+      ? 'border-primary bg-primary/10 text-primary'
+      : 'border-border bg-muted text-muted-foreground';
+  return (
+    <span
+      className={[
+        'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+        className,
+      ].join(' ')}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function ScoreHistory({ userId }: Props) {
+  const t = useTranslations('profile.history');
+  const locale = useLocale();
+  const { state, refetch } = useMyScores(userId);
+
+  if (state.status === 'loading') {
+    return (
+      <section className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{t('loading')}</p>
+      </section>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{t('error')}</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-3 inline-flex items-center justify-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90"
+        >
+          {t('retry')}
+        </button>
+      </section>
+    );
+  }
+
+  if (state.data.length === 0) {
+    return (
+      <section className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{t('empty')}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-md border border-border bg-card p-4 space-y-3">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('title')}
+      </p>
+
+      <div className="space-y-2">
+        {state.data.map((s) => {
+          const score = formatScore(s.value, s.scoreType);
+          const badge = s.isValidated ? t('ranked') : t('saved');
+          const tone = s.isValidated ? 'ranked' : 'saved';
+          const toChallenge = `/${locale}/app/arena/${s.challengeId}`;
+          const toFinisher = `/${locale}/app/finish?challengeId=${s.challengeId}&ranked=${String(
+            s.isValidated,
+          )}&scoreId=${encodeURIComponent(s.id)}`;
+
+          return (
+            <div key={s.id} className="rounded-sm border border-border bg-background p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-black uppercase tracking-tight">
+                    {s.challengeTitle}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {score} · {new Date(s.submittedAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <Badge tone={tone}>{badge}</Badge>
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Link
+                  href={toChallenge}
+                  className="inline-flex items-center justify-center rounded-md border border-border bg-muted px-3 py-2 text-[11px] font-black uppercase tracking-[0.18em] text-foreground hover:bg-background"
+                >
+                  {t('viewChallenge')}
+                </Link>
+                <Link
+                  href={toFinisher}
+                  className="inline-flex items-center justify-center rounded-md bg-primary px-3 py-2 text-[11px] font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90"
+                >
+                  {t('viewCard')}
+                </Link>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/features/profile/hooks/useMyScores.ts
+++ b/src/features/profile/hooks/useMyScores.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { listMyScores, type ProfileScoreItem } from '@/features/profile/services/scores';
+
+type State =
+  | { status: 'loading'; data: null; error: null }
+  | { status: 'error'; data: null; error: string }
+  | { status: 'ready'; data: ProfileScoreItem[]; error: null };
+
+const initial: State = { status: 'loading', data: null, error: null };
+
+export function useMyScores(userId: string | null): { state: State; refetch: () => void } {
+  const [state, setState] = useState<State>(initial);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!userId) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await listMyScores(userId);
+        if (!cancelled) setState({ status: 'ready', data, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', data: null, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState(initial);
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  return { state, refetch };
+}

--- a/src/features/profile/services/scores.ts
+++ b/src/features/profile/services/scores.ts
@@ -1,0 +1,48 @@
+import { supabase } from '@/lib/supabase';
+import type { ScoreType } from '@/lib/types/database.types';
+
+export type ProfileScoreItem = {
+  id: string;
+  challengeId: string;
+  challengeTitle: string;
+  scoreType: ScoreType;
+  value: number;
+  isValidated: boolean;
+  submittedAt: string;
+};
+
+const SCORE_SELECT =
+  'id,challenge_id,value,is_validated,submitted_at,challenge:challenges!scores_challenge_id_fkey(id,title,score_type)';
+
+type Row = {
+  id: string;
+  challenge_id: string;
+  value: number;
+  is_validated: boolean;
+  submitted_at: string;
+  challenge: { id: string; title: string; score_type: ScoreType } | null;
+};
+
+export async function listMyScores(userId: string, limit = 25): Promise<ProfileScoreItem[]> {
+  const { data, error } = await supabase
+    .from('scores')
+    .select(SCORE_SELECT)
+    .eq('user_id', userId)
+    .order('submitted_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+
+  const rows = (data ?? []) as unknown as Row[];
+  return rows
+    .filter((r) => !!r.challenge)
+    .map((r) => ({
+      id: r.id,
+      challengeId: r.challenge_id,
+      challengeTitle: r.challenge!.title,
+      scoreType: r.challenge!.score_type,
+      value: Number(r.value),
+      isValidated: r.is_validated,
+      submittedAt: r.submitted_at,
+    }));
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -241,6 +241,17 @@
         "upload": "Upload failed.",
         "remove": "Could not remove avatar."
       }
+    },
+    "history": {
+      "title": "HISTORY",
+      "loading": "Loading scores...",
+      "error": "Could not load your scores.",
+      "retry": "Retry",
+      "empty": "No scores yet. Go earn one.",
+      "ranked": "RANKED",
+      "saved": "SAVED",
+      "viewChallenge": "CHALLENGE",
+      "viewCard": "CARD"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -241,6 +241,17 @@
         "upload": "Échec de l'upload.",
         "remove": "Impossible de supprimer l'avatar."
       }
+    },
+    "history": {
+      "title": "HISTORIQUE",
+      "loading": "Chargement des scores...",
+      "error": "Impossible de charger tes scores.",
+      "retry": "Réessayer",
+      "empty": "Aucun score pour l'instant. Va en gagner un.",
+      "ranked": "CLASSÉ",
+      "saved": "SAUVEGARDÉ",
+      "viewChallenge": "DÉFI",
+      "viewCard": "CARD"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds Profile score history (latest submissions) including ranked vs saved badges.
- Links to the challenge page and to the Finisher Card screen for each score (gallery via regeneration).
- Adds i18n (en/fr) and an e2e smoke gate for `/app/profile`.

## Test plan
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm e2e`

Made with [Cursor](https://cursor.com)