### PR TITLE
feat(referral): faction recruitment links (#52)

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -181,11 +181,12 @@ L’IA n’a pas besoin d’être “hors du repo” au sens code : le **code** 
 
 ## E. Referral — V1 forte
 
-- [ ] **Lien signé ou paramètres** : `?faction=horde` + **validation** côté onboarding (rejet si valeur invalide).
-- [ ] **Persistance** : cookie / localStorage limité + sync au signup — documenter durée TTL.
-- [ ] **Analytics** (optionnel) : event “landing referral” sans PII invasive.
-- [ ] **UI Clan / Overview** : CTA “Recruter un allié” + partage natif / copie lien.
-- [ ] **Pas de multi-niveaux MLM** en V1 sauf décision explicite.
+- [x] **Lien** : `?faction=horde` + `parseReferralFaction()` validation (rejet si valeur invalide).
+- [x] **Persistance** : `localStorage` + TTL 7 jours — `storeReferralFaction` / `loadReferralFaction` / `clearReferralFaction`.
+- [ ] **Analytics** (optionnel) : event “landing referral” sans PII invasive — reporté V1.1.
+- [x] **UI Clan** : `RecruitCta` — boutons Share (Web Share API) + Copy link, dans `ClanScreen`.
+- [x] **Onboarding** : `OnboardingFlow` lit `?faction` ou localStorage et pré-sélectionne la faction ; `clearReferralFaction` après choix.
+- [x] **Pas de MLM** : lien plat, pas de tracking multi-niveaux.
 
 ---
 
@@ -238,7 +239,7 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | Creator Score                            | 🟡 [#46](https://github.com/igorms-pro/truegrynd/issues/46) — PR branch `feature/issue-46-creator-score`                      |
 | Streaks                                  | 🟡 [#48](https://github.com/igorms-pro/truegrynd/issues/48) — PR branch `feature/issue-48-streaks`                            |
 | Respect                                  | 🟡 [#50](https://github.com/igorms-pro/truegrynd/issues/50) — PR branch `feature/issue-50-respect`                            |
-| Referral                                 | 🔴 — section **E**                                                                                                            |
+| Referral                                 | 🟡 [#52](https://github.com/igorms-pro/truegrynd/issues/52) — PR branch `feature/issue-52-referral`                           |
 | Confiance / plateforme                   | 🔴 — section **F**                                                                                                            |
 | Mouvements / prescription (mix)          | 🟡 [#44](https://github.com/igorms-pro/truegrynd/issues/44) — PR branch `feature/issue-44-movement-catalog`                   |
 

--- a/src/features/factions/components/ClanScreen.tsx
+++ b/src/features/factions/components/ClanScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 
+import { RecruitCta } from '@/features/factions/components/RecruitCta';
 import { useClanHud } from '@/features/factions/hooks/useClanHud';
 
 function formatPoints(points: number): string {
@@ -42,6 +43,13 @@ export function ClanScreen() {
             {t('retry')}
           </button>
         </div>
+      ) : null}
+
+      {state.status === 'ready' && state.faction ? (
+        <RecruitCta
+          faction={state.faction}
+          siteUrl={process.env.NEXT_PUBLIC_SITE_URL ?? 'https://truegrynd.app'}
+        />
       ) : null}
 
       {state.status === 'ready' ? (

--- a/src/features/factions/components/RecruitCta.tsx
+++ b/src/features/factions/components/RecruitCta.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { buildReferralUrl } from '@/features/factions/lib/referral';
+import type { Faction } from '@/lib/types/database.types';
+
+type Props = {
+  faction: Faction;
+  siteUrl: string;
+};
+
+export function RecruitCta({ faction, siteUrl }: Props) {
+  const t = useTranslations('clan.recruit');
+  const [copied, setCopied] = useState(false);
+
+  const referralUrl = buildReferralUrl(siteUrl, faction);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(referralUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard not available */
+    }
+  }, [referralUrl]);
+
+  const handleShare = useCallback(async () => {
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share({
+          title: t('shareTitle'),
+          text: t('shareText'),
+          url: referralUrl,
+        });
+      } catch {
+        /* user cancelled or not supported */
+      }
+    } else {
+      await handleCopy();
+    }
+  }, [handleCopy, referralUrl, t]);
+
+  return (
+    <article className="rounded-md border border-border bg-card p-4">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('title')}
+      </p>
+      <p className="mt-2 text-sm text-muted-foreground">{t('body')}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => void handleShare()}
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('share')}
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleCopy()}
+          className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {copied ? t('copied') : t('copy')}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/features/factions/lib/referral.test.ts
+++ b/src/features/factions/lib/referral.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildReferralUrl, parseReferralFaction } from '@/features/factions/lib/referral';
+
+describe('parseReferralFaction', () => {
+  it('returns valid factions', () => {
+    expect(parseReferralFaction('nomads')).toBe('nomads');
+    expect(parseReferralFaction('horde')).toBe('horde');
+    expect(parseReferralFaction('iron_alliance')).toBe('iron_alliance');
+  });
+
+  it('rejects invalid values', () => {
+    expect(parseReferralFaction(null)).toBeNull();
+    expect(parseReferralFaction('')).toBeNull();
+    expect(parseReferralFaction('avengers')).toBeNull();
+  });
+});
+
+describe('buildReferralUrl', () => {
+  it('appends faction param', () => {
+    const url = buildReferralUrl('https://truegrynd.app', 'horde');
+    expect(url).toBe('https://truegrynd.app/?faction=horde');
+  });
+
+  it('preserves existing params', () => {
+    const url = buildReferralUrl('https://truegrynd.app?x=1', 'nomads');
+    expect(url).toContain('x=1');
+    expect(url).toContain('faction=nomads');
+  });
+});

--- a/src/features/factions/lib/referral.ts
+++ b/src/features/factions/lib/referral.ts
@@ -1,0 +1,55 @@
+import type { Faction } from '@/lib/types/database.types';
+
+const STORAGE_KEY = 'tg_referral_faction';
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const VALID_FACTIONS: ReadonlySet<string> = new Set<string>(['nomads', 'horde', 'iron_alliance']);
+
+type StoredReferral = {
+  faction: Faction;
+  expiresAt: number;
+};
+
+export function parseReferralFaction(value: string | null): Faction | null {
+  if (!value || !VALID_FACTIONS.has(value)) return null;
+  return value as Faction;
+}
+
+export function storeReferralFaction(faction: Faction): void {
+  try {
+    const entry: StoredReferral = { faction, expiresAt: Date.now() + TTL_MS };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+  } catch {
+    /* quota or private mode — ignore */
+  }
+}
+
+export function loadReferralFaction(): Faction | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as StoredReferral;
+    if (!entry.faction || !VALID_FACTIONS.has(entry.faction)) return null;
+    if (Date.now() > entry.expiresAt) {
+      localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return entry.faction;
+  } catch {
+    return null;
+  }
+}
+
+export function clearReferralFaction(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function buildReferralUrl(baseUrl: string, faction: Faction): string {
+  const url = new URL(baseUrl);
+  url.searchParams.set('faction', faction);
+  return url.toString();
+}

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -5,6 +5,12 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, type ReactNode } from 'react';
 
 import { useRequireAuth } from '@/features/auth/hooks/useRequireAuth';
