### PR TITLE
feat(leaderboard): Respect button — score likes (#50)

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -171,11 +171,11 @@ L’IA n’a pas besoin d’être “hors du repo” au sens code : le **code** 
 
 ## D. Respect (leaderboard) — V1 forte
 
-- [ ] **DB** : table **`score_respects`** (migration `004_score_respects.sql` — **auditer** schéma + RLS actuels ; aligner produit : une ligne par `(user_id, score_id)`, pas de self-respect côté app + optionnel contrainte DB).
-- [ ] **RLS** : insert seulement si auth ; pas de spam (unique constraint + erreur UX).
-- [ ] **UI** : bouton sur ligne leaderboard — états default / loading / disabled / “déjà respecté” ; **pas** de compteur public toxique sans réflexion (définir affichage).
-- [ ] **Anti-gaming** : pas de self-respect ; optionnel cooldown.
-- [ ] **i18n** + a11y bouton.
+- [x] **DB** : table `score_respects` déjà en place (migration `004`) — schéma + RLS audités, UNIQUE constraint `(score_id, user_id)`.
+- [x] **RLS** : INSERT auth only, DELETE own only, SELECT all — spam bloqué par UNIQUE constraint.
+- [x] **UI** : `RespectButton` sur chaque ligne leaderboard — états default / loading / disabled / respected ; compteur discret.
+- [x] **Anti-gaming** : self-respect masqué (bouton hidden si `scoreUserId === currentUserId`) + UNIQUE DB constraint.
+- [x] **i18n** EN + FR + `aria-label` (`leaderboard.respect.*`).
 
 ---
 
@@ -237,7 +237,7 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | **`/app/admin`**                         | 🔴 — suivre section **A**                                                                                                     |
 | Creator Score                            | 🟡 [#46](https://github.com/igorms-pro/truegrynd/issues/46) — PR branch `feature/issue-46-creator-score`                      |
 | Streaks                                  | 🟡 [#48](https://github.com/igorms-pro/truegrynd/issues/48) — PR branch `feature/issue-48-streaks`                            |
-| Respect                                  | 🔴 — section **D**                                                                                                            |
+| Respect                                  | 🟡 [#50](https://github.com/igorms-pro/truegrynd/issues/50) — PR branch `feature/issue-50-respect`                            |
 | Referral                                 | 🔴 — section **E**                                                                                                            |
 | Confiance / plateforme                   | 🔴 — section **F**                                                                                                            |
 | Mouvements / prescription (mix)          | 🟡 [#44](https://github.com/igorms-pro/truegrynd/issues/44) — PR branch `feature/issue-44-movement-catalog`                   |

--- a/src/features/challenges/components/Leaderboard.tsx
+++ b/src/features/challenges/components/Leaderboard.tsx
@@ -4,15 +4,18 @@ import { useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { LeaderboardFiltersBar } from '@/features/challenges/components/LeaderboardFilters';
+import { RespectButton } from '@/features/challenges/components/RespectButton';
+import { useChallengeLeaderboard } from '@/features/challenges/hooks/useChallengeLeaderboard';
+import { useScoreRespects } from '@/features/challenges/hooks/useScoreRespects';
 import { applyLeaderboardFilters } from '@/features/challenges/lib/applyFilters';
-import { formatScore } from '@/features/challenges/lib/scoreFormat';
 import { sortScoresByType } from '@/features/challenges/lib/leaderboardSort';
+import { formatScore } from '@/features/challenges/lib/scoreFormat';
 import {
   EMPTY_FILTERS,
   type LeaderboardEntry,
   type LeaderboardFilters,
 } from '@/features/challenges/lib/types';
-import { useChallengeLeaderboard } from '@/features/challenges/hooks/useChallengeLeaderboard';
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import type { ScoreType } from '@/lib/types/database.types';
 
 type Props = {
@@ -24,25 +27,45 @@ function LeaderboardRow({
   rank,
   entry,
   scoreType,
+  currentUserId,
+  respectCount,
+  isRespected,
+  respectDisabled,
+  onRespectToggle,
 }: {
   rank: number;
   entry: LeaderboardEntry;
   scoreType: ScoreType;
+  currentUserId: string | null;
+  respectCount: number;
+  isRespected: boolean;
+  respectDisabled: boolean;
+  onRespectToggle: (scoreId: string) => Promise<void>;
 }) {
   const username = entry.profile?.username ?? '—';
   return (
-    <li className="grid grid-cols-[3rem_1fr_auto] items-center gap-3 border-b border-border px-3 py-2 last:border-b-0">
+    <li className="grid grid-cols-[3rem_1fr_auto_auto] items-center gap-3 border-b border-border px-3 py-2 last:border-b-0">
       <span className="font-mono text-sm tabular-nums text-muted-foreground">#{rank}</span>
       <span className="truncate text-sm font-bold text-foreground">{username}</span>
       <span className="font-mono text-sm tabular-nums text-foreground">
         {formatScore(entry.value, scoreType)}
       </span>
+      <RespectButton
+        scoreId={entry.id}
+        scoreUserId={entry.user_id}
+        currentUserId={currentUserId}
+        count={respectCount}
+        respected={isRespected}
+        disabled={respectDisabled}
+        onToggle={onRespectToggle}
+      />
     </li>
   );
 }
 
 export function Leaderboard({ challengeId, scoreType }: Props) {
   const t = useTranslations('leaderboard');
+  const profile = useOptionalAppProfile();
   const { data, loading, error, refetch } = useChallengeLeaderboard({
     challengeId,
     scoreType,
@@ -53,6 +76,14 @@ export function Leaderboard({ challengeId, scoreType }: Props) {
     () => sortScoresByType(applyLeaderboardFilters(data, filters), scoreType),
     [data, filters, scoreType],
   );
+
+  const scoreIds = useMemo(() => sorted.map((e) => e.id), [sorted]);
+  const {
+    counts,
+    respected,
+    loading: respectLoading,
+    toggle,
+  } = useScoreRespects(scoreIds, profile?.id ?? null);
 
   return (
     <section className="space-y-3">
@@ -92,7 +123,17 @@ export function Leaderboard({ challengeId, scoreType }: Props) {
       {!loading && !error && sorted.length > 0 ? (
         <ol className="overflow-hidden rounded-md border border-border bg-card">
           {sorted.map((entry, index) => (
-            <LeaderboardRow key={entry.id} rank={index + 1} entry={entry} scoreType={scoreType} />
+            <LeaderboardRow
+              key={entry.id}
+              rank={index + 1}
+              entry={entry}
+              scoreType={scoreType}
+              currentUserId={profile?.id ?? null}
+              respectCount={counts.get(entry.id) ?? 0}
+              isRespected={respected.has(entry.id)}
+              respectDisabled={respectLoading}
+              onRespectToggle={toggle}
+            />
           ))}
         </ol>
       ) : null}

--- a/src/features/challenges/components/RespectButton.tsx
+++ b/src/features/challenges/components/RespectButton.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+
+type Props = {
+  scoreId: string;
+  /** ID of the score owner — if same as current user, button is hidden. */
+  scoreUserId: string;
+  currentUserId: string | null;
+  count: number;
+  respected: boolean;
+  disabled: boolean;
+  onToggle: (scoreId: string) => Promise<void>;
+};
+
+export function RespectButton({
+  scoreId,
+  scoreUserId,
+  currentUserId,
+  count,
+  respected,
+  disabled,
+  onToggle,
+}: Props) {
+  const t = useTranslations('leaderboard.respect');
+
+  const handleClick = useCallback(() => {
+    void onToggle(scoreId);
+  }, [onToggle, scoreId]);
+
+  if (currentUserId && currentUserId === scoreUserId) {
+    return null;
+  }
+
+  const label = respected ? t('undo') : t('give');
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled || !currentUserId}
+      aria-label={t('aria', { count })}
+      className={[
+        'inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] font-black uppercase tracking-wider transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-40',
+        respected
+          ? 'border-primary/40 bg-primary/15 text-primary'
+          : 'border-border bg-background text-muted-foreground hover:text-foreground hover:border-primary/30',
+      ].join(' ')}
+    >
+      <span aria-hidden>👊</span>
+      <span className="tabular-nums">{count > 0 ? count : ''}</span>
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+}

--- a/src/features/challenges/hooks/useScoreRespects.ts
+++ b/src/features/challenges/hooks/useScoreRespects.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  addRespect,
+  getRespectCounts,
+  getUserRespectedScoreIds,
+  removeRespect,
+} from '@/features/challenges/services/respects';
+
+type State = {
+  counts: Map<string, number>;
+  respected: Set<string>;
+  loading: boolean;
+};
+
+export function useScoreRespects(
+  scoreIds: string[],
+  userId: string | null,
+): {
+  counts: Map<string, number>;
+  respected: Set<string>;
+  loading: boolean;
+  toggle: (scoreId: string) => Promise<void>;
+} {
+  const [state, setState] = useState<State>({
+    counts: new Map(),
+    respected: new Set(),
+    loading: true,
+  });
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (scoreIds.length === 0) {
+      setState({ counts: new Map(), respected: new Set(), loading: false });
+      return;
+    }
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const [counts, respected] = await Promise.all([
+          getRespectCounts(scoreIds),
+          userId ? getUserRespectedScoreIds(userId, scoreIds) : Promise.resolve(new Set<string>()),
+        ]);
+        if (!cancelled) {
+          setState({ counts, respected, loading: false });
+        }
+      } catch {
+        if (!cancelled) {
+          setState((prev) => ({ ...prev, loading: false }));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scoreIds.join(','), userId]);
+
+  const toggle = useCallback(
+    async (scoreId: string) => {
+      if (!userId || busyId) return;
+      setBusyId(scoreId);
+
+      const wasRespected = state.respected.has(scoreId);
+
+      setState((prev) => {
+        const nextRespected = new Set(prev.respected);
+        const nextCounts = new Map(prev.counts);
+        const current = nextCounts.get(scoreId) ?? 0;
+
+        if (wasRespected) {
+          nextRespected.delete(scoreId);
+          nextCounts.set(scoreId, Math.max(0, current - 1));
+        } else {
+          nextRespected.add(scoreId);
+          nextCounts.set(scoreId, current + 1);
+        }
+
+        return { ...prev, counts: nextCounts, respected: nextRespected };
+      });
+
+      try {
+        if (wasRespected) {
+          await removeRespect(scoreId, userId);
+        } else {
+          await addRespect(scoreId, userId);
+        }
+      } catch {
+        setState((prev) => {
+          const nextRespected = new Set(prev.respected);
+          const nextCounts = new Map(prev.counts);
+          const current = nextCounts.get(scoreId) ?? 0;
+
+          if (wasRespected) {
+            nextRespected.add(scoreId);
+            nextCounts.set(scoreId, current + 1);
+          } else {
+            nextRespected.delete(scoreId);
+            nextCounts.set(scoreId, Math.max(0, current - 1));
+          }
+
+          return { ...prev, counts: nextCounts, respected: nextRespected };
+        });
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [busyId, state.respected, userId],
+  );
+
+  return {
+    counts: state.counts,
+    respected: state.respected,
+    loading: state.loading,
+    toggle,
+  };
+}

--- a/src/features/challenges/services/respects.ts
+++ b/src/features/challenges/services/respects.ts
@@ -1,0 +1,56 @@
+import { supabase } from '@/lib/supabase';
+
+export type RespectCount = {
+  scoreId: string;
+  count: number;
+};
+
+export async function getRespectCounts(scoreIds: string[]): Promise<Map<string, number>> {
+  if (scoreIds.length === 0) return new Map();
+
+  const { data, error } = await supabase
+    .from('score_respects')
+    .select('score_id')
+    .in('score_id', scoreIds);
+
+  if (error) throw new Error(error.message);
+
+  const counts = new Map<string, number>();
+  for (const row of data ?? []) {
+    const sid = row.score_id as string;
+    counts.set(sid, (counts.get(sid) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export async function getUserRespectedScoreIds(
+  userId: string,
+  scoreIds: string[],
+): Promise<Set<string>> {
+  if (scoreIds.length === 0) return new Set();
+
+  const { data, error } = await supabase
+    .from('score_respects')
+    .select('score_id')
+    .eq('user_id', userId)
+    .in('score_id', scoreIds);
+
+  if (error) throw new Error(error.message);
+  return new Set((data ?? []).map((r) => r.score_id as string));
+}
+
+export async function addRespect(scoreId: string, userId: string): Promise<void> {
+  const { error } = await supabase
+    .from('score_respects')
+    .insert({ score_id: scoreId, user_id: userId });
+  if (error) throw new Error(error.message);
+}
+
+export async function removeRespect(scoreId: string, userId: string): Promise<void> {
+  const { error } = await supabase
+    .from('score_respects')
+    .delete()
+    .eq('score_id', scoreId)
+    .eq('user_id', userId);
+  if (error) throw new Error(error.message);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -372,6 +372,11 @@
     "columnRank": "RANK",
     "columnUser": "USER",
     "columnScore": "SCORE",
+    "respect": {
+      "give": "Respect",
+      "undo": "Undo respect",
+      "aria": "Respect this score ({count})"
+    },
     "filters": {
       "title": "Filters",
       "all": "All",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -372,6 +372,11 @@
     "columnRank": "RANG",
     "columnUser": "JOUEUR",
     "columnScore": "SCORE",
+    "respect": {
+      "give": "Respect",
+      "undo": "Retirer le respect",
+      "aria": "Respecter ce score ({count})"
+    },
     "filters": {
       "title": "Filtres",
       "all": "Tous",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Respect (like) button on leaderboard scores — Section D from `docs/issues/issues.md`. Closes #50.

### What's included

- `RespectButton` — toggle button with optimistic UI, hidden for self-scores, a11y labels
- `useScoreRespects` hook — batch-fetch counts + user respects, optimistic toggle with error rollback
- Service layer: `getRespectCounts`, `getUserRespectedScoreIds`, `addRespect`, `removeRespect`
- Integrated into `Leaderboard` rows (4-column grid: rank, user, score, respect)
- Anti-gaming: self-respect button hidden + UNIQUE DB constraint
- i18n EN + FR (`leaderboard.respect.*`)

### DB

Uses existing `score_respects` table from migration `004` — no new migration needed. Schema + RLS audited: INSERT auth only, DELETE own only, SELECT all, UNIQUE `(score_id, user_id)`.

### Checks

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test:run` — 19 files, 96 tests passing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

