### PR TITLE
feat(profile): Creator Score — reputation system (#46)

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -147,13 +147,13 @@ L’IA n’a pas besoin d’être “hors du repo” au sens code : le **code** 
 
 ## B. Creator Score — V1 forte (réputation créateur)
 
-- [ ] **Produit** : définition formelle du score (ex. +N par score **validé** sur un défi dont tu es **créateur** et `approved` ; plafond journalier anti-farming).
-- [ ] **DB** : utiliser `profiles.creator_score` existant ou migrer vers table `creator_stats` si historique/agrégats nécessaires.
-- [ ] **Trigger ou job** : incrément **côté serveur** (trigger on `scores` insert/update validated) — pas seulement client.
-- [ ] **RLS** : `creator_score` lecture publique OK ; **UPDATE** réservé trigger / `SECURITY DEFINER` — pas d’UPDATE client direct.
-- [ ] **UI profil** : affichage score + **tooltip / lien** “comment ça marche”.
-- [ ] **Badges** (optionnel V1) : seuils (bronze/argent/or) — sinon report V1.1 avec assets.
-- [ ] **i18n** + états loading/error sur bloc profil.
+- [x] **Produit** : +1 par score **validé** sur un défi dont tu es **créateur** et `approved` ; plafond **10/jour** anti-farming ; self-scores exclus.
+- [x] **DB** : utilise `profiles.creator_score` existant (migration `010`).
+- [x] **Trigger** : `increment_creator_score()` AFTER INSERT OR UPDATE on `scores` — SECURITY DEFINER, daily cap, self-score guard.
+- [x] **RLS** : `guard_server_managed_profile_fields()` BEFORE UPDATE sur `profiles` — revert client writes via GUC flag `app.server_managed_update`.
+- [x] **UI profil** : `CreatorScoreBadge` dans `ProfileHeader` — score + tier + tooltip explicatif.
+- [x] **Badges** : Bronze (≥5), Silver (≥25), Gold (≥100) — couleurs dans `CreatorScoreBadge`.
+- [x] **i18n** EN + FR (`profile.creatorScore.*`).
 
 ---
 
@@ -235,7 +235,7 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | Doc backlog V1 (ce fichier)              | 🟢 [#31](https://github.com/igorms-pro/truegrynd/issues/31) mergé — PR [#32](https://github.com/igorms-pro/truegrynd/pull/32) |
 | Doc tri IA + mouvements mix (ce fichier) | 🟢 [#35](https://github.com/igorms-pro/truegrynd/issues/35) mergé — PR [#36](https://github.com/igorms-pro/truegrynd/pull/36) |
 | **`/app/admin`**                         | 🔴 — suivre section **A**                                                                                                     |
-| Creator Score                            | 🔴 — section **B**                                                                                                            |
+| Creator Score                            | 🟡 [#46](https://github.com/igorms-pro/truegrynd/issues/46) — PR branch `feature/issue-46-creator-score`                      |
 | Streaks                                  | 🔴 — section **C**                                                                                                            |
 | Respect                                  | 🔴 — section **D**                                                                                                            |
 | Referral                                 | 🔴 — section **E**                                                                                                            |

--- a/src/features/profile/components/CreatorScoreBadge.tsx
+++ b/src/features/profile/components/CreatorScoreBadge.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import {
+  creatorTier,
+  nextTierThreshold,
+  type CreatorTier,
+} from '@/features/profile/lib/creatorBadge';
+
+const TIER_STYLES: Record<CreatorTier, string> = {
+  none: 'border-border bg-muted text-muted-foreground',
+  bronze: 'border-amber-700/40 bg-amber-900/15 text-amber-500',
+  silver: 'border-slate-400/40 bg-slate-500/15 text-slate-300',
+  gold: 'border-[var(--accent)]/40 bg-[var(--accent)]/15 text-[var(--accent)]',
+};
+
+type Props = {
+  score: number;
+};
+
+export function CreatorScoreBadge({ score }: Props) {
+  const t = useTranslations('profile.creatorScore');
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const tier = creatorTier(score);
+  const next = nextTierThreshold(score);
+  const tierLabel = tier === 'none' ? '' : ` · ${t(`tiers.${tier}`)}`;
+
+  const toggleTooltip = useCallback(() => {
+    setShowTooltip((prev) => !prev);
+  }, []);
+
+  const closeTooltip = useCallback(() => {
+    setShowTooltip(false);
+  }, []);
+
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={toggleTooltip}
+        onBlur={closeTooltip}
+        className={[
+          'inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] transition-colors',
+          TIER_STYLES[tier],
+        ].join(' ')}
+        aria-label={t('aria', { score })}
+      >
+        <span className="font-variant-numeric tabular-nums">{score}</span>
+        <span>
+          {t('label')}
+          {tierLabel}
+        </span>
+      </button>
+      {showTooltip ? (
+        <span
+          role="tooltip"
+          className="absolute top-full left-0 z-30 mt-2 w-56 rounded-sm border border-border bg-card p-3 text-[11px] leading-relaxed text-muted-foreground shadow-lg"
+        >
+          <span className="block font-black uppercase tracking-[0.14em] text-foreground">
+            {t('tooltipTitle')}
+          </span>
+          {t('tooltipBody')}
+          {next ? (
+            <span className="mt-1.5 block text-[10px]">{t('nextTier', { threshold: next })}</span>
+          ) : null}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
+import { CreatorScoreBadge } from '@/features/profile/components/CreatorScoreBadge';
 import { AVATAR_ACCEPT, useAvatarUpload } from '@/features/profile/hooks/useAvatarUpload';
 import { initialsFromUsername } from '@/features/profile/lib/initials';
 import type { Faction, Profile } from '@/lib/types/database.types';
@@ -127,6 +128,7 @@ export function ProfileHeader({ profile, onAvatarUpdated }: Props) {
               <span className="text-xs text-muted-foreground">
                 {t('streak', { days: profile.streak_days })}
               </span>
+              <CreatorScoreBadge score={profile.creator_score} />
             </div>
           </div>
 

--- a/src/features/profile/lib/creatorBadge.test.ts
+++ b/src/features/profile/lib/creatorBadge.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { creatorTier, nextTierThreshold } from '@/features/profile/lib/creatorBadge';
+
+describe('creatorTier', () => {
+  it('returns none for 0', () => expect(creatorTier(0)).toBe('none'));
+  it('returns none for 4', () => expect(creatorTier(4)).toBe('none'));
+  it('returns bronze for 5', () => expect(creatorTier(5)).toBe('bronze'));
+  it('returns bronze for 24', () => expect(creatorTier(24)).toBe('bronze'));
+  it('returns silver for 25', () => expect(creatorTier(25)).toBe('silver'));
+  it('returns silver for 99', () => expect(creatorTier(99)).toBe('silver'));
+  it('returns gold for 100', () => expect(creatorTier(100)).toBe('gold'));
+  it('returns gold for 999', () => expect(creatorTier(999)).toBe('gold'));
+});
+
+describe('nextTierThreshold', () => {
+  it('returns 5 for 0', () => expect(nextTierThreshold(0)).toBe(5));
+  it('returns 25 for 10', () => expect(nextTierThreshold(10)).toBe(25));
+  it('returns 100 for 50', () => expect(nextTierThreshold(50)).toBe(100));
+  it('returns null for 100+', () => expect(nextTierThreshold(150)).toBeNull());
+});

--- a/src/features/profile/lib/creatorBadge.ts
+++ b/src/features/profile/lib/creatorBadge.ts
@@ -1,0 +1,21 @@
+export type CreatorTier = 'none' | 'bronze' | 'silver' | 'gold';
+
+const THRESHOLDS: { tier: CreatorTier; min: number }[] = [
+  { tier: 'gold', min: 100 },
+  { tier: 'silver', min: 25 },
+  { tier: 'bronze', min: 5 },
+];
+
+export function creatorTier(score: number): CreatorTier {
+  for (const { tier, min } of THRESHOLDS) {
+    if (score >= min) return tier;
+  }
+  return 'none';
+}
+
+export function nextTierThreshold(score: number): number | null {
+  if (score >= 100) return null;
+  if (score >= 25) return 100;
+  if (score >= 5) return 25;
+  return 5;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -465,6 +465,18 @@
       "viewChallenge": "CHALLENGE",
       "viewCard": "CARD"
     },
+    "creatorScore": {
+      "label": "CR",
+      "aria": "Creator score: {score}",
+      "tooltipTitle": "CREATOR SCORE",
+      "tooltipBody": "You earn +1 every time someone submits a validated score on a challenge you created. Max 10 per day.",
+      "nextTier": "Next tier at {threshold}.",
+      "tiers": {
+        "bronze": "BRONZE",
+        "silver": "SILVER",
+        "gold": "GOLD"
+      }
+    },
     "header": {
       "unknownUser": "UNKNOWN",
       "avatarAlt": "Profile avatar",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -465,6 +465,18 @@
       "viewChallenge": "DÉFI",
       "viewCard": "CARD"
     },
+    "creatorScore": {
+      "label": "CR",
+      "aria": "Score créateur : {score}",
+      "tooltipTitle": "SCORE CRÉATEUR",
+      "tooltipBody": "Tu gagnes +1 chaque fois qu'un score validé est soumis sur un défi que tu as créé. Max 10 par jour.",
+      "nextTier": "Prochain palier à {threshold}.",
+      "tiers": {
+        "bronze": "BRONZE",
+        "silver": "ARGENT",
+        "gold": "OR"
+      }
+    },
     "header": {
       "unknownUser": "INCONNU",
       "avatarAlt": "Avatar du profil",

--- a/supabase/migrations/010_creator_score_trigger.sql
+++ b/supabase/migrations/010_creator_score_trigger.sql
@@ -1,0 +1,90 @@
+-- Creator Score: auto-increment when a validated score is submitted on a challenge
+-- owned by another user. +1 per validated score, daily cap of 10 per creator.
+-- Self-scores do not count. Only approved challenges qualify.
+
+-- Guard: silently revert client-side writes to server-managed fields on profiles.
+-- Uses a transaction-local GUC flag so that SECURITY DEFINER triggers can bypass.
+CREATE OR REPLACE FUNCTION public.guard_server_managed_profile_fields()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF current_setting('app.server_managed_update', true) IS DISTINCT FROM 'true' THEN
+    NEW.creator_score := OLD.creator_score;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.guard_server_managed_profile_fields IS
+  'Prevents client-side mutation of creator_score. Server triggers set app.server_managed_update=true to bypass.';
+
+CREATE TRIGGER guard_profile_server_fields
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.guard_server_managed_profile_fields();
+
+-- Increment trigger on scores table
+CREATE OR REPLACE FUNCTION public.increment_creator_score()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_creator_id UUID;
+  v_daily_count INT;
+  v_daily_cap CONSTANT INT := 10;
+BEGIN
+  IF NOT NEW.is_validated THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.is_validated THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT creator_id INTO v_creator_id
+  FROM public.challenges
+  WHERE id = NEW.challenge_id
+    AND status = 'approved'
+    AND creator_id IS NOT NULL;
+
+  IF v_creator_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_creator_id = NEW.user_id THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT COUNT(*) INTO v_daily_count
+  FROM public.scores s
+  JOIN public.challenges c ON c.id = s.challenge_id
+  WHERE c.creator_id = v_creator_id
+    AND s.is_validated = true
+    AND s.user_id != v_creator_id
+    AND s.submitted_at::date = CURRENT_DATE
+    AND s.id != NEW.id;
+
+  IF v_daily_count >= v_daily_cap THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM set_config('app.server_managed_update', 'true', true);
+
+  UPDATE public.profiles
+  SET creator_score = creator_score + 1
+  WHERE id = v_creator_id;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.increment_creator_score IS
+  'Auto-increment creator_score when someone submits a validated score on an approved challenge. Daily cap: 10. Self-scores excluded.';
+
+CREATE TRIGGER on_score_increment_creator
+  AFTER INSERT OR UPDATE ON public.scores
+  FOR EACH ROW
+  EXECUTE FUNCTION public.increment_creator_score();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Creator Score reputation system — Section B from `docs/issues/issues.md`. Closes #46.

### What's included

**Database (migration `010_creator_score_trigger.sql`)**
- `increment_creator_score()` — AFTER INSERT OR UPDATE trigger on `scores`
  - +1 to challenge creator's `profiles.creator_score` when a validated score is submitted
  - Daily cap: 10 points per creator per day (anti-farming)
  - Self-scores excluded (submitting on your own challenge doesn't count)
  - Only approved challenges qualify
  - SECURITY DEFINER for safe cross-table update
- `guard_server_managed_profile_fields()` — BEFORE UPDATE trigger on `profiles`
  - Silently reverts client-side writes to `creator_score`
  - Uses transaction-local GUC flag `app.server_managed_update` so the increment trigger can bypass

**UI (`src/features/profile/components/CreatorScoreBadge.tsx`)**
- Score display with tier badge: Bronze (≥5), Silver (≥25), Gold (≥100)
- Tooltip on click explaining how the score works + next tier threshold
- Tier-colored styling (amber/slate/gold)
- Integrated into `ProfileHeader` next to streak badge

**Logic (`src/features/profile/lib/creatorBadge.ts`)**
- `creatorTier(score)` — returns `none | bronze | silver | gold`
- `nextTierThreshold(score)` — returns the next tier boundary or null

**i18n** — EN + FR (`profile.creatorScore.*`): label, tooltip, tier names

### Checks

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test:run` — 18 files, 90 tests passing (12 new for creator badge)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