+import {
+  clearReferralFaction,
+  loadReferralFaction,
+  parseReferralFaction,
+  storeReferralFaction,
+} from '@/features/factions/lib/referral';
 import { useOnboardingProfile } from '@/features/onboarding/hooks/useOnboardingProfile';
 import type { OnboardingStep } from '@/features/onboarding/lib/onboardingStep';
 import { OnboardingIdentityStep } from '@/features/onboarding/components/OnboardingIdentityStep';
@@ -37,6 +43,15 @@ export function OnboardingFlow() {
     const safeNext = normalizeNextPath(searchParams.get('next'));
     return safeNext ?? `/${locale}/app/overview`;
   }, [locale, searchParams]);
+
+  const referralFaction = useMemo(() => {
+    const fromUrl = parseReferralFaction(searchParams.get('faction'));
+    if (fromUrl) {
+      storeReferralFaction(fromUrl);
+      return fromUrl;
+    }
+    return loadReferralFaction();
+  }, [searchParams]);
 
   useEffect(() => {
     if (!initialized || loading) return;
@@ -110,9 +125,10 @@ export function OnboardingFlow() {
     content = (
       <OnboardingFactionStep
         userId={profile.id}
-        initialFaction={profile.faction}
+        initialFaction={profile.faction ?? referralFaction}
         onBack={handleBack}
         onCompleted={async () => {
+          clearReferralFaction();
           await reload();
         }}
       />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -174,6 +174,15 @@
       "nomads": "NOMADS",
       "horde": "HORDE",
       "iron_alliance": "IRON ALLIANCE"
+    },
+    "recruit": {
+      "title": "RECRUIT AN ALLY",
+      "body": "Send this link to bring someone directly into your faction.",
+      "share": "SHARE",
+      "copy": "COPY LINK",
+      "copied": "COPIED!",
+      "shareTitle": "Truegrynd — Join my faction",
+      "shareText": "Join my faction on Truegrynd and compete together."
     }
   },
   "arena": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -174,6 +174,15 @@
       "nomads": "NOMADES",
       "horde": "HORDE",
       "iron_alliance": "ALLIANCE DE FER"
+    },
+    "recruit": {
+      "title": "RECRUTER UN ALLIÉ",
+      "body": "Envoie ce lien pour amener quelqu'un directement dans ta faction.",
+      "share": "PARTAGER",
+      "copy": "COPIER LE LIEN",
+      "copied": "COPIÉ !",
+      "shareTitle": "Truegrynd — Rejoins ma faction",
+      "shareText": "Rejoins ma faction sur Truegrynd et compétis ensemble."
     }
   },
   "arena": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Faction referral links — Section E from `docs/issues/issues.md`. Closes #52.

### What's included

- **Referral lib**: `parseReferralFaction`, `storeReferralFaction`, `loadReferralFaction`, `clearReferralFaction`, `buildReferralUrl`
- **Persistence**: `localStorage` with 7-day TTL
- **RecruitCta** component in `ClanScreen`: Share (Web Share API fallback to copy) + Copy link buttons
- **Onboarding integration**: `OnboardingFlow` reads `?faction` URL param or localStorage, pre-selects faction, clears after completion
- **i18n** EN + FR (`clan.recruit.*`)
- **Tests**: 4 unit tests (parse validation + URL building)

### Checks

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test:run` — 20 files, 100 tests passing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

