### PR TITLE
feat(polish): issue #28 seo + errors

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -8,15 +8,13 @@
 
 ## 🚀 IMMEDIATE NEXT ACTION (For AI Agent)
 
-**Target:** Issue #9: App navigation & layout (tabs, Overview, Clan)
+**Target:** Issue #10: Polish & deployment
 **Workflow to execute:**
 
-1. GitHub Issue created: #25
-2. PRs for Issue #9 work:
-   - Overview: PR #26 (merged ✅)
-   - Clan HUD: PR #27 (open)
-3. Branch: `feature/issue-25-clan-hud`
-4. Execute the tasks listed under "Issue #9" below.
+1. GitHub Issue created: #28
+2. Previous work merged: PR #27 (Issue #9) ✅
+3. Branch: `feature/issue-28-polish-deploy`
+4. Execute the tasks listed under "Issue #10" below.
 5. Check off the boxes `[x] 🟢` and update the status when finished.
 
 ---
@@ -620,7 +618,7 @@ Authenticated layout with 4 tabs: Overview, Arena, Clan, Profile. Overview: dail
 
 ## 🎯 Issue #10: Polish & deployment
 
-**Status:** 🔴 **NOT STARTED**  
+**Status:** 🟡 **IN PROGRESS**  
 **Priority:** HIGH  
 **Phase:** MVP delivery  
 **Dependencies:** Issues #3–#9
@@ -633,14 +631,14 @@ Basic SEO, meta tags, error handling (404), Vercel deployment, domain if needed.
 
 #### SEO & meta
 
-- [ ] 🔴 Meta title, description on main pages (landing, login, app)
-- [ ] 🔴 Open Graph / Twitter Card for sharing (at least landing)
-- [ ] 🔴 Favicon + meta consistent with brand
+- [x] 🟢 Meta title, description on main pages (landing, login, app)
+- [x] 🟢 Open Graph / Twitter Card for sharing (at least landing)
+- [x] 🟢 Favicon + meta consistent with brand
 - [ ] 🔴 (Optional) i18n per locale for meta
 
 #### Errors
 
-- [ ] 🔴 404 page (design system)
+- [x] 🟢 404 page (design system)
 - [ ] 🔴 Auth errors (session expired, etc.) with redirect or message
 - [ ] 🔴 i18n for error messages
 
@@ -653,7 +651,7 @@ Basic SEO, meta tags, error handling (404), Vercel deployment, domain if needed.
 
 #### E2E & quality
 
-- [ ] 🔴 Smoke E2E: at least landing + auth (login or redirect) + one app route if possible
+- [x] 🟢 Smoke E2E: at least landing + auth (login or redirect) + one app route if possible
 - [ ] 🔴 pre-push (or CI): typecheck + test:run + e2e pass
 
 ### Acceptance criteria

--- a/src/app/[locale]/auth/page.tsx
+++ b/src/app/[locale]/auth/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useLocale } from 'next-intl';
 import { useTranslations } from 'next-intl';
+import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@/features/auth/AuthProvider';
 import { signInWithMagicLink, signInWithOAuth } from '@/features/auth/services/auth';
 import { HeaderMobileSignIn } from '@/components/HeaderMobileSignIn';
@@ -20,6 +21,7 @@ export default function AuthPage() {
   const t = useTranslations('auth');
   const { user, initialized, lastEvent } = useAuth();
   const locale = useLocale();
+  const searchParams = useSearchParams();
 
   const [mounted, setMounted] = useState(false);
   const [email, setEmail] = useState('');
@@ -121,6 +123,11 @@ export default function AuthPage() {
         <div className="flex flex-col gap-2">
           <h1 className="text-4xl font-black tracking-tight">{t('title')}</h1>
           <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+          {searchParams.get('next') ? (
+            <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+              {t('signInToContinue')}
+            </p>
+          ) : null}
         </div>
 
         {debugEnabled ? <DevSessionReset /> : null}

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorBoundary({ error, reset }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('errors.app');
+
+  useEffect(() => {
+    // Intentionally no console logging in production.
+    void error;
+  }, [error]);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground px-4 pt-24">
+      <div className="mx-auto w-full max-w-lg space-y-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{t('label')}</p>
+        <h1 className="text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('body')}</p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={reset}
+            className="inline-flex flex-1 items-center justify-center rounded-md bg-primary px-4 py-3 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('retry')}
+          </button>
+          <Link
+            href={`/${locale}/app/overview`}
+            className="inline-flex flex-1 items-center justify-center rounded-md border border-border bg-card px-4 py-3 text-xs font-black uppercase tracking-[0.18em] text-foreground hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('home')}
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+export default function NotFound() {
+  const locale = useLocale();
+  const t = useTranslations('errors.notFound');
+
+  return (
+    <main className="min-h-screen bg-background text-foreground px-4 pt-24">
+      <div className="mx-auto w-full max-w-lg space-y-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{t('label')}</p>
+        <h1 className="text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('body')}</p>
+        <Link
+          href={`/${locale}/app/overview`}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-3 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('cta')}
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,26 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 180, height: 180 };
+export const contentType = 'image/png';
+
+export default function AppleIcon(): ImageResponse {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        background: '#0a0a0f',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 96,
+        fontWeight: 900,
+        letterSpacing: '-0.08em',
+        color: '#dc2626',
+      }}
+    >
+      TG
+    </div>,
+    { ...size },
+  );
+}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,26 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 64, height: 64 };
+export const contentType = 'image/png';
+
+export default function Icon(): ImageResponse {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        background: '#0a0a0f',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 40,
+        fontWeight: 900,
+        letterSpacing: '-0.08em',
+        color: '#dc2626',
+      }}
+    >
+      TG
+    </div>,
+    { ...size },
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,9 +14,27 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Truegrynd',
+  title: {
+    default: 'Truegrynd',
+    template: '%s · Truegrynd',
+  },
   description:
     'Async fitness competition. Standardized challenges, global leaderboard, free. Prove your effort.',
+  applicationName: 'Truegrynd',
+  metadataBase: new URL('https://truegrynd.app'),
+  openGraph: {
+    type: 'website',
+    title: 'Truegrynd',
+    description:
+      'Async fitness competition. Standardized challenges, global leaderboard, free. Prove your effort.',
+    siteName: 'Truegrynd',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Truegrynd',
+    description:
+      'Async fitness competition. Standardized challenges, global leaderboard, free. Prove your effort.',
+  },
 };
 
 export default async function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,13 @@ export const metadata: Metadata = {
   description:
     'Async fitness competition. Standardized challenges, global leaderboard, free. Prove your effort.',
   applicationName: 'Truegrynd',
-  metadataBase: new URL('https://truegrynd.app'),
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL
+      ? process.env.NEXT_PUBLIC_SITE_URL
+      : process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : 'http://localhost:3000',
+  ),
   openGraph: {
     type: 'website',
     title: 'Truegrynd',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,6 +28,22 @@
       "magicLinkRateLimited": "Too many attempts. Wait a few minutes, then try again.",
       "oauthFailed": "Sign-in failed. Try again.",
       "profileLoadFailed": "Signed in, but we could not load your profile."
+    },
+    "signInToContinue": "Sign in to continue."
+  },
+  "errors": {
+    "notFound": {
+      "label": "404",
+      "title": "Not found",
+      "body": "This page doesn’t exist. Go back to the Arena.",
+      "cta": "Back to overview"
+    },
+    "app": {
+      "label": "Error",
+      "title": "Something broke",
+      "body": "Try again. If it keeps happening, reload the page.",
+      "retry": "Retry",
+      "home": "Overview"
     }
   },
   "onboarding": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -28,6 +28,22 @@
       "magicLinkRateLimited": "Trop de tentatives. Attends quelques minutes puis réessaie.",
       "oauthFailed": "Connexion échouée. Réessaie.",
       "profileLoadFailed": "Connecté, mais impossible de charger ton profil."
+    },
+    "signInToContinue": "Connecte-toi pour continuer."
+  },
+  "errors": {
+    "notFound": {
+      "label": "404",
+      "title": "Introuvable",
+      "body": "Cette page n’existe pas. Retourne dans l’Arène.",
+      "cta": "Retour à l’aperçu"
+    },
+    "app": {
+      "label": "Erreur",
+      "title": "Ça a cassé",
+      "body": "Réessaie. Si ça continue, recharge la page.",
+      "retry": "Réessayer",
+      "home": "Aperçu"
     }
   },
   "onboarding": {


### PR DESCRIPTION
## Summary
- Adds global SEO metadata (Open Graph + Twitter) and app icons.
- Implements styled 404 (`not-found.tsx`) and app error boundary (`error.tsx`).
- Improves auth UX when redirecting with `?next=`.
- Updates `docs/issues/issues.md` progress for Issue #10.

## Remaining (Issue #28)
- [ ] Vercel deploy + env vars + domain (if needed)
- [ ] Session-expired/auth error copy audit
- [ ] Optional: locale-aware metadata

## Test plan
- [ ] Visit a bad URL under `/en/*` and confirm 404
- [ ] Hit a protected route while logged out and confirm auth shows “Sign in to continue”
- [ ] `pnpm typecheck && pnpm test:run && pnpm e2e`

Made with [Cursor](https://cursor.com)