### PR TITLE
feat(profile): header + cards gallery

### DIFF
--- a/src/app/[locale]/app/profile/page.tsx
+++ b/src/app/[locale]/app/profile/page.tsx
@@ -3,6 +3,8 @@
 import { useTranslations } from 'next-intl';
 
 import { AvatarUploader } from '@/features/profile/components/AvatarUploader';
+import { FinisherGallery } from '@/features/profile/components/FinisherGallery';
+import { ProfileHeader } from '@/features/profile/components/ProfileHeader';
 import { ScoreHistory } from '@/features/profile/components/ScoreHistory';
 import { useProfile } from '@/features/profile/hooks/useProfile';
 
@@ -52,11 +54,19 @@ export default function ProfilePage() {
         {tabs('profile')}
       </h1>
 
+      <ProfileHeader profile={state.profile} />
+
       <AvatarUploader
         userId={state.profile.id}
         avatarUrl={state.profile.avatar_url}
         username={state.profile.username}
         onUpdated={refetch}
+      />
+
+      <FinisherGallery
+        userId={state.profile.id}
+        username={state.profile.username}
+        faction={state.profile.faction}
       />
 
       <ScoreHistory userId={state.profile.id} />

--- a/src/features/finisher-card/lib/drawCard.ts
+++ b/src/features/finisher-card/lib/drawCard.ts
@@ -9,6 +9,8 @@ type Options = {
   scoreType: ScoreType;
   scoreValue: number;
   topPercent: number | null;
+  rankTextOverride?: string;
+  rankSubOverride?: string;
 };
 
 function factionColor(faction: Faction): string {
@@ -78,12 +80,15 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
   // rank
   ctx.fillStyle = fg;
   ctx.font = '900 72px system-ui, -apple-system, Segoe UI, sans-serif';
-  const rankText = options.topPercent ? `TOP ${options.topPercent}%` : 'SAVED';
+  const rankText =
+    options.rankTextOverride ?? (options.topPercent ? `TOP ${options.topPercent}%` : 'SAVED');
   ctx.fillText(rankText, innerX + 30, innerY + 470);
 
   ctx.fillStyle = muted;
   ctx.font = '900 22px system-ui, -apple-system, Segoe UI, sans-serif';
-  const rankSub = options.topPercent ? 'WORLDWIDE (VALIDATED)' : 'NOT RANKED (NO VIDEO)';
+  const rankSub =
+    options.rankSubOverride ??
+    (options.topPercent ? 'WORLDWIDE (VALIDATED)' : 'NOT RANKED (NO VIDEO)');
   ctx.fillText(rankSub, innerX + 30, innerY + 560);
 
   // footer identity

--- a/src/features/profile/components/AvatarUploader.tsx
+++ b/src/features/profile/components/AvatarUploader.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 
 import { uploadAvatar } from '@/features/profile/services/avatarUpload';
 import { updateAvatarUrl } from '@/features/profile/services/profile';
+import { initialsFromUsername } from '@/features/profile/lib/initials';
 
 type Props = {
   userId: string;
@@ -15,15 +16,6 @@ type Props = {
 
 const ACCEPT = 'image/png,image/jpeg,image/webp';
 const MAX_BYTES = 3 * 1024 * 1024;
-
-function initials(username: string | null): string {
-  const raw = (username ?? '').trim();
-  if (!raw) return 'TG';
-  const parts = raw.split(/\s+/).filter(Boolean);
-  const a = parts[0]?.[0] ?? raw[0] ?? 'T';
-  const b = parts[1]?.[0] ?? parts[0]?.[1] ?? 'G';
-  return `${a}${b}`.toUpperCase();
-}
 
 export function AvatarUploader({ userId, avatarUrl, username, onUpdated }: Props) {
   const t = useTranslations('profile');
@@ -83,7 +75,7 @@ export function AvatarUploader({ userId, avatarUrl, username, onUpdated }: Props
             <img src={avatarUrl} alt={t('avatar.alt')} className="h-full w-full object-cover" />
           ) : (
             <div className="flex h-full w-full items-center justify-center text-lg font-black tracking-tight">
-              {initials(username)}
+              {initialsFromUsername(username)}
             </div>
           )}
         </div>

--- a/src/features/profile/components/FinisherGallery.tsx
+++ b/src/features/profile/components/FinisherGallery.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+import { useEffect, useMemo, useRef } from 'react';
+
+import { drawFinisherCard } from '@/features/finisher-card/lib/drawCard';
+import { useMyScores } from '@/features/profile/hooks/useMyScores';
+import type { Faction } from '@/lib/types/database.types';
+
+type Props = {
+  userId: string;
+  username: string | null;
+  faction: Faction | null;
+};
+
+function ThumbCanvas({
+  username,
+  faction,
+  challengeTitle,
+  scoreType,
+  scoreValue,
+  ranked,
+}: {
+  username: string;
+  faction: Faction;
+  challengeTitle: string;
+  scoreType: 'time' | 'reps';
+  scoreValue: number;
+  ranked: boolean;
+}) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+
+  const options = useMemo(
+    () => ({
+      width: 360,
+      height: 640,
+      faction,
+      username,
+      challengeTitle,
+      scoreType,
+      scoreValue,
+      topPercent: null,
+      rankTextOverride: ranked ? 'RANKED' : 'SAVED',
+      rankSubOverride: ranked ? 'VALIDATED' : 'NO VIDEO',
+    }),
+    [challengeTitle, faction, ranked, scoreType, scoreValue, username],
+  );
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    drawFinisherCard(canvas, options);
+  }, [options]);
+
+  return <canvas ref={ref} className="h-auto w-full block" />;
+}
+
+export function FinisherGallery({ userId, username, faction }: Props) {
+  const t = useTranslations('profile.gallery');
+  const locale = useLocale();
+  const { state } = useMyScores(userId, { limit: 6 });
+
+  if (!username || !faction) {
+    return null;
+  }
+
+  if (state.status === 'loading') {
+    return (
+      <section className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{t('loading')}</p>
+      </section>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{t('error')}</p>
+      </section>
+    );
+  }
+
+  if (state.data.length === 0) {
+    return (
+      <section className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">{t('empty')}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('title')}
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        {state.data.map((s) => {
+          const href = `/${locale}/app/finish?challengeId=${s.challengeId}&ranked=${String(
+            s.isValidated,
+          )}&scoreId=${encodeURIComponent(s.id)}`;
+
+          return (
+            <Link
+              key={s.id}
+              href={href}
+              className="rounded-md border border-border bg-card p-2 hover:border-primary/40"
+              aria-label={t('open')}
+            >
+              <ThumbCanvas
+                username={username}
+                faction={faction}
+                challengeTitle={s.challengeTitle}
+                scoreType={s.scoreType}
+                scoreValue={s.value}
+                ranked={s.isValidated}
+              />
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { Faction, Profile } from '@/lib/types/database.types';
+import { initialsFromUsername } from '@/features/profile/lib/initials';
+
+function factionClasses(faction: Faction): { bg: string; text: string; border: string } {
+  if (faction === 'nomads') {
+    return {
+      bg: 'bg-[var(--faction-nomads)]/15',
+      text: 'text-[var(--faction-nomads)]',
+      border: 'border-[var(--faction-nomads)]/40',
+    };
+  }
+  if (faction === 'horde') {
+    return {
+      bg: 'bg-[var(--faction-horde)]/15',
+      text: 'text-[var(--faction-horde)]',
+      border: 'border-[var(--faction-horde)]/40',
+    };
+  }
+  return {
+    bg: 'bg-[var(--faction-iron)]/15',
+    text: 'text-[var(--faction-iron)]',
+    border: 'border-[var(--faction-iron)]/40',
+  };
+}
+
+export function ProfileHeader({ profile }: { profile: Profile }) {
+  const t = useTranslations('profile.header');
+
+  const username = profile.username ?? t('unknownUser');
+  const faction = profile.faction;
+  const badge = faction ? factionClasses(faction) : null;
+
+  return (
+    <section className="rounded-md border border-border bg-card p-4">
+      <div className="flex items-center gap-4">
+        <div className="relative h-16 w-16 overflow-hidden rounded-sm border border-border bg-muted">
+          {profile.avatar_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={profile.avatar_url}
+              alt={t('avatarAlt')}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-lg font-black tracking-tight">
+              {initialsFromUsername(profile.username)}
+            </div>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xl font-black uppercase tracking-tight">{username}</p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {badge ? (
+              <span
+                className={[
+                  'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+                  badge.bg,
+                  badge.text,
+                  badge.border,
+                ].join(' ')}
+              >
+                {t(`factions.${faction}`)}
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-sm border border-border bg-muted px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+                {t('noFaction')}
+              </span>
+            )}
+
+            <span className="text-xs text-muted-foreground">
+              {t('streak', { days: profile.streak_days })}
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/profile/hooks/useMyScores.ts
+++ b/src/features/profile/hooks/useMyScores.ts
@@ -11,9 +11,18 @@ type State =
 
 const initial: State = { status: 'loading', data: null, error: null };
 
-export function useMyScores(userId: string | null): { state: State; refetch: () => void } {
+type Options = {
+  limit?: number;
+};
+
+export function useMyScores(
+  userId: string | null,
+  options?: Options,
+): { state: State; refetch: () => void } {
   const [state, setState] = useState<State>(initial);
   const [reloadKey, setReloadKey] = useState(0);
+
+  const limit = options?.limit ?? 25;
 
   useEffect(() => {
     if (!userId) return undefined;
@@ -21,7 +30,7 @@ export function useMyScores(userId: string | null): { state: State; refetch: () 
     let cancelled = false;
     void (async () => {
       try {
-        const data = await listMyScores(userId);
+        const data = await listMyScores(userId, limit);
         if (!cancelled) setState({ status: 'ready', data, error: null });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : 'unknown';
@@ -32,7 +41,7 @@ export function useMyScores(userId: string | null): { state: State; refetch: () 
     return () => {
       cancelled = true;
     };
-  }, [userId, reloadKey]);
+  }, [limit, userId, reloadKey]);
 
   const refetch = useCallback(() => {
     setState(initial);

--- a/src/features/profile/lib/initials.ts
+++ b/src/features/profile/lib/initials.ts
@@ -1,0 +1,8 @@
+export function initialsFromUsername(username: string | null): string {
+  const raw = (username ?? '').trim();
+  if (!raw) return 'TG';
+  const parts = raw.split(/\s+/).filter(Boolean);
+  const a = parts[0]?.[0] ?? raw[0] ?? 'T';
+  const b = parts[1]?.[0] ?? parts[0]?.[1] ?? 'G';
+  return `${a}${b}`.toUpperCase();
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -252,6 +252,24 @@
       "saved": "SAVED",
       "viewChallenge": "CHALLENGE",
       "viewCard": "CARD"
+    },
+    "header": {
+      "unknownUser": "UNKNOWN",
+      "avatarAlt": "Profile avatar",
+      "noFaction": "NO FACTION",
+      "streak": "Streak: {days}d",
+      "factions": {
+        "nomads": "NOMADS",
+        "horde": "HORDE",
+        "iron_alliance": "IRON ALLIANCE"
+      }
+    },
+    "gallery": {
+      "title": "CARDS",
+      "loading": "Loading cards...",
+      "error": "Could not load cards.",
+      "empty": "No cards yet.",
+      "open": "Open finisher card"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -252,6 +252,24 @@
       "saved": "SAUVEGARDÉ",
       "viewChallenge": "DÉFI",
       "viewCard": "CARD"
+    },
+    "header": {
+      "unknownUser": "INCONNU",
+      "avatarAlt": "Avatar du profil",
+      "noFaction": "SANS FACTION",
+      "streak": "Série : {days}j",
+      "factions": {
+        "nomads": "NOMADES",
+        "horde": "HORDE",
+        "iron_alliance": "ALLIANCE DE FER"
+      }
+    },
+    "gallery": {
+      "title": "CARDS",
+      "loading": "Chargement des cards...",
+      "error": "Impossible de charger les cards.",
+      "empty": "Aucune card pour l'instant.",
+      "open": "Ouvrir la finisher card"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds profile identity header (username, faction badge, streak).
- Adds a cards gallery grid (thumbnails rendered via canvas) linking to the full Finisher Card screen.
- Refactors initials helper into shared util; extends finisher card draw util to allow rank label overrides.

## Test plan
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm e2e`

Made with [Cursor](https://cursor.com)