### PR TITLE
feat(platform): reports table, SEO metadata, runbook (#54)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,76 @@
+# Truegrynd — Runbook
+
+Internal operations reference for Supabase + Vercel.
+
+---
+
+## Promote a user to admin
+
+Run in **Supabase SQL Editor** (Dashboard → SQL Editor):
+
+```sql
+UPDATE public.profiles SET is_admin = true WHERE id = '<user-uuid-from-auth.users>';
+```
+
+Verify:
+
+```sql
+SELECT id, username, is_admin FROM public.profiles WHERE is_admin = true;
+```
+
+---
+
+## Rollback a migration
+
+Supabase migrations are forward-only. To "undo" a migration:
+
+1. Write a new migration that reverses the changes (e.g. `DROP TABLE`, `DROP FUNCTION`, `ALTER TABLE DROP COLUMN`).
+2. Name it `NNN_rollback_<original>.sql`.
+3. Test locally with `supabase db reset` before applying to production.
+
+**Never** delete a migration file that has been applied to production.
+
+---
+
+## RLS review checklist
+
+When adding or modifying RLS policies:
+
+- [ ] Every table has `ENABLE ROW LEVEL SECURITY`
+- [ ] No table is missing policies (default-deny when RLS is enabled)
+- [ ] SELECT policies don't leak private data (e.g. other users' emails, rejected challenges to non-creators)
+- [ ] INSERT policies check `auth.uid() = <owner_column>`
+- [ ] UPDATE policies use both USING and WITH CHECK
+- [ ] SECURITY DEFINER functions have `SET search_path = public`
+- [ ] No `service_role` key in client-side code
+- [ ] Test: unauthenticated user gets denied
+- [ ] Test: non-admin user cannot run admin RPCs
+
+---
+
+## Rate limiting (approach)
+
+V1 relies on Supabase built-in rate limits + UNIQUE constraints:
+
+| Action             | Protection                                                                                   |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| Score submission   | No duplicate `(challenge_id, user_id)` abuse — app allows multiple but DB/client can enforce |
+| Challenge creation | Auth required; admin review gate prevents spam from reaching users                           |
+| Respect            | UNIQUE `(score_id, user_id)` constraint                                                      |
+| Reports            | UNIQUE `(target_type, target_id, reporter_id)` constraint                                    |
+| Admin RPC          | `is_app_admin()` gate                                                                        |
+| Creator score      | Daily cap of 10 in trigger                                                                   |
+
+For V1.1+: consider Supabase Edge Functions with `x-ratelimit` headers or a Redis-based sliding window.
+
+---
+
+## Environment variables
+
+| Variable                        | Where                          | Purpose                                       |
+| ------------------------------- | ------------------------------ | --------------------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Client + Server                | Supabase project URL                          |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Client + Server                | Supabase anon key (RLS enforced)              |
+| `NEXT_PUBLIC_SITE_URL`          | Client + Server                | Canonical site URL for OG/meta                |
+| `SUPABASE_SERVICE_ROLE_KEY`     | Server only                    | Admin operations — **never** expose to client |
+| `OPENAI_API_KEY`                | Supabase Edge Function secrets | AI triage (admin-challenge-ai-review)         |

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -192,11 +192,11 @@ L’IA n’a pas besoin d’être “hors du repo” au sens code : le **code** 
 
 ## F. Confiance & plateforme — V1 forte
 
-- [ ] **Signalement** : table `reports` (target_type, target_id, reporter_id, reason, created_at) + RLS + file admin ou même RPC admin phase 2.
-- [ ] **SEO i18n** : meta `title` / `description` par locale sur landing + routes clés.
-- [ ] **Observabilité** : Sentry (ou équivalent) — erreurs client + contexte anonyme ; pas de tokens en logs.
-- [ ] **Rate limiting** : création défis / soumissions / RPC admin — policy Supabase ou Edge Function si abus.
-- [ ] **Runbook** : doc interne courte “promouvoir admin”, “rollback migration”, “revue RLS”.
+- [x] **Signalement** : table `reports` (migration `012`) + RLS (insert own, read own, admin read all) + UNIQUE constraint.
+- [x] **SEO i18n** : `generateMetadata` dans `[locale]/layout.tsx` — title/description par locale via `next-intl`.
+- [ ] **Observabilité** : Sentry — reporté V1.1 (config externe, hors repo).
+- [x] **Rate limiting** : documenté dans `docs/RUNBOOK.md` — V1 via UNIQUE constraints + admin gates ; V1.1 Edge Function.
+- [x] **Runbook** : `docs/RUNBOOK.md` — promouvoir admin, rollback migration, revue RLS, rate limiting, env vars.
 
 ---
 
@@ -240,7 +240,7 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | Streaks                                  | 🟡 [#48](https://github.com/igorms-pro/truegrynd/issues/48) — PR branch `feature/issue-48-streaks`                            |
 | Respect                                  | 🟡 [#50](https://github.com/igorms-pro/truegrynd/issues/50) — PR branch `feature/issue-50-respect`                            |
 | Referral                                 | 🟡 [#52](https://github.com/igorms-pro/truegrynd/issues/52) — PR branch `feature/issue-52-referral`                           |
-| Confiance / plateforme                   | 🔴 — section **F**                                                                                                            |
+| Confiance / plateforme                   | 🟡 [#54](https://github.com/igorms-pro/truegrynd/issues/54) — PR branch `feature/issue-54-trust-platform`                     |
 | Mouvements / prescription (mix)          | 🟡 [#44](https://github.com/igorms-pro/truegrynd/issues/44) — PR branch `feature/issue-44-movement-catalog`                   |
 
 **Ordre d’attaque recommandé :** **A** (admin, puis **A9–A10** une fois la base admin + RPC OK) → **G** (standardisation création, en parallèle possible) → **B** → **C** / **D** → **E** → **F** continu.

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,23 @@
+import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
-import { getMessages } from 'next-intl/server';
+import { getMessages, getTranslations } from 'next-intl/server';
 import { AuthProvider } from '@/features/auth/AuthProvider';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'common' });
+  return {
+    title: {
+      default: t('appName'),
+      template: `%s · ${t('appName')}`,
+    },
+    description: t('tagline'),
+  };
+}
 
 export default async function LocaleLayout({
   children,

--- a/src/features/challenges/services/reports.ts
+++ b/src/features/challenges/services/reports.ts
@@ -1,0 +1,24 @@
+import { supabase } from '@/lib/supabase';
+
+export type ReportTargetType = 'score' | 'challenge' | 'profile';
+
+export async function submitReport(input: {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: string;
+}): Promise<void> {
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) throw new Error('auth_required');
+
+  const { error } = await supabase.from('reports').insert({
+    target_type: input.targetType,
+    target_id: input.targetId,
+    reporter_id: auth.user.id,
+    reason: input.reason.trim(),
+  });
+
+  if (error) {
+    if (error.code === '23505') throw new Error('already_reported');
+    throw new Error(error.message);
+  }
+}

--- a/supabase/migrations/012_reports.sql
+++ b/supabase/migrations/012_reports.sql
@@ -1,0 +1,35 @@
+-- Reports: users can flag scores, challenges, or profiles for review.
+-- Admin queue for reports is deferred to phase 2 (uses same admin infra as challenge moderation).
+
+CREATE TABLE IF NOT EXISTS public.reports (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  target_type TEXT        NOT NULL CHECK (target_type IN ('score', 'challenge', 'profile')),
+  target_id   UUID        NOT NULL,
+  reporter_id UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reason      TEXT        NOT NULL CHECK (length(trim(reason)) >= 5 AND length(reason) <= 1000),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT reports_unique_per_target UNIQUE (target_type, target_id, reporter_id)
+);
+
+ALTER TABLE public.reports ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_reports_target ON public.reports(target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_reports_reporter ON public.reports(reporter_id);
+
+COMMENT ON TABLE public.reports IS 'User-submitted reports (flag for review). One per (target, reporter).';
+
+CREATE POLICY "Users can insert own reports"
+  ON public.reports FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = reporter_id);
+
+CREATE POLICY "Users can read own reports"
+  ON public.reports FOR SELECT
+  TO authenticated
+  USING (auth.uid() = reporter_id);
+
+CREATE POLICY "Admins can read all reports"
+  ON public.reports FOR SELECT
+  TO authenticated
+  USING (public.is_app_admin());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Trust & platform foundations — Section F from `docs/issues/issues.md`. Closes #54.

### What's included

**Reporting (migration `012_reports.sql`)**
- `reports` table: `target_type` (score/challenge/profile), `target_id`, `reporter_id`, `reason` (5–1000 chars)
- RLS: insert own, read own, admin read all
- UNIQUE constraint `(target_type, target_id, reporter_id)` — one report per target per user
- `submitReport` service with auth check + duplicate handling

**SEO i18n**
- `generateMetadata` in `[locale]/layout.tsx` — per-locale title/description via `next-intl`
- Inherits from root layout's OG/Twitter config

**Runbook (`docs/RUNBOOK.md`)**
- Promote admin (SQL)
- Rollback migration (process)
- RLS review checklist
- Rate limiting approach (V1 UNIQUE constraints + admin gates; V1.1 Edge Functions)
- Environment variables reference

### Deferred
- **Sentry**: external config, deferred to V1.1
- **Rate limiting implementation**: documented approach, actual enforcement deferred to prod config

### Checks

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test:run` — 20 files, 100 tests passing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c33857-fc08-4bb1-962e-da95efd18c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

