### PR TITLE
feat(v1.5): QA prep — public profiles, clan refactor, arena pending

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,67 +1,364 @@
-# Truegrynd – Contexte produit & technique
+# Truegrynd — Product & Technical Context
 
-Document de référence pour toute l’équipe et pour l’IA. À jour = source de vérité.
+Ce document est le **brief de référence** à envoyer à une personne, une IA ou un agent cloud avant tout travail sur Truegrynd. Il doit permettre de comprendre rapidement ce que le produit fait, pourquoi il existe, ce qui est déjà livré, ce qu’il ne faut pas construire, et vers quoi il doit évoluer.
 
----
-
-## 1. Executive Summary
-
-**Tagline :** _"L'effort ne s'achète pas, il se prouve."_
-
-**Problème :** Se mesurer et valider son niveau en fitness coûte cher (100–150 € pour Hyrox, Spartan, etc.) et impose de se déplacer. La compétition est devenue un produit de luxe.
-
-**Solution :** Truegrynd est une app web B2C de **compétition asynchrone**, propulsée par la communauté (UGC). N’importe quel sportif peut affronter les autres sur des **défis standardisés**, partout dans le monde, **gratuitement**. On enlève la barrière financière et logistique : l’effort reste le même, l’arène devient globale.
-
-**Positionnement :** Le "Casio G-Shock" du fitness face aux "Rolex" de l’événementiel — détermination brute, pas premium sous les néons.
+Pour l’exploitation technique pure (admin, migrations, rollback, RLS, secrets), voir plutôt [`docs/RUNBOOK.md`](./RUNBOOK.md). Le runbook n’est pas un pitch produit : c’est une fiche opérations.
 
 ---
 
-## 2. Le Golden Circle
+## 1. One-Liner
 
-|          |                                                                                                                                        |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **WHY**  | Le mérite, la sueur et le dépassement de soi n’appartiennent pas qu’à une élite financière.                                            |
-| **HOW**  | Décentraliser la compétition : n’importe quel salon, parc ou salle low-cost devient une arène mondiale connectée.                      |
-| **WHAT** | Plateforme sociale de défis sportifs virtuels : créer/rejoindre/valider des épreuves, grimper au classement mondial, gagner du statut. |
+**Truegrynd est une arène de compétition fitness asynchrone où n’importe qui peut se mesurer à son niveau, gratuitement, avec preuve, classement, factions et progression.**
 
----
+Tagline actuelle :
 
-## 3. Innovations clés
+> L’effort ne s’achète pas, il se prouve.
 
-- **Factions** : À l’inscription, choix d’une équipe mondiale (ex. Les Nomades, La Horde, L’Alliance de Fer). Le score individuel compte aussi pour la Faction. Rétention par appartenance.
-- **Smart Proof** : Pas d’hébergement vidéo. Scores sur l’honneur pour la majorité ; pour le **Top 10%** du leaderboard, obligation d’une URL vidéo (YouTube/TikTok non répertoriée).
-- **Creator Score** : Les créateurs de défis populaires gagnent badges et réputation (UGC).
+Phrase V2 :
+
+> Race-day energy without the 110€ ticket.
 
 ---
 
-## 4. MVP – Périmètre technique
+## 2. Problème
 
-- **Auth** : Google / Apple / Email (Supabase).
-- **Onboarding** : Profil biométrique (pseudo, sexe, âge, poids) + initiation simplifiée (défis “bouton c’est fait”, pas de GPS) + choix de Faction.
-- **Arène** : Feed de défis (seeded au début), page défi + leaderboard filtrable (global, âge, sexe, faction).
-- **Soumission** : Chrono ou reps + URL vidéo si Top 10%.
-- **Finisher Card** : Image générée (score, rang, faction) + partage (téléchargement pour Stories).
-- **Profil** : Historique, rang Faction, vitrine des trophées.
+La compétition fitness est devenue intimidante et chère :
 
-Pas d’initiation lourde (pas de 50 burpees / 1 km run obligatoire avant d’entrer).
+- événements à 100–150 € ;
+- déplacement obligatoire ;
+- pression sociale et niveau perçu très élevé ;
+- classement global qui écrase les débutants ;
+- peu d’occasions de compétition entre les grands événements ;
+- aucun “palmarès amateur” simple pour suivre sa progression.
 
----
-
-## 5. Stack & fondations
-
-- **Framework :** Next.js 16 (App Router), TypeScript.
-- **Style :** Tailwind v4, thème sombre Truegrynd.
-- **Backend :** Supabase (auth, DB, realtime).
-- **State :** Zustand + React Query.
-- **Forms :** React Hook Form + Zod.
-- **UI :** Radix UI, Lucide, Sonner.
-- **Tests :** Vitest (unit) + Playwright (e2e).
-- **Qualité :** ESLint, Prettier, Husky (pre-commit: lint-staged, pre-push: typecheck + test:run).
-
-Les règles Cursor (`.cursor/rules/*.mdc`) détaillent l’architecture, le backend Supabase, le design system et les conventions de code.
+Résultat : beaucoup de sportifs veulent le frisson de la compétition, mais n’osent pas, n’ont pas le budget, ou ne se sentent pas légitimes.
 
 ---
 
-## 6. Issues & tracking
+## 3. Solution
 
-**Backlog post-MVP** (dont périmètre **Admin UGC**) : **[docs/issues/issues.md](./issues/issues.md)**. Conventions : **[docs/issues/README.md](./issues/README.md)**.
+Truegrynd transforme n’importe quel salon, parc, garage ou salle low-cost en arène compétitive connectée.
+
+Les utilisateurs :
+
+- rejoignent une faction ;
+- choisissent ou créent des challenges standardisés ;
+- soumettent des scores en reps ou temps ;
+- prouvent les meilleurs scores via URL vidéo ;
+- gagnent un rang, une carte partageable, du respect, des streaks et de la réputation créateur ;
+- progressent vers une compétition plus sérieuse sans payer un ticket d’événement.
+
+La V2 pousse plus loin : **divisions de niveau**, **teams**, **weekly challenges**, **rival matches**, **rating** et **micro-events** pour que les sportifs moyens soient en compétition contre leur monde à eux, pas seulement contre les élites.
+
+---
+
+## 4. Positionnement
+
+Truegrynd n’est pas une copie d’un gros événement fitness. C’est l’angle mort des gros événements.
+
+Les grands acteurs possèdent le **jour d’événement**. Truegrynd vise les **51 autres semaines** : entraînement compétitif, progression, rivalités, divisions, preuves, communautés.
+
+Positionnement mental :
+
+- **anti-luxe** : brut, sombre, street, no excuses ;
+- **accessible** : pas besoin de billet, de voyage ou d’être déjà elite ;
+- **compétitif** : classement, preuve, badges, rivalités ;
+- **asynchrone** : chacun joue quand il peut ;
+- **social par le score**, pas par le feed social.
+
+Ce que Truegrynd peut devenir pour un gros acteur sportif : un **top-of-funnel compétitif** qui transforme des sportifs normaux en futurs participants d’événements payants.
+
+---
+
+## 5. Ce Que Truegrynd Est
+
+- Une app B2C de compétition fitness asynchrone.
+- Une arène mondiale de challenges standardisés.
+- Une plateforme UGC modérée : la communauté crée, l’admin valide.
+- Un système de preuve léger : pas d’hébergement vidéo, seulement des liens externes.
+- Un jeu d’identité sportive : faction, rang, streak, creator score, respect, finisher cards.
+- En V2 : une ligue accessible avec divisions, weekly events, rival matches et rating.
+
+## 6. Ce Que Truegrynd N’est Pas
+
+- Pas un workout tracker personnel.
+- Pas une app de programme d’entraînement.
+- Pas un réseau social généraliste.
+- Pas une plateforme vidéo.
+- Pas une marketplace de coachs.
+- Pas un clone d’événement type Hyrox/Spartan.
+- Pas une expérience pay-to-win : payer ne doit jamais améliorer un rang sportif.
+
+---
+
+## 7. Golden Circle
+
+|          | Sens                                                                                                                                       |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **WHY**  | Le mérite, la sueur et le dépassement de soi ne doivent pas appartenir uniquement à ceux qui paient un ticket cher.                        |
+| **HOW**  | Décentraliser la compétition : des challenges standardisés, des preuves simples, des classements, des factions et des divisions de niveau. |
+| **WHAT** | Une web app de compétition fitness async : créer, rejoindre, soumettre, prouver, progresser, partager.                                     |
+
+---
+
+## 8. V1 Livrée Sur `main`
+
+La V1 macro est livrée en code. Référence : [`docs/issues/issues.md`](./issues/issues.md).
+
+### Socle MVP / V1
+
+- Auth Supabase : Google / Apple / email.
+- Onboarding : profil biométrique + faction.
+- Arena : feed challenges + page challenge + leaderboard.
+- Score submission : reps ou temps.
+- Smart Proof : scores avec vidéo = classés / validés, scores sans vidéo = sauvegardés mais non classés.
+- Finisher Card : image partageable.
+- Profil : historique, avatar, creator score, streak, logout.
+- Factions / Clan : guerre de factions + referral.
+- UGC Creator Studio : création de challenges.
+- Admin moderation : file admin, approve/reject, motif, audit.
+- AI triage admin : Edge Function Supabase `admin-challenge-ai-review`.
+- Movement catalog : 93 mouvements + option off-catalog.
+- Creator score : trigger DB.
+- Streaks : trigger DB.
+- Respect : bouton leaderboard.
+- Reports : table + RLS.
+- SEO i18n + runbook.
+
+### Migrations prod attendues
+
+`001` à `012` appliquées, notamment :
+
+- `008_admin_ugc_moderation.sql`
+- `009_challenge_ai_review.sql`
+- `010_creator_score_trigger.sql`
+- `011_streak_trigger.sql`
+- `012_reports.sql`
+
+---
+
+## 9. Innovations V1 Déjà En Place
+
+### Factions
+
+Trois équipes mondiales :
+
+- `nomads`
+- `horde`
+- `iron_alliance`
+
+Le score individuel nourrit aussi une identité collective.
+
+### Smart Proof
+
+Règle produit actuelle :
+
+- score avec URL vidéo valide = `is_validated: true`, classé ;
+- score sans vidéo = sauvegardé, pas classé ;
+- vidéo externe uniquement : YouTube / TikTok, jamais d’hébergement Truegrynd.
+
+### Creator Score
+
+Les créateurs de challenges approuvés gagnent de la réputation quand d’autres soumettent des scores validés sur leurs défis.
+
+### Admin AI Triage
+
+L’IA ne valide jamais automatiquement. Elle classe et résume pour l’admin :
+
+- green ;
+- orange ;
+- red.
+
+L’humain décide.
+
+---
+
+## 10. Vision V2
+
+La V2 doit faire passer Truegrynd de “challenge leaderboard app” à **ligue compétitive accessible**.
+
+Le principe :
+
+> Les gens un peu nuls ne doivent pas servir de décor aux élites. Ils doivent jouer contre des gens de leur niveau, progresser, monter de division, représenter leur team, et ressentir une vraie compétition.
+
+V2 n’est pas “Hyrox-style”. V2 est l’anti-barrière :
+
+- pas de ticket cher ;
+- pas de déplacement ;
+- pas d’humiliation sur un leaderboard global unique ;
+- compétition par division ;
+- scaling officiel ;
+- teams/factions ;
+- weekly challenges ;
+- rival matches ;
+- micro-events async ;
+- passport compétitif.
+
+Référence détaillée : [`docs/V2_STRATEGY.md`](./V2_STRATEGY.md).
+
+---
+
+## 11. Piliers V2
+
+### Divisions De Niveau
+
+Divisions proposées :
+
+- `rookie`
+- `regular`
+- `savage`
+- `elite`
+
+Objectif : permettre “top 12% Rookie” plutôt que “41 862e mondial”.
+
+### Scaling Officiel
+
+Chaque challenge important peut avoir des variantes assumées :
+
+- no equipment ;
+- bodyweight ;
+- dumbbell ;
+- standard ;
+- savage.
+
+Le scaling n’est pas un mode facile honteux. C’est une porte d’entrée officielle.
+
+### Weekly Global Challenge
+
+Un rendez-vous récurrent :
+
+- un challenge par semaine ;
+- divisions ;
+- factions ;
+- leaderboards par ville/pays ;
+- finisher card weekly ;
+- streak compétitif.
+
+### Truegrynd Rating
+
+Un rating global et des axes :
+
+- Engine ;
+- Power ;
+- Strength ;
+- Grit ;
+- Consistency.
+
+Il sert à proposer des divisions justes, des rivaux pertinents, et une progression lisible.
+
+### Team Wars / Factions
+
+Les factions doivent devenir des équipes compétitives par division, pas seulement un badge onboarding.
+
+Exemple de narration :
+
+> Horde Rookie Paris bat Iron Alliance Lyon sur le Weekly Engine Test.
+
+### Challenge Passport
+
+Le profil devient un palmarès amateur :
+
+- divisions atteintes ;
+- meilleurs scores ;
+- badges ;
+- finisher cards ;
+- weekly challenges complétés ;
+- rival matches gagnés ;
+- rating history.
+
+### Rival Matches
+
+Défis 1v1 ou petits groupes :
+
+- même division par défaut ;
+- faction adverse ou même faction ;
+- durée 24h / 7j ;
+- best-of-3 possible.
+
+### Micro-Events
+
+Événements async sans lieu physique :
+
+- Rookie Week ;
+- No Equipment Cup ;
+- Faction War Weekend ;
+- City Clash ;
+- Grit Open ;
+- Comeback Week.
+
+### Proof Levels
+
+Évolution du Smart Proof :
+
+- Honor ;
+- Video Ranked ;
+- Community Verified ;
+- Judge Verified ;
+- Event Verified.
+
+---
+
+## 12. Backlog V2
+
+Les candidates issues sont dans [`docs/issues/issues.md`](./issues/issues.md), section **H** :
+
+- V2-01 : Divisions de niveau
+- V2-02 : Variantes officielles / scaling
+- V2-03 : Weekly Global Challenge
+- V2-04 : Leaderboards par division, faction, ville, pays
+- V2-05 : Truegrynd Rating
+- V2-06 : Challenge Passport
+- V2-07 : Rival Matches
+- V2-08 : Team Wars / Faction Wars
+- V2-09 : Micro-events async
+- V2-10 : Proof Levels
+- V2-11 : Growth loops
+- V2-12 : Monétisation exploratoire
+
+Recommandation de premier lot : **V2-01 → V2-03**.
+
+---
+
+## 13. Stack Technique
+
+- **Framework** : Next.js 16, App Router.
+- **Langage** : TypeScript.
+- **Backend** : Supabase Auth, Postgres, RLS, Edge Functions.
+- **Styling** : Tailwind CSS v4, dark-only MVP.
+- **State** : Zustand + React Query.
+- **Forms** : React Hook Form + Zod.
+- **UI primitives** : Radix UI, Lucide, Sonner.
+- **Tests** : Vitest + Playwright.
+- **i18n** : `next-intl`, routes locales.
+
+Architecture attendue :
+
+- `app/` assemble les pages ;
+- `features/` contient les domaines produit ;
+- `components/` pour UI partagée ;
+- `lib/` pour infra, types, utils ;
+- Supabase calls dans services/hooks, jamais dispersés dans les composants.
+
+---
+
+## 14. Règles De Décision Produit
+
+- Prioriser la compétition accessible avant la monétisation.
+- Ne jamais construire une expérience où seuls les élites se sentent légitimes.
+- Garder la friction basse pour le premier score.
+- Garder la preuve plus stricte pour les rangs sérieux.
+- Refuser le pay-to-win.
+- Éviter le réseau social généraliste : Truegrynd est social par la compétition.
+- Construire mobile-first.
+- Tout nouveau texte visible doit avoir i18n EN + FR.
+- Toute feature sensible doit respecter RLS + tests ou checklist de sécurité.
+
+---
+
+## 15. Documents De Référence
+
+- Backlog et issues : [`docs/issues/issues.md`](./issues/issues.md)
+- Stratégie V2 : [`docs/V2_STRATEGY.md`](./V2_STRATEGY.md)
+- Runbook ops : [`docs/RUNBOOK.md`](./RUNBOOK.md)
+- Wireframes : [`docs/wireframes/wireframes.md`](./wireframes/wireframes.md)
+- Règles Cursor / agents : `AGENTS.md` et `.cursor/rules/*.mdc`

--- a/docs/QA_V1_CHECKLIST.md
+++ b/docs/QA_V1_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Truegrynd — QA checklist V1 (strong)
 
-**Périmètre :** tout ce qui est sur `main` après PR #30 → #55 + migrations prod `006`–`012`.  
+**Périmètre :** tout ce qui est sur `main` après PR #30 → #55 + migrations prod `006`–`013`.  
 **Pas V2** (divisions, weekly, rating, etc.) — pas encore codé.
 
 **Environnement :** tester contre **prod Supabase** + déploiement Vercel (ou `pnpm dev` + `.env.local` prod).  
@@ -13,7 +13,7 @@ Coche : `[ ]` à faire · `[x]` OK · `[!]` bug (noter en bas)
 
 ## 0. Prérequis ops
 
-- [ ] Migrations **`001`–`012`** appliquées sur le projet Supabase utilisé par l’app
+- [ ] Migrations **`001`–`013`** appliquées sur le projet Supabase utilisé par l’app (`013` = `challenges.ends_at` + RPC `admin_close_challenge`)
 - [ ] Edge Function **`admin-challenge-ai-review`** déployée
 - [ ] Secrets Supabase : **`OPENAI_API_KEY`** (et optionnel `OPENAI_MODEL`)
 - [ ] Au moins 1 compte avec `profiles.is_admin = true` (voir `docs/RUNBOOK.md`)
@@ -46,12 +46,13 @@ Coche : `[ ]` à faire · `[x]` OK · `[!]` bug (noter en bas)
 
 ## 3. Arena & navigation
 
-| #   | Test                                        | Attendu                                         | EN  | FR  |
-| --- | ------------------------------------------- | ----------------------------------------------- | --- | --- |
-| 3.1 | `/en/app/arena`                             | Liste challenges (approved), pas écran blanc    | [ ] | [ ] |
-| 3.2 | Dock / nav desktop                          | Overview, Arena, Clan, Profile (+ MOD si admin) | [ ] | [ ] |
-| 3.3 | Filtres leaderboard (si présents sur liste) | Changement sans erreur                          | [ ] | [ ] |
-| 3.4 | Ouvrir un challenge **approved**            | Détail + leaderboard                            | [ ] | [ ] |
+| #    | Test                                        | Attendu                                                                | EN  | FR  |
+| ---- | ------------------------------------------- | ---------------------------------------------------------------------- | --- | --- |
+| 3.1  | `/en/app/arena`                             | Liste challenges **live** (approved, pas fermés), pas écran blanc      | [ ] | [ ] |
+| 3.1b | Défi **FERMER** en MOD (admin)              | Disparaît du feed `/arena` ; détail direct URL encore OK (leaderboard) | [ ] | [ ] |
+| 3.2  | Dock / nav desktop                          | Overview, Arena, Clan, Profile (+ MOD si admin)                        | [ ] | [ ] |
+| 3.3  | Filtres leaderboard (si présents sur liste) | Changement sans erreur                                                 | [ ] | [ ] |
+| 3.4  | Ouvrir un challenge **approved**            | Détail + leaderboard                                                   | [ ] | [ ] |
 
 ---
 
@@ -84,11 +85,11 @@ Coche : `[ ]` à faire · `[x]` OK · `[!]` bug (noter en bas)
 
 | #   | Test                                                              | Attendu                                                     | EN  | FR  |
 | --- | ----------------------------------------------------------------- | ----------------------------------------------------------- | --- | --- |
-| 6.1 | Affichage streak                                                  | `streak_days` cohérent après nouvelle soumission (jour UTC) | [ ] | [ ] |
-| 6.2 | **Creator score** + badge (bronze/silver/gold si seuils atteints) | Affichage + tooltip / copy                                  | [ ] | [ ] |
-| 6.3 | Historique scores                                                 | Liste avec états ranked / saved si applicable               | [ ] | [ ] |
-| 6.4 | Galerie finisher cards                                            | Chargement / empty / erreur + retry                         | [ ] | [ ] |
-| 6.5 | Changement avatar                                                 | Upload OK, erreur si fichier trop gros / mauvais type       | [ ] | [ ] |
+| 6.1 | Affichage streak                                                  | `streak_days` cohérent après nouvelle soumission (jour UTC) | [x] | [x] |
+| 6.2 | **Creator score** + badge (bronze/silver/gold si seuils atteints) | Affichage + tooltip / copy                                  | [x] | [x] |
+| 6.3 | Historique scores                                                 | Liste avec états ranked / saved si applicable               | [x] | [x] |
+| 6.4 | Galerie finisher cards                                            | Chargement / empty / erreur + retry                         | [!] | [!] |
+| 6.5 | Changement avatar                                                 | Upload OK, erreur si fichier trop gros / mauvais type       | [x] | [x] |
 
 **Streak (DB) :** après 1ère soumission du jour → streak ≥ 1 ; 2e soumission même jour → pas de double incrément (idempotent).
 
@@ -120,19 +121,24 @@ Coche : `[ ]` à faire · `[x]` OK · `[!]` bug (noter en bas)
 
 ## 9. Admin — Modération UGC
 
-**Compte admin requis.**
+**Compte admin requis.**  
+**Onglets MOD :** EN REVUE (`pending`) · EN COURS / LIVE (`arena_live`) · TERMINÉ / DONE (`arena_done`) · REFUSÉ (`rejected`).  
+Filtres IA / batch **uniquement** sur EN REVUE.
 
-| #   | Test                                        | Attendu                                                       | EN  | FR  |
-| --- | ------------------------------------------- | ------------------------------------------------------------- | --- | --- |
-| 9.1 | User non-admin → `/en/app/admin/challenges` | **404** ou redirect (pas d’accès)                             | [ ] | [ ] |
-| 9.2 | Admin : liste pending                       | Pagination, loading, empty, error+retry                       | [ ] | [ ] |
-| 9.3 | **Approve** (simple)                        | Confirmation modal → challenge approved, disparaît de la file | [ ] | [ ] |
-| 9.4 | **Reject**                                  | Motif &lt; 10 car. refusé ; ≥ 10 OK ; créateur voit motif     | [ ] | [ ] |
-| 9.5 | Batch approve + confirm                     | N challenges approuvés                                        | [ ] | [ ] |
-| 9.6 | Filtres IA : tier + tri risque              | Filtre cohérent                                               | [ ] | [ ] |
-| 9.7 | **AI scan** (1 ligne pending)               | Tier + résumé remplis ; pas d’auto-approve sans clic          | [ ] | [ ] |
-| 9.8 | AI scan sans `OPENAI_API_KEY`               | Message type “non configuré”, pas crash opaque                | [ ] | [ ] |
-| 9.9 | Batch approve **verts only** (si coché)     | Seuls `ai_tier=green` passent en approved                     | [ ] | [ ] |
+| #    | Test                                             | Attendu                                                   | EN  | FR  |
+| ---- | ------------------------------------------------ | --------------------------------------------------------- | --- | --- |
+| 9.1  | User non-admin → `/en/app/admin/challenges`      | **404** ou redirect (pas d’accès)                         | [ ] | [ ] |
+| 9.2  | Compteurs onglets + total communauté             | Chiffres cohérents sur les 4 onglets + ligne total UGC    | [ ] | [ ] |
+| 9.3  | EN REVUE : liste pending                         | Pagination, loading, empty, error+retry                   | [ ] | [ ] |
+| 9.4  | **Approve** (simple)                             | Confirmation modal → onglet **EN COURS**, compteur +1     | [ ] | [ ] |
+| 9.5  | **FERMER** (EN COURS)                            | Confirmation → onglet **TERMINÉ**, compteur EN COURS −1   | [ ] | [ ] |
+| 9.6  | **Reject**                                       | Motif &lt; 10 car. refusé ; ≥ 10 OK ; créateur voit motif | [ ] | [ ] |
+| 9.7  | Batch approve + confirm (EN REVUE)               | N challenges → EN COURS                                   | [ ] | [ ] |
+| 9.8  | Filtres IA : tier + tri risque (EN REVUE)        | Filtre cohérent                                           | [ ] | [ ] |
+| 9.9  | **AI scan** (1 ligne pending)                    | Tier + résumé remplis ; pas d’auto-approve sans clic      | [ ] | [ ] |
+| 9.10 | AI scan sans `OPENAI_API_KEY`                    | Message type “non configuré”, pas crash opaque            | [ ] | [ ] |
+| 9.11 | Batch approve **verts only** (si coché)          | Seuls `ai_tier=green` passent en approved                 | [ ] | [ ] |
+| 9.12 | Onglets historique (EN COURS / TERMINÉ / REFUSÉ) | **VOIR** ouvre le détail ; pas d’actions approve/reject   | [ ] | [ ] |
 
 ---
 
@@ -188,10 +194,11 @@ Sinon si UI trouvée :
 
 ## Bugs trouvés
 
-| ID  | Sévérité | Parcours | Description | Repro | Statut |
-| --- | -------- | -------- | ----------- | ----- | ------ |
-| B1  |          |          |             |       |        |
-| B2  |          |          |             |       |        |
+| ID  | Sévérité | Parcours               | Description                                                                                                                                              | Repro                                  | Statut |
+| --- | -------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------ |
+| B1  | P1       | Profil → CARD / finish | `/app/finish` affiche toujours « Could not load… » (ranked **et** saved) — `FinishPage` client lit `searchParams` en prop au lieu de `useSearchParams()` | Profil → CARD ou galerie → `/finish?…` | ouvert |
+| B2  | P2       | Profil §6.4 galerie    | `FinisherGallery` en erreur : message seul, **pas de bouton Retry** (contrairement à `ScoreHistory`)                                                     | Simuler erreur fetch scores            | ouvert |
+| B3  | P3       | Profil galerie         | Miniature card SAVED : chevauchement texte faction / « NO VIDEO » sur le canvas                                                                          | Profil avec score non validé           | ouvert |
 
 **Sévérité :** P0 bloquant · P1 majeur · P2 mineur · P3 cosmétique
 
@@ -202,7 +209,7 @@ Sinon si UI trouvée :
 - [ ] **GO** — prêt pour travailler V2-01 en confiance
 - [ ] **NO-GO** — bugs P0/P1 à corriger d’abord
 
-**Signé :** ******\_\_\_****** **Date :** ******\_\_\_******
+**Signé :** **\*\***\_\_\_**\*\*** **Date :** **\*\***\_\_\_**\*\***
 
 ---
 

--- a/docs/QA_V1_CHECKLIST.md
+++ b/docs/QA_V1_CHECKLIST.md
@@ -1,0 +1,215 @@
+# Truegrynd — QA checklist V1 (strong)
+
+**Périmètre :** tout ce qui est sur `main` après PR #30 → #55 + migrations prod `006`–`012`.  
+**Pas V2** (divisions, weekly, rating, etc.) — pas encore codé.
+
+**Environnement :** tester contre **prod Supabase** + déploiement Vercel (ou `pnpm dev` + `.env.local` prod).  
+**Locales :** au minimum **EN** + **FR** sur les parcours critiques.  
+**Comptes suggérés :** 1 admin, 2 users normaux (factions différentes), 1 créateur UGC.
+
+Coche : `[ ]` à faire · `[x]` OK · `[!]` bug (noter en bas)
+
+---
+
+## 0. Prérequis ops
+
+- [ ] Migrations **`001`–`012`** appliquées sur le projet Supabase utilisé par l’app
+- [ ] Edge Function **`admin-challenge-ai-review`** déployée
+- [ ] Secrets Supabase : **`OPENAI_API_KEY`** (et optionnel `OPENAI_MODEL`)
+- [ ] Au moins 1 compte avec `profiles.is_admin = true` (voir `docs/RUNBOOK.md`)
+- [ ] Navigateur : session propre ou navigation privée pour tests auth
+
+---
+
+## 1. Auth & entrée
+
+| #   | Test                                | Attendu                                                  | EN  | FR  |
+| --- | ----------------------------------- | -------------------------------------------------------- | --- | --- |
+| 1.1 | `/` ou `/en` non connecté           | Redirige vers `/en/auth` (ou locale)                     | [ ] | [ ] |
+| 1.2 | Page auth : magic link              | Formulaire visible, pas de crash                         | [ ] | [ ] |
+| 1.3 | OAuth Google / Apple (si configuré) | Login OK ou erreur claire                                | [ ] | [ ] |
+| 1.4 | Routes protégées sans session       | `/en/app/arena`, `/profile`, `/onboarding` → auth        | [ ] | [ ] |
+| 1.5 | **LOG OUT** (profil)                | Retour auth, session invalidée, routes app inaccessibles | [ ] | [ ] |
+
+---
+
+## 2. Onboarding
+
+| #   | Test                                        | Attendu                                                        | EN  | FR  |
+| --- | ------------------------------------------- | -------------------------------------------------------------- | --- | --- |
+| 2.1 | Nouveau user : parcours onboarding complet  | Profil + faction + fin initiation → arena/overview             | [ ] | [ ] |
+| 2.2 | Champs requis                               | Impossible de continuer sans pseudo, sexe, âge, poids, faction | [ ] | [ ] |
+| 2.3 | Referral `?faction=horde` (ou autre valide) | Faction pré-sélectionnée si flow prévu                         | [ ] | [ ] |
+| 2.4 | Referral invalide                           | Pas de crash ; valeur ignorée ou rejet propre                  | [ ] | [ ] |
+
+---
+
+## 3. Arena & navigation
+
+| #   | Test                                        | Attendu                                         | EN  | FR  |
+| --- | ------------------------------------------- | ----------------------------------------------- | --- | --- |
+| 3.1 | `/en/app/arena`                             | Liste challenges (approved), pas écran blanc    | [ ] | [ ] |
+| 3.2 | Dock / nav desktop                          | Overview, Arena, Clan, Profile (+ MOD si admin) | [ ] | [ ] |
+| 3.3 | Filtres leaderboard (si présents sur liste) | Changement sans erreur                          | [ ] | [ ] |
+| 3.4 | Ouvrir un challenge **approved**            | Détail + leaderboard                            | [ ] | [ ] |
+
+---
+
+## 4. Soumission de score & Smart Proof
+
+**Préparer :** un challenge **time** et un **reps**, avec quelques scores déjà validés si possible.
+
+| #   | Test                                                 | Attendu                                                            | EN  | FR  |
+| --- | ---------------------------------------------------- | ------------------------------------------------------------------ | --- | --- |
+| 4.1 | Submit **sans** vidéo                                | Score enregistré ; **pas** dans le leaderboard classé (non validé) | [ ] | [ ] |
+| 4.2 | Submit **avec** URL YouTube/TikTok valide            | Score **validé** ; apparaît au leaderboard                         | [ ] | [ ] |
+| 4.3 | URL vidéo invalide                                   | Message d’erreur clair, pas de crash                               | [ ] | [ ] |
+| 4.4 | Cap temps (si challenge avec `max_duration_seconds`) | Rejet ou message si temps trop long                                | [ ] | [ ] |
+| 4.5 | Finisher flow après submit                           | Page finish / card générée ou CTA cohérent                         | [ ] | [ ] |
+
+---
+
+## 5. Leaderboard & Respect
+
+| #   | Test                                      | Attendu                                                  | EN  | FR  |
+| --- | ----------------------------------------- | -------------------------------------------------------- | --- | --- |
+| 5.1 | Filtres : global / sexe / âge / faction   | Classement change, pas d’erreur                          | [ ] | [ ] |
+| 5.2 | **Respect** sur ligne d’un **autre** user | Compteur +1, état “déjà respecté”, pas de double respect | [ ] | [ ] |
+| 5.3 | Respect sur **son** propre score          | Bouton **absent** ou désactivé (anti self-respect)       | [ ] | [ ] |
+| 5.4 | Refresh / realtime (optionnel)            | Autre session voit le respect (si realtime activé)       | [ ] | [ ] |
+
+---
+
+## 6. Profil
+
+| #   | Test                                                              | Attendu                                                     | EN  | FR  |
+| --- | ----------------------------------------------------------------- | ----------------------------------------------------------- | --- | --- |
+| 6.1 | Affichage streak                                                  | `streak_days` cohérent après nouvelle soumission (jour UTC) | [ ] | [ ] |
+| 6.2 | **Creator score** + badge (bronze/silver/gold si seuils atteints) | Affichage + tooltip / copy                                  | [ ] | [ ] |
+| 6.3 | Historique scores                                                 | Liste avec états ranked / saved si applicable               | [ ] | [ ] |
+| 6.4 | Galerie finisher cards                                            | Chargement / empty / erreur + retry                         | [ ] | [ ] |
+| 6.5 | Changement avatar                                                 | Upload OK, erreur si fichier trop gros / mauvais type       | [ ] | [ ] |
+
+**Streak (DB) :** après 1ère soumission du jour → streak ≥ 1 ; 2e soumission même jour → pas de double incrément (idempotent).
+
+**Creator score (DB) :** user B soumet score **validé** sur défi **approuvé** créé par user A (pas soi-même) → `creator_score` de A augmente (plafond 10/jour).
+
+---
+
+## 7. Clan & referral
+
+| #   | Test                           | Attendu                                 | EN  | FR  |
+| --- | ------------------------------ | --------------------------------------- | --- | --- |
+| 7.1 | `/en/app/clan`                 | Stats factions, pas de crash            | [ ] | [ ] |
+| 7.2 | **Recruit CTA** : copier lien  | Lien contient faction (ex. `?faction=`) | [ ] | [ ] |
+| 7.3 | Share (si supporté navigateur) | Pas de crash si annulé                  | [ ] | [ ] |
+
+---
+
+## 8. UGC — Création de défi
+
+| #   | Test                                    | Attendu                                                     | EN  | FR  |
+| --- | --------------------------------------- | ----------------------------------------------------------- | --- | --- |
+| 8.1 | `/en/app/arena/create`                  | Formulaire create visible                                   | [ ] | [ ] |
+| 8.2 | Catalogue mouvements                    | Sélection par catégorie + option “Autre”                    | [ ] | [ ] |
+| 8.3 | Circuit : ≥ 1 bloc valide               | Zod / message si 0 bloc ou reps invalides                   | [ ] | [ ] |
+| 8.4 | Submit création                         | Challenge en **pending**, pas visible public comme approved | [ ] | [ ] |
+| 8.5 | Détail challenge **pending** (créateur) | Bannière pending + pas de leaderboard public                | [ ] | [ ] |
+
+---
+
+## 9. Admin — Modération UGC
+
+**Compte admin requis.**
+
+| #   | Test                                        | Attendu                                                       | EN  | FR  |
+| --- | ------------------------------------------- | ------------------------------------------------------------- | --- | --- |
+| 9.1 | User non-admin → `/en/app/admin/challenges` | **404** ou redirect (pas d’accès)                             | [ ] | [ ] |
+| 9.2 | Admin : liste pending                       | Pagination, loading, empty, error+retry                       | [ ] | [ ] |
+| 9.3 | **Approve** (simple)                        | Confirmation modal → challenge approved, disparaît de la file | [ ] | [ ] |
+| 9.4 | **Reject**                                  | Motif &lt; 10 car. refusé ; ≥ 10 OK ; créateur voit motif     | [ ] | [ ] |
+| 9.5 | Batch approve + confirm                     | N challenges approuvés                                        | [ ] | [ ] |
+| 9.6 | Filtres IA : tier + tri risque              | Filtre cohérent                                               | [ ] | [ ] |
+| 9.7 | **AI scan** (1 ligne pending)               | Tier + résumé remplis ; pas d’auto-approve sans clic          | [ ] | [ ] |
+| 9.8 | AI scan sans `OPENAI_API_KEY`               | Message type “non configuré”, pas crash opaque                | [ ] | [ ] |
+| 9.9 | Batch approve **verts only** (si coché)     | Seuls `ai_tier=green` passent en approved                     | [ ] | [ ] |
+
+---
+
+## 10. Overview
+
+| #    | Test               | Attendu                                  | EN  | FR  |
+| ---- | ------------------ | ---------------------------------------- | --- | --- |
+| 10.1 | `/en/app/overview` | CTA, streak, faction nudge, pas de crash | [ ] | [ ] |
+
+---
+
+## 11. i18n & SEO (smoke)
+
+| #    | Test                                              | Attendu                                        |
+| ---- | ------------------------------------------------- | ---------------------------------------------- |
+| 11.1 | Basculer locale EN ↔ FR sur auth + arena + profil | Pas de clés brutes `admin.queue.foo` visibles  |
+| 11.2 | View source / meta                                | `title` / `description` présents (layout i18n) |
+
+---
+
+## 12. Mobile & états UI (smoke rapide)
+
+Sur **375px** largeur :
+
+- [ ] Dock utilisable (touch 44px min)
+- [ ] Modals admin (reject / approve) utilisables
+- [ ] Table admin scroll horizontal OK
+- [ ] Pas de texte coupé critique sur profil / clan
+
+---
+
+## 13. Reports (table `012`)
+
+**Note :** service `submitReport` existe ; **vérifier si une UI l’expose**. Si pas d’UI en V1 :
+
+- [ ] **N/A UI** — cocher “backend only, QA UI reportée V2+”
+
+Sinon si UI trouvée :
+
+- [ ] Signaler un score / challenge → insert OK
+- [ ] Double signalement même cible → message “already reported”
+
+---
+
+## 14. Régression rapide (5 min avant release)
+
+- [ ] Login → arena → 1 submit → profil → logout
+- [ ] Admin : 1 approve + 1 reject sur pending test
+- [ ] Pas d’erreur console rouge en prod (DevTools)
+- [ ] Pas de fuite évidente de clé service role côté client
+
+---
+
+## Bugs trouvés
+
+| ID  | Sévérité | Parcours | Description | Repro | Statut |
+| --- | -------- | -------- | ----------- | ----- | ------ |
+| B1  |          |          |             |       |        |
+| B2  |          |          |             |       |        |
+
+**Sévérité :** P0 bloquant · P1 majeur · P2 mineur · P3 cosmétique
+
+---
+
+## Verdict QA V1
+
+- [ ] **GO** — prêt pour travailler V2-01 en confiance
+- [ ] **NO-GO** — bugs P0/P1 à corriger d’abord
+
+**Signé :** ******\_\_\_****** **Date :** ******\_\_\_******
+
+---
+
+## Après QA V1 (suite produit)
+
+1. Corriger bugs listés ci-dessus
+2. Créer issues GitHub pour **V2-01 → V2-03**
+3. Commencer implémentation V2 (voir `docs/V2_STRATEGY.md`, `docs/issues/issues.md` section H)
+
+**Références :** [`CONTEXT.md`](./CONTEXT.md) · [`issues.md`](./issues/issues.md) · [`RUNBOOK.md`](./RUNBOOK.md)

--- a/docs/V2_STRATEGY.md
+++ b/docs/V2_STRATEGY.md
@@ -1,0 +1,213 @@
+# Truegrynd V2 — Accessible Competitive Fitness
+
+## Positionnement
+
+Truegrynd V2 n'essaie pas de copier les grands événements fitness. L'angle est l'inverse : récupérer tous ceux qui veulent la tension de la compétition sans billet cher, déplacement, pression élitiste ou humiliation face aux monstres du classement global.
+
+**Thèse :** les grands acteurs du sport vendent le jour d'événement ; Truegrynd possède les 51 autres semaines.
+
+**Phrase courte :** Race-day energy without the 110€ ticket.
+
+**Promesse :** chacun peut entrer dans l'arène à son niveau, dans sa division, avec son équipe, et progresser vers le haut.
+
+## Pourquoi C'est Rachetable
+
+Un acteur événementiel ou sportif ne rachèterait pas seulement une app de challenges. Il rachèterait :
+
+- un funnel de sportifs amateurs vers la compétition payante ;
+- des données de progression et de niveau sur des milliers d'athlètes ;
+- une couche d'engagement entre les événements officiels ;
+- un système de divisions qui rend la compétition moins intimidante ;
+- des formats viraux peu coûteux à opérer : weekly challenges, micro-events, rival matches.
+
+Truegrynd devient le **top of funnel compétitif** : les gens s'entraînent, se comparent, prennent confiance, puis osent acheter un ticket d'événement plus tard.
+
+## Piliers Produit
+
+### 1. Divisions Par Niveau
+
+Le leaderboard global reste prestigieux, mais l'expérience principale doit classer les utilisateurs contre des gens comparables.
+
+Divisions de départ :
+
+- **Rookie** : découvre la compétition.
+- **Regular** : pratique régulière, scores propres.
+- **Savage** : très solide, cherche le top.
+- **Elite** : minorité très forte, vitrine aspirante.
+
+La clé : un utilisateur moyen doit pouvoir dire “je suis top 12% Rookie” au lieu de “je suis 41 862e mondial”.
+
+### 2. Scaling Officiel
+
+Chaque challenge important doit proposer des variantes assumées, pas honteuses :
+
+- no equipment ;
+- bodyweight ;
+- dumbbell ;
+- standard ;
+- savage.
+
+Le scaling n'est pas un mode facile : c'est une division officielle.
+
+### 3. Weekly Global Challenge
+
+Un rendez-vous simple, récurrent, partageable :
+
+- un challenge par semaine ;
+- variantes par division ;
+- leaderboard par division, faction, ville, sexe, âge ;
+- finisher card automatique ;
+- bonus de streak compétitif.
+
+Objectif : créer l'habitude de revenir sans devoir organiser un événement physique.
+
+### 4. Truegrynd Rating
+
+Un rating global qui résume le niveau sportif sans réduire l'utilisateur à un seul score.
+
+Axes possibles :
+
+- **Engine** : endurance / cardio.
+- **Power** : puissance / explosivité.
+- **Strength** : force relative.
+- **Grit** : capacité à tenir l'inconfort.
+- **Consistency** : régularité.
+
+Le rating sert à proposer une division juste, des rivaux pertinents et des objectifs de progression.
+
+### 5. Team Identity
+
+Les factions deviennent plus qu'un badge : elles transforment l'effort individuel en guerre collective.
+
+V2 doit croiser :
+
+- équipe/faction ;
+- division ;
+- ville/pays ;
+- weekly challenges ;
+- micro-events.
+
+Exemple de narration : “Horde Rookie Paris gagne le week-end engine contre Iron Alliance Lyon.”
+
+### 6. Rival Matches
+
+Défis 1v1 ou petits groupes entre athlètes de niveau proche :
+
+- même division ;
+- même faction ou faction adverse ;
+- même ville/pays ;
+- même tranche d'âge ou poids si pertinent ;
+- best-of-3 sur la semaine.
+
+C'est compétitif sans devenir un réseau social généraliste.
+
+### 7. Micro-Events
+
+Un event Truegrynd peut durer 24h, 7 jours ou 30 jours.
+
+Formats :
+
+- Rookie Week ;
+- No Equipment Cup ;
+- Faction War Weekend ;
+- City Clash ;
+- Grit Open ;
+- Comeback Week.
+
+Pas de ticket, pas de déplacement, pas d'élitisme. L'arène est partout.
+
+### 8. Challenge Passport
+
+Le profil doit devenir un palmarès amateur :
+
+- divisions atteintes ;
+- meilleurs scores par catégorie ;
+- badges ;
+- finisher cards ;
+- micro-events terminés ;
+- progression du rating ;
+- victoires en rival match ;
+- historique faction.
+
+C'est le CV compétitif du sportif normal.
+
+### 9. Proof Levels
+
+Garder la friction basse, mais donner des couches de crédibilité :
+
+- **Honor** : score sauvé, pas classé prestige.
+- **Video Ranked** : URL vidéo valide, leaderboard standard.
+- **Community Verified** : validation par pairs / signal faible.
+- **Judge Verified** : coach, admin ou organisateur.
+- **Event Verified** : score issu d'un micro-event officiel.
+
+Les leaderboards sérieux peuvent filtrer par niveau de preuve.
+
+## Roadmap V2 Recommandée
+
+### V2.1 — Divisions + Weekly Challenge
+
+Le plus gros levier de rétention et d'accessibilité.
+
+- divisions ;
+- variantes officielles ;
+- weekly challenge ;
+- leaderboards par division ;
+- finisher cards divisées.
+
+### V2.2 — Rating + Passport
+
+Créer l'identité compétitive durable.
+
+- Truegrynd Rating ;
+- axes de performance ;
+- profil passport ;
+- historique de progression.
+
+### V2.3 — Rival Matches + Team Wars
+
+Transformer l'usage solo en compétition sociale légère.
+
+- rival matches ;
+- faction wars par division ;
+- city/faction leaderboards.
+
+### V2.4 — Micro-Events + Verification
+
+Créer l'équivalent event sans opération lourde.
+
+- event packs ;
+- proof levels ;
+- judge/admin verification ;
+- pages de résultat.
+
+### V2.5 — Monétisation
+
+À ne pas coder trop tôt. D'abord prouver l'engagement.
+
+Options :
+
+- premium athlete passport ;
+- micro-event entry cosmetics ;
+- branded challenge sponsorship ;
+- gym/team dashboard ;
+- coach/judge accounts.
+
+## Métriques à Suivre
+
+- Weekly challenge participants.
+- % users classés dans une division.
+- % nouveaux utilisateurs qui soumettent un premier score en 7 jours.
+- Rétention weekly challenge à 4 semaines.
+- Partage de finisher cards.
+- Rival match completion rate.
+- Promotion Rookie → Regular.
+- Scores video-ranked vs honor.
+
+## Principe Produit
+
+Ne jamais construire une expérience où les “nuls” sont seulement de la chair à leaderboard pour les élites.
+
+Le produit gagne si quelqu'un de moyen peut ressentir :
+
+> Je suis vraiment en compétition, mais contre mon monde à moi.

--- a/docs/V3_STRATEGY.md
+++ b/docs/V3_STRATEGY.md
@@ -1,0 +1,181 @@
+Désolé pour le contretemps, l'affichage précédent a dû être corrompu par l'interpréteur de texte.
+
+Voici le lien direct pour télécharger ton fichier proprement au format Markdown, prêt à être poussé sur ton dépôt :
+
+[Télécharger v3_strategy.md](https://www.google.com/search?q=sandbox:/v3_strategy.md)
+
+### Pour le créer directement en ligne de commande dans ton repo :
+
+Si tu es sur ton terminal dans le dossier de ton projet, tu peux aussi simplement exécuter cette commande pour générer le fichier instantanément :
+
+````bash
+cat << 'EOF' > v3_strategy.md
+# Truegrynd V3 Strategy — The Hybrid B2B2C Ecosystem
+
+## 1. Executive Summary & Thesis
+
+Truegrynd V2 focused on building the ultimate accessible competitive fitness app for individual athletes. V3 introduces the structural pivot to a **B2B2C model**, turning the B2C engagement engine into a Trojan Horse to capture the European Hybrid & Functional Fitness facility market.
+
+**The Market Gap (Europe vs. US):**
+US giants (*Wodify, SugarWOD, BTWB*) were built in 2012–2015 for pure CrossFit (barbells & gymnastics). They are heavy, expensive ($150–$250/mo), act as rigid accounting/booking tools, and completely ignore the explosion of **Hybrid Training & Hyrox-style endurance** (VMA, running pacing, ergs) in Europe. Furthermore, gym management platforms in Europe (*Resawod, Deciplus, Xplor*) are administrative, corporate, and completely devoid of community "vibe".
+
+**The Truegrynd V3 Thesis:**
+Gym owners don't want another invoicing tool; they want **community retention and automated session animation**. Truegrynd V3 owns the competitive layer, the community engagement, and the hybrid athletic identity, operating alongside existing booking systems.
+
+* **B2C Objective:** Create user acquisition, athletic identity (*Passport*), and organic growth loops.
+* **B2B Objective:** Monetize affiliates (Gyms, Boxes, Clubs) at **$100/month** by offering automated retention, league competition, and interactive facility animation.
+
+---
+
+## 2. Business Model Hierarchy (RBAC Core)
+
+To maintain extreme efficiency as a solopreneur, the platform uses a single unified codebase with **Role-Based Access Control (RBAC)** to route users dynamically:
+
+- **Role: ATHLETE (/app interface)**
+  * Free / Freemium
+  * Passport & Rating
+  * Weekly Challenges
+  * Rival Matches
+  * Generates organic traction
+
+- **Role: PRO (/pro interface)**
+  * $100/mo subscription
+  * TV Broadcaster Mode
+  * Inter-Gym Leagues
+  * Pacing Automation
+  * Monetizes the structures
+
+- **Role: ADMIN (/admin interface)**
+  * Platform control (Your backend)
+  * Global Workout Engine
+  * Audit & Verification
+  * Systems Config
+
+---
+
+## 3. Product Specifications
+
+### ─── OPTION B2C: L'Arène (The Athlete Interface) ───
+*Focus: Frictionless score submission, status progression, and social loops.*
+
+#### 1. The Hybrid Passport & Multi-Axis Rating
+* **Truegrynd Rating:** Evaluates performance across 5 native axes (*Engine, Power, Strength, Grit, Consistency*).
+* **Cardio-Ready Engine:** The *Engine* metric captures running performance benchmarks (e.g., VMA, 5K/10K times) to contextualize the athlete's aerobic engine without requiring real-time GPS tracking.
+* **The Passport:** Digital athletic résumé showcasing reached divisions, historical metrics, earned badges, and verified match history.
+
+#### 2. Lean Score Submission & Anti-Cheat Proof Levels
+To scale without human moderation, tracking is decentralized via layered proof:
+* **Honor Level:** Simple manual text entry. Fits casual users who want to compare against peers without leaderboard pressure.
+* **Community Verified:** User pastes a public workout link (Strava, Garmin, Nike Run) or uploads a picture of the machine console/smartwatch screen.
+* **Judge Verified:** One-click validation by an affiliated coach or gym owner through their Pro Dashboard. Automatically upgrades the score to premium global ranking status.
+
+#### 3. Equipment-Agnostic Scaling Engine
+Challenges are designed to be inclusive, offering 3 standardized official scaling options based on available infrastructure:
+* *No Equipment:* Bodyweight, outdoor running, park-ready.
+* *Light Equipment:* Home-gym setups, dumbbells, kettlebells.
+* *Full Gym:* Access to functional fitness boxes, ergs (Row/Ski/Bike), and barbell stations.
+
+#### 4. Growth Loops
+* **Rival Matches:** Automated 1v1 matchmaker pairings against users in the same division with similar Truegrynd Ratings.
+* **Finisher Cards:** High-quality, automated Instagram Story-ready image generation at the completion of weekly events (*"Top 12% Regular — Grit Engine Challenge"*).
+
+### ─── OPTION B2B: L'Espace Pro (Truegrynd Business) ───
+*Focus: Value-driven features justifying the $100/mo fee by saving coaches' time and entertaining members.*
+
+#### 1. TV Broadcaster Mode
+* An optimized, read-only web interface meant to be cast on facilities' large television screens.
+* **Live Arena Effect:** When an athlete submits their score on their personal app in the locker room or gym floor, the TV screen instantly animates, updates the daily local leaderboard, and triggers visual cues representing their faction/team. It replaces the old-school whiteboard with a premium, live sports-broadcast aesthetic.
+
+#### 2. Inter-Box & Inter-Gym Leagues
+* Affiliated gyms can opt-into local, national, or regional digital leagues directly from the dashboard.
+* Truegrynd automates friendly club-vs-club matches (e.g., *Box Antibes vs. Box Marseille*). Gym performance scores are calculated using member averages across scaling groups. This converts isolated, solo workouts into high-retention club pride.
+
+#### 3. The Judge Console (One-Click Verification)
+* A specialized feed aggregating all scores submitted by members assigned to that specific gym.
+* Coaches can quickly review and click "Verify" on performances they witnessed on the floor. This immediately pushes the athlete's score to the highest rank on global boards, valuing both the coach's local authority and the athlete's effort.
+
+#### 4. Automated Hybrid Pacing Assistant
+* Programming hybrid workouts is notoriously difficult for coaches because running/rowing capacities vary heavily per member.
+* **The Feature:** The coach inputs a workout layout (e.g., *3x 1000m Run + 50 Wall Balls*). Truegrynd Pro pulls individual athlete data from their *Passports* and automatically displays targeted, customized splits and pacing strategies directly inside the athletes' apps (e.g., *"Your target split for interval 1: 4m15s"*). The coach delivers advanced individual programming in 2 clicks.
+
+---
+
+## 4. Engineering & Database Blueprint
+
+### Relational Schema Foundations
+To implement this cleanly, the schema uses explicit relations tying athletes to their physical facilities:
+
+```sql
+-- Role Enumeration
+CREATE TYPE user_role AS ENUM ('athlete', 'coach', 'gym_admin', 'platform_admin');
+CREATE TYPE proof_level AS ENUM ('honor', 'community', 'judge_verified');
+
+-- Profiles/Users Table Extensions
+ALTER TABLE public.profiles ADD COLUMN role user_role DEFAULT 'athlete';
+ALTER TABLE public.profiles ADD COLUMN affiliated_gym_id UUID REFERENCES public.gyms(id);
+
+-- Gyms/Affiliates Table (B2B Core)
+CREATE TABLE public.gyms (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    location_city TEXT,
+    owner_id UUID REFERENCES public.profiles(id),
+    subscription_active BOOLEAN DEFAULT false,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+-- Scores Table Extension
+ALTER TABLE public.scores ADD COLUMN proof_status proof_level DEFAULT 'honor';
+ALTER TABLE public.scores ADD COLUMN verified_by_coach_id UUID REFERENCES public.profiles(id);
+ALTER TABLE public.scores ADD COLUMN proof_url TEXT; -- image or external strava link
+
+````
+
+### Security & Multi-Tenancy (Row-Level Security)
+
+Access control is fully enforced via Postgres RLS:
+
+```sql
+-- Example: Pro routes are locked behind role checks
+CREATE POLICY "Allow gym owners to view their own dashboard"
+ON public.gyms FOR ALL
+USING (auth.uid() = owner_id AND role = 'gym_admin');
+
+CREATE POLICY "Allow coaches to view member submissions"
+ON public.scores FOR UPDATE
+USING (
+    EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE profiles.id = auth.uid()
+        AND profiles.role IN ('coach', 'gym_admin')
+        AND profiles.affiliated_gym_id = scores.gym_id
+    )
+);
+
+```
+
+---
+
+## 5. Monetization Strategy & Funnel
+
+1. **Phase 1: B2C Distribution (The Hook)**
+   Launch the free V2.1 features (Weekly Global Challenges, Divisions, Passport). Distribute it locally in regional clubs. Let athletes request their coaches to verify their profiles.
+2. **Phase 2: Product-Led Growth B2B Outreach**
+   When multiple athletes from the same box request verification or share Truegrynd finisher cards on Instagram tagging their gym, trigger a direct offer to the gym owner: _Unlock Truegrynd Pro, get the TV Broadcaster Mode, and enter your gym into the Regional Faction League for $100/mo._
+3. **Phase 3: Deep Retention**
+   Once a facility has configured its TV screen, automated its coaching splits, and got its members hooked on the inter-box league leaderboard, the churn risk drops to near zero.
+
+---
+
+## 6. Target Exit Profile
+
+By combining highly defensible B2B enterprise revenue (SaaS cash-flow with <2% monthly churn) with a highly active B2C network of hybrid fitness athletes, Truegrynd positions itself as a prime acquisition target for:
+
+- Major functional fitness/Hyrox events organizers needing a 52-week top-of-funnel platform.
+- Multi-facility fitness franchises wanting proprietary gamification technology to increase membership retention.
+- Emerging apparel or fitness equipment manufacturers looking to acquire a captive, highly qualified athletic data marketplace in Europe.
+  EOF
+
+```
+
+```

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -3,7 +3,7 @@
 > **MVP core livré.** **V1 sérieuse (sections A–G)** : **livré sur `main`** (PR [#30](https://github.com/igorms-pro/truegrynd/pull/30) → [#55](https://github.com/igorms-pro/truegrynd/pull/55)).  
 > **V2** : stratégie dans [docs/V2_STRATEGY.md](../V2_STRATEGY.md). Angle : compétition fitness accessible, divisions de niveau, weekly challenges, équipes/factions, progression amateur.
 
-**Dernière mise à jour :** 17 mai 2026
+**Dernière mise à jour :** 1 juin 2026
 
 ---
 
@@ -26,16 +26,19 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 
 ## Sommaire backlog
 
-| Bloc                            | Détail dans ce fichier                                  |
-| ------------------------------- | ------------------------------------------------------- |
-| **`/app/admin` (UGC)**          | Section **A** — tâches détaillées (+ **A9–A10** IA tri) |
-| **Mouvements & prescription**   | Section **G** — catalogue mix + règles création         |
-| **Creator Score**               | Section **B**                                           |
-| **Streaks**                     | Section **C**                                           |
-| **Respect (leaderboard)**       | Section **D**                                           |
-| **Referral**                    | Section **E**                                           |
-| **Confiance & plateforme**      | Section **F**                                           |
-| **V2 — Accessible competition** | Section **H** — backlog issue-par-issue                 |
+| Bloc                                      | Détail dans ce fichier                                      |
+| ----------------------------------------- | ----------------------------------------------------------- |
+| **`/app/admin` (UGC)**                    | Section **A** — tâches détaillées (+ **A9–A10** IA tri)     |
+| **Mouvements & prescription**             | Section **G** — catalogue mix + règles création             |
+| **Creator Score**                         | Section **B**                                               |
+| **Streaks**                               | Section **C**                                               |
+| **Respect (leaderboard)**                 | Section **D**                                               |
+| **Referral**                              | Section **E**                                               |
+| **Confiance & plateforme**                | Section **F**                                               |
+| **V1.5 — Pages Faction & symétrie UI**    | Section **I** — arbitrages dock / Clan / Overview           |
+| **V1.5 — Profil épuré & page Historique** | Section **K** — carrousel CARDS + `/app/profile/history`    |
+| **Fix & polish pré-V2 (QA V1)**           | Section **J** — flow soumission score / copy CTA            |
+| **V2 — Accessible competition**           | Section **H** — backlog issue-par-issue (**V2-00** en tête) |
 
 **Macro-checklist**
 
@@ -51,8 +54,18 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 
 **Clôture V1 (macro)** : toutes les lignes ci-dessus sont **livrées en code**. Cases `[ ]` encore présentes dans les sections détaillées = **hors périmètre V1 obligatoire** (tests admin SQL, skeleton, rate limit IA, Sentry, `movement_aliases`, etc.) → traiter en **V1.1** ou issue dédiée.
 
+**Macro V1.5 (avant premier lot V2 compétitif)**
+
+- [ ] **V1.5** — Pages `/app/faction/[slug]` + symétrie Clan / Overview — section **I** (arbitrages ci-dessous)
+- [ ] **V1.5** — Profil épuré + page Historique dédiée (`Show More` → `/app/profile/history`) — section **K**
+
+**Macro pré-V2 (polish post-QA V1, avant V2-01)**
+
+- [ ] **FIX UI** — Flow soumission score (I'M IN → formulaire → SUBMIT) — section **J** (copy + garde-fous ; QA §4)
+
 **Macro V2 proposée (à transformer en GitHub issues avant dev)**
 
+- [ ] **V2-00** — Cadre factions & **exclusions sociales** (pas teams perso / pas DM) + prérequis V1.5 — section **H**
 - [ ] **V2-01** — Divisions de niveau (Rookie / Regular / Savage / Elite)
 - [ ] **V2-02** — Variantes officielles / scaling par challenge
 - [ ] **V2-03** — Weekly Global Challenge
@@ -215,7 +228,7 @@ L’IA n’a pas besoin d’être “hors du repo” au sens code : le **code** 
 - [x] **SEO i18n** : `generateMetadata` dans `[locale]/layout.tsx` — title/description par locale via `next-intl`.
 - [ ] **Observabilité** : Sentry — reporté V1.1 (config externe, hors repo).
 - [x] **Rate limiting** : documenté dans `docs/RUNBOOK.md` — V1 via UNIQUE constraints + admin gates ; V1.1 Edge Function.
-- [x] **Runbook** : `docs/RUNBOOK.md` — promouvoir admin, rollback migration, revue RLS, rate limiting, env vars.
+- [x] **Runbook** : `docs/RUNBOOK.md` — pronamouvoir admin, rollback migration, revue RLS, rate limiting, env vars.
 
 ---
 
@@ -231,11 +244,214 @@ L’IA n’a pas besoin d’être “hors du repo” au sens code : le **code** 
 
 ---
 
+## I. V1.5 — Pages Faction & symétrie Clan / Overview
+
+**Contexte produit (MVP V1.5)** : Truegrynd reste une arène async **B2B2C** — passeport athlète (âge, sexe, poids), **3 factions mondiales** (Iron Alliance, Horde, Nomads), affiliation salle physique **optionnelle** (B2B gym → V3). Dock standard : **Overview · Arena · Clan · Profil** (+ MOD admin).
+
+### Vision dock (rappel)
+
+| Onglet       | Rôle                                                                                                             |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| **Overview** | Dashboard perso, état de **ta** faction, défi du jour, streaks                                                   |
+| **Arena**    | Catalogue défis official + UGC, filtres matériel, création UGC                                                   |
+| **Clan**     | Leaderboard live Faction War + tableau des mercenaires (top faction)                                             |
+| **Profil**   | Vitrine athlète, carrousel Finisher Cards (3–4 récentes), historique filtrable via **Show More** → section **K** |
+
+### Routage factions — `/app/faction/[slug]`
+
+Vues dynamiques par slug (`nomads` \| `horde` \| `iron_alliance`). Charte = couleurs CSS faction (`--faction-*`).
+
+**Règles de clic UI**
+
+| Origine                | Comportement                                                                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview**           | Widget **uniquement ta** faction → clic → `/app/faction/[my_faction_slug]`                                                            |
+| **Clan — Faction War** | Les **3** lignes (ta faction + rivales) **cliquables de façon symétrique** → `/app/faction/[slug]` (rival = espionnage / rivalité OK) |
+| **Clan — Top Dogs**    | Lignes → profil public `/app/u/[username]` (déjà amorcé) ; **ne pas** envoyer la ligne « ta faction » vers Arena seule                |
+
+**Contenu page `/app/faction/[slug]`**
+
+1. **Header** : blason / identité clan + nom en grand (couleur faction).
+2. **Stats guerre** : rang Faction War, points équipe (agrégat V1 = heuristique client tant que pas V2 serveur), combattants actifs (période à préciser en implémentation ; cible produit = « cette semaine »).
+3. **Hall of Fame** : top 5–10 athlètes **de cette faction** (ego + repérer rivaux).
+4. **Si slug = faction utilisateur** : bouton secondaire **Recruter des alliés** (lien referral `?faction=[slug]` — réutiliser `RecruitCta` / `buildReferralUrl`).
+5. **CTA principal (sticky bas)** : **POST A SCORE** / **CONTRIBUER À LA GUERRE** → `/app/arena` (même catalogue pour tous ; **pas** de défis réservés à une faction en V1.5).
+
+### Tâches implémentation V1.5
+
+**Livré sur `chore/qa-v1-prep` (PR à merger)** — socle QA + parcours public ; **pages faction** et symétrie Faction War **restent ouvertes**.
+
+- [x] **Profil public** : `src/app/[locale]/app/u/[username]/page.tsx` — `PublicProfileScreen`, `usePublicProfile`, `getProfileByUsername`.
+- [x] **Clan — Top Dogs** : `ClanTopMembersCard` — lignes → `/app/u/[username]` (soi → `/app/profile`).
+- [x] **Refactor Clan (partiel)** : `ClanFactionWarCard`, `ClanTopMembersCard`, `ClanArenaCta`, `formatClanPoints`, `clanRowLinkClass`.
+- [x] **Challenge detail** : split `ChallengeDetailHero`, panels spec/circuit/locked, `parseChallengeRules`.
+- [x] **Arena pending** : `ArenaPendingSection`, `useMyPendingChallenges` + migration **`013`** `arena_ends_at`.
+- [x] **Admin file** : onglets statut queue + `arenaLifecycle` (helpers + tests).
+- [ ] **Route** : `src/app/[locale]/app/faction/[slug]/page.tsx` + garde slug invalide (404 ou redirect Clan).
+- [ ] **Service / hook** : données faction (rang, pts, membres actifs, top N) — réutiliser / factoriser `getClanHudData` ou équivalent par `faction`.
+- [ ] **UI** : `FactionPageScreen` (header, stats, hall of fame, CTA, recruit si « ma » faction).
+- [ ] **Overview** : widget ta faction → lien vers `/app/faction/[slug]` (pas Clan/Arena direct).
+- [ ] **Clan** : `ClanFactionWarCard` — **3 lignes** → `/app/faction/[slug]` (retirer lien Arena direct sur « ta » ligne).
+- [ ] **i18n EN/FR** : copy page faction + aria labels ; pas de mur de texte type tutoriel Share/Copy.
+- [ ] **QA** : cocher §7 Clan + nouveau parcours faction dans [docs/QA_V1_CHECKLIST.md](../QA_V1_CHECKLIST.md).
+
+**Branche suite :** `feature/v1-5-faction-pages` (issue GitHub dédiée).
+
+---
+
+## J. Fix & polish pré-V2 — flow soumission score (QA V1 §4)
+
+**Contexte QA (juin 2026) :** sur la page détail, le CTA **« I'M IN »** / **« JE M'INSCRIS »** prête à confusion — on croit parfois que le score part tout de suite. En réalité, le code actuel (`ChallengeDetailHero` → `Link` vers `/app/arena/[id]/submit`) **ne fait qu’une navigation** ; l’insert SQL n’a lieu que sur **`ScoreSubmissionScreen`**. Le fix = **clarifier l’UI + verrouiller la logique** avant V2.
+
+**Objectif :** séparer nettement **engagement** (écran A) vs **soumission** (écran B).
+
+### FIX LOGIQUE UI — flow de soumission des défis
+
+Le bouton **« I'M IN »** ne doit **pas** soumettre le score directement en base. Règles :
+
+1. **Écran A — détail défi** : **« I'M IN »** = **navigation uniquement** → ouvre l’écran B **sans rien enregistrer**.
+2. **Écran B — formulaire** (`/app/arena/[id]/submit`) :
+   - score par défaut à **0** (`YOUR REPS` / équivalent time) ;
+   - champ **PROOF URL** optionnel (copy Smart Proof déjà présente) ;
+   - bouton **persistant en bas** : **« SUBMIT YOUR SCORE »** / **« SOUMETTRE MON SCORE »**.
+3. **Seul** le clic sur **« SUBMIT YOUR SCORE »** :
+   - valide les inputs (Zod) ;
+   - applique la règle **Smart Proof / top 10%** (vidéo obligatoire si elite) ;
+   - exécute l’**insert** score en base.
+
+### Tâches
+
+- [ ] **Copy EN/FR** : renommer ou clarifier le CTA détail (ex. garder kicker « ENTER THE GRIND » mais CTA explicite **POST SCORE** / **SOUMETTRE**, ou renforcer la subline sous I'M IN).
+- [ ] **Audit code** : confirmer qu’aucun handler sur I'M IN n’appelle `submitScore` / insert Supabase (aujourd’hui : OK via `Link` seul — documenter en test).
+- [ ] **Écran B** : bouton submit sticky bas viewport ; états loading / disabled / error inchangés.
+- [ ] **Tests** : RTL ou e2e — clic I'M IN → **0 insert** ; submit valide → 1 insert ; §4 checklist [docs/QA_V1_CHECKLIST.md](../QA_V1_CHECKLIST.md).
+- [ ] **GitHub Issue** + branche `fix/issue-N-submit-flow-cta` avant merge.
+
+**Fichiers probables :** `ChallengeDetailHero.tsx`, `ScoreSubmissionScreen` (+ hooks/services submit), `src/locales/en.json` / `fr.json` (`challenge.ctaStart`, `ctaSubline`, submit.\*).
+
+**Priorité :** **avant V2-01** (avec ou juste après V1.5 + fin QA §4) — pas bloquant divisions, mais **bloquant clarté produit** sur le cœur Arena.
+
+**Branche suggérée :** `fix/submit-flow-cta` ou issue dédiée post-`chore/qa-v1-prep`.
+
+---
+
+## K. V1.5 — Profil épuré & page Historique (Show More)
+
+**Contexte produit :** le carrousel horizontal **CARDS** (`FinisherGallery`) convient pour parcourir les **3–4 dernières** performances — au-delà, swiper 50 fois est invivable. La section **HISTORY** (`ScoreHistory`) en bas du profil **duplique** l’info et surcharge l’écran principal. On sépare : **vitrine épurée** sur `/app/profile` vs **registre de guerre filtrable** sur `/app/profile/history`.
+
+**État actuel (juin 2026) :** `ProfilePage` compose `ProfileHeader` + `SignOutButton` + `FinisherGallery` (toutes les cartes validées) + `ScoreHistory` (liste complète). Pas de route history dédiée ; pas de filtres par statut.
+
+### Vision UX
+
+```
+ÉCRAN PROFIL PRINCIPAL (/app/profile)
++-------------------------------------------------------+
+|  PROFILE                                         ⚙️   |
+|  [ Photo ]  IGORMS (IRON ALLIANCE)                    |
++-------------------------------------------------------+
+|  CARDS                             [ SHOW MORE ➔ ]   |
+|  (Scroll X — 3 ou 4 dernières cartes max)             |
+|  +------------+  +------------+  +------------+       |
+|  | TRUEGRYND  |  | TRUEGRYND  |  | TRUEGRYND  |       |
+|  +------------+  +------------+  +------------+       |
++-------------------------------------------------------+
+  (plus de section HISTORY ici)
+
+      ⬇️ Show More → /app/profile/history
+
+PAGE HISTORIQUE (/app/profile/history)
++-------------------------------------------------------+
+|  ➔  MON HISTORIQUE                                    |
+|  [ Tout ] [ En cours ⏳ ] [ Validés 🔥 ] [ Sauvegardés ] [ Gagnés 🏆 ] |
+|  +-------------------------------------------------+  |
+|  | QA OFFICIAL — BURPEES                [ RANKED ] |  |
+|  | 07:10 · 6/1/2026                       [ CARD ] |  |
+|  +-------------------------------------------------+  |
+|  | SANDBAG CHALLENGE               [ IN PROGRESS ] |  |
+|  +-------------------------------------------------+  |
++-------------------------------------------------------+
+```
+
+### 1. Écran profil principal (`/app/profile`)
+
+- [ ] **Supprimer** `ScoreHistory` du bas de la page — **définitif**, pas de doublon.
+- [ ] **Carrousel CARDS** : limiter `FinisherGallery` aux **3 ou 4 cartes les plus récentes** (tri `created_at` desc).
+- [ ] **Bouton « Show More »** (`SHOW MORE ➔`) : en haut à droite de la section CARDS (à côté du titre) → lien `/app/profile/history`.
+- [ ] **Settings ⚙️** : icône en haut à droite à côté du titre **PROFILE** ; y déplacer **Log out** (retirer `SignOutButton` visible du corps de page).
+- [ ] **i18n EN/FR** : `profile.cards.showMore`, `profile.settings.*`, titres section.
+
+### 2. Nouvelle route `/app/profile/history`
+
+- [ ] **Route** : `src/app/[locale]/app/profile/history/page.tsx` — page fine, compose un `ProfileHistoryScreen`.
+- [ ] **Header** : retour + titre « Mon historique » / « My history ».
+- [ ] **Barre de filtres (tabs rapides)** :
+  - **Tout** — historique global (scores + engagements en cours).
+  - **En cours** — défis où l’utilisateur a cliqué **I'M IN** mais **pas encore** de score soumis (to-do entraînements).
+  - **Validés** — scores `is_validated: true` / badge **RANKED** (preuve vidéo, classés).
+  - **Sauvegardés** — scores honor level sans vidéo / badge **SAVED**.
+  - **Gagnés** _(option V1.5+)_ — coups d’éclat : top 10 % validés et/ou défis officiels avec badge (règle exacte à figer en implémentation).
+- [ ] **Ligne d’historique** : titre défi, score formaté, date, badge statut (`RANKED` \| `SAVED` \| `IN PROGRESS`), action **CARD** (re-voir / re-télécharger la Finisher Card si applicable).
+- [ ] **États complets** : loading / empty / error / default par filtre ; empty copy contextualisé (« Aucun défi en cours », etc.).
+- [ ] **Hook / service** : étendre ou factoriser `useMyScores` + source « en cours » (table/commitment I'M IN — à préciser : score absent vs flag engagement si modèle ajouté plus tard ; en V1.5 heuristique = pas de row `scores` pour ce `challenge_id`).
+
+### 3. Données & statuts
+
+| Filtre UI       | Règle V1.5 (MVP)                                                                    |
+| --------------- | ----------------------------------------------------------------------------------- |
+| **Tout**        | Union scores soumis + engagements en cours sans score                               |
+| **En cours**    | Challenge visité via I'M IN, **aucun** score user pour ce `challenge_id`            |
+| **Validés**     | `scores.is_validated = true`                                                        |
+| **Sauvegardés** | `scores.is_validated = false` (score existant)                                      |
+| **Gagnés**      | Sous-ensemble Validés : top 10 % (`rankPercent ≤ 10`) ou tag official (à confirmer) |
+
+> **Note :** sans persistance explicite de « I'M IN » en V1, le filtre **En cours** peut démarrer en **placeholder** (liste vide + copy) ou s’appuyer sur une future table `challenge_commitments` — documenter le choix dans la PR.
+
+### 4. Qualité & DoD
+
+- [ ] **Tests** : filtrage pur (helper `filterHistoryByTab`) + au moins un test composant ou RTL sur tabs.
+- [ ] **QA** : ajouter parcours profil → Show More → filtres dans [docs/QA_V1_CHECKLIST.md](../QA_V1_CHECKLIST.md).
+- [ ] **Accessibilité** : tabs avec rôles ARIA, `aria-label` sur Show More et Settings.
+- [ ] **Pas de régression** : profil public `/app/u/[username]` hors scope (pas de page history publique en V1.5).
+
+**Fichiers probables :** `src/app/[locale]/app/profile/page.tsx`, `FinisherGallery.tsx`, `ScoreHistory.tsx` (réutiliser lignes sur history page), nouveau `ProfileHistoryScreen.tsx`, `useProfileHistory.ts`, `src/locales/en.json` / `fr.json`.
+
+**Priorité :** **V1.5**, avec ou juste après section **I** (faction pages) — **avant V2-06** (Passport) qui capitalisera sur cette base historique.
+
+**Branche suggérée :** `feature/v1-5-profile-history` (GitHub Issue dédiée avant dev).
+
+---
+
 ## H. V2 — Accessible Competitive Fitness
 
 **Décision produit :** ne pas copier les gros events fitness. Truegrynd attaque leur angle mort : **l'énergie compétition sans ticket à 110 €, sans déplacement, sans élitisme**. Les gens jouent **dans leur division**, avec **leur team**, contre des gens de niveau comparable. Le leaderboard global reste une vitrine, pas l'expérience principale.
 
 Référence stratégie : [docs/V2_STRATEGY.md](../V2_STRATEGY.md).
+
+### V2-00. Cadre Factions & Exclusions Sociales (lire avant V2-07 / V2-08)
+
+**Objectif :** figer ce que Truegrynd **n’est pas** en V2 early, et ce qui est **déjà couvert en V1.5** avant d’attaquer divisions, weekly et Team Wars.
+
+**Exclusions explicites (ne pas coder)**
+
+- [ ] **Pas** de sous-équipes / « team perso avec des potos » privée hors des 3 factions mondiales.
+- [ ] **Pas** de messagerie privée (DM), **pas** de graphe Follow/Unfollow.
+- [ ] **Pas** de catalogue de défis « Horde only » / « Iron only » — la faction est un **camp de guerre**, pas un mode de jeu séparé.
+- [ ] **Interaction sociale MVP** : uniquement **👊 Respect** (`+1`) sur lignes de leaderboard ; le reste = referral faction + vitrines publiques.
+
+**Effet de groupe autorisé en V1 / V1.5**
+
+- Parrainage **faction globale** (`?faction=` + Recruit).
+- Affiliation **salle physique** (piste B2B → [docs/V3_STRATEGY.md](../V3_STRATEGY.md)).
+- Pages **`/app/faction/[slug]`** symétriques (section **I**) : overview rivale, hall of fame, CTA Arena.
+
+**Ce que V2 ajoute par-dessus (issues suivantes, pas en V1.5)**
+
+- [ ] **V2-01–03** : divisions, scaling, weekly → compétition **par niveau**, pas par team custom.
+- [ ] **V2-08** : Team Wars / Faction Wars **par division** — score équipe **serveur**, events, contribution perso (remplace l’heuristique Clan HUD).
+- [ ] **V2-09** : micro-events (Faction War Weekend, etc.).
+- [ ] **V2-07** : Rival Matches — duel 1v1 / petit groupe sur défis, **pas** remplacement des 3 factions.
+
+**Prérequis avant de démarrer V2-01 :** section **I (V1.5)** livrée + QA Clan/faction OK.
 
 ### V2-01. Divisions De Niveau
 
@@ -360,22 +576,25 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 
 ## Suivi synthétique
 
-| Bloc                                     | Avancement                                                                                                                    |
-| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| UGC création + cap                       | 🟢 PR #30                                                                                                                     |
-| Doc backlog V1 (ce fichier)              | 🟢 [#31](https://github.com/igorms-pro/truegrynd/issues/31) mergé — PR [#32](https://github.com/igorms-pro/truegrynd/pull/32) |
-| Doc tri IA + mouvements mix (ce fichier) | 🟢 [#35](https://github.com/igorms-pro/truegrynd/issues/35) mergé — PR [#36](https://github.com/igorms-pro/truegrynd/pull/36) |
-| **`/app/admin`**                         | 🟢 PR #41 mergé (admin + AI triage)                                                                                           |
-| Creator Score                            | 🟢 [#46](https://github.com/igorms-pro/truegrynd/issues/46) mergé — PR [#47](https://github.com/igorms-pro/truegrynd/pull/47) |
-| Streaks                                  | 🟢 [#48](https://github.com/igorms-pro/truegrynd/issues/48) mergé — PR [#49](https://github.com/igorms-pro/truegrynd/pull/49) |
-| Respect                                  | 🟢 [#50](https://github.com/igorms-pro/truegrynd/issues/50) mergé — PR [#51](https://github.com/igorms-pro/truegrynd/pull/51) |
-| Referral                                 | 🟢 [#52](https://github.com/igorms-pro/truegrynd/issues/52) mergé — PR [#53](https://github.com/igorms-pro/truegrynd/pull/53) |
-| Confiance / plateforme                   | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55) |
-| Mouvements / prescription (mix)          | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45) |
-| **V2 — Accessible competition**          | 🔴 cadré dans [docs/V2_STRATEGY.md](../V2_STRATEGY.md) — issues candidates **V2-01 → V2-12** en section **H**                 |
-| **QA V1 (manuel)**                       | 🟡 [docs/QA_V1_CHECKLIST.md](../QA_V1_CHECKLIST.md) — à cocher avant V2-01                                                    |
+| Bloc                                      | Avancement                                                                                                                    |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| UGC création + cap                        | 🟢 PR #30                                                                                                                     |
+| Doc backlog V1 (ce fichier)               | 🟢 [#31](https://github.com/igorms-pro/truegrynd/issues/31) mergé — PR [#32](https://github.com/igorms-pro/truegrynd/pull/32) |
+| Doc tri IA + mouvements mix (ce fichier)  | 🟢 [#35](https://github.com/igorms-pro/truegrynd/issues/35) mergé — PR [#36](https://github.com/igorms-pro/truegrynd/pull/36) |
+| **`/app/admin`**                          | 🟢 PR #41 mergé (admin + AI triage)                                                                                           |
+| Creator Score                             | 🟢 [#46](https://github.com/igorms-pro/truegrynd/issues/46) mergé — PR [#47](https://github.com/igorms-pro/truegrynd/pull/47) |
+| Streaks                                   | 🟢 [#48](https://github.com/igorms-pro/truegrynd/issues/48) mergé — PR [#49](https://github.com/igorms-pro/truegrynd/pull/49) |
+| Respect                                   | 🟢 [#50](https://github.com/igorms-pro/truegrynd/issues/50) mergé — PR [#51](https://github.com/igorms-pro/truegrynd/pull/51) |
+| Referral                                  | 🟢 [#52](https://github.com/igorms-pro/truegrynd/issues/52) mergé — PR [#53](https://github.com/igorms-pro/truegrynd/pull/53) |
+| Confiance / plateforme                    | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55) |
+| Mouvements / prescription (mix)           | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45) |
+| **V1.5 — Pages Faction**                  | 🟡 section **I** — profil public + Clan refactor **mergés** ; reste `/app/faction/[slug]` + liens Overview/Clan               |
+| **V1.5 — Profil & Historique**            | 🔴 spec section **K** — carrousel 3–4 cartes + `/app/profile/history` + filtres (Show More)                                   |
+| **Fix flow submit (I'M IN → formulaire)** | 🔴 section **J** — polish pré-V2 (QA V1 §4, copy CTA)                                                                         |
+| **V2 — Accessible competition**           | 🔴 [docs/V2_STRATEGY.md](../V2_STRATEGY.md) — **V2-00** (exclusions) puis **V2-01 → V2-12** section **H**                     |
+| **QA V1 (manuel)**                        | 🟡 [docs/QA_V1_CHECKLIST.md](../QA_V1_CHECKLIST.md) — à cocher ; ajouter parcours faction après V1.5                          |
 
-**Suite produit :** V1 macro **terminée**. Prochaine priorité = **QA V1** ([checklist](../QA_V1_CHECKLIST.md)), puis choisir le premier lot **V2** : recommandation produit = **V2-01 → V2-03** (divisions, scaling, weekly challenge).
+**Suite produit :** V1 macro **terminée**. Prochaine priorité = finir **V1.5 (sections I + K)** + **QA V1** (+ **section J** si ambiguïté submit confirmée en §4), puis **V2-00** (cadrage) + lot **V2-01 → V2-03** (divisions, scaling, weekly). **Ne pas** sauter V1.5 pour coder des « teams perso ».
 
 ---
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -1,7 +1,7 @@
-# Truegrynd – Backlog V1 (strong)
+# Truegrynd – Backlog V1 / V2
 
 > **MVP core livré.** **V1 sérieuse (sections A–G)** : **livré sur `main`** (PR [#30](https://github.com/igorms-pro/truegrynd/pull/30) → [#55](https://github.com/igorms-pro/truegrynd/pull/55)).  
-> Ce fichier reste la référence ; les cases `[ ]` restantes sont **optionnelles** ou **V1.1** (voir fin de section A et blocs B–G).
+> **V2** : stratégie dans [docs/V2_STRATEGY.md](../V2_STRATEGY.md). Angle : compétition fitness accessible, divisions de niveau, weekly challenges, équipes/factions, progression amateur.
 
 **Dernière mise à jour :** 17 mai 2026
 
@@ -26,15 +26,16 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 
 ## Sommaire backlog
 
-| Bloc                          | Détail dans ce fichier                                  |
-| ----------------------------- | ------------------------------------------------------- |
-| **`/app/admin` (UGC)**        | Section **A** — tâches détaillées (+ **A9–A10** IA tri) |
-| **Mouvements & prescription** | Section **G** — catalogue mix + règles création         |
-| **Creator Score**             | Section **B**                                           |
-| **Streaks**                   | Section **C**                                           |
-| **Respect (leaderboard)**     | Section **D**                                           |
-| **Referral**                  | Section **E**                                           |
-| **Confiance & plateforme**    | Section **F**                                           |
+| Bloc                            | Détail dans ce fichier                                  |
+| ------------------------------- | ------------------------------------------------------- |
+| **`/app/admin` (UGC)**          | Section **A** — tâches détaillées (+ **A9–A10** IA tri) |
+| **Mouvements & prescription**   | Section **G** — catalogue mix + règles création         |
+| **Creator Score**               | Section **B**                                           |
+| **Streaks**                     | Section **C**                                           |
+| **Respect (leaderboard)**       | Section **D**                                           |
+| **Referral**                    | Section **E**                                           |
+| **Confiance & plateforme**      | Section **F**                                           |
+| **V2 — Accessible competition** | Section **H** — backlog issue-par-issue                 |
 
 **Macro-checklist**
 
@@ -49,6 +50,21 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 - [x] **FEAT / CHORE** — Confiance & plateforme — section **F** — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55)
 
 **Clôture V1 (macro)** : toutes les lignes ci-dessus sont **livrées en code**. Cases `[ ]` encore présentes dans les sections détaillées = **hors périmètre V1 obligatoire** (tests admin SQL, skeleton, rate limit IA, Sentry, `movement_aliases`, etc.) → traiter en **V1.1** ou issue dédiée.
+
+**Macro V2 proposée (à transformer en GitHub issues avant dev)**
+
+- [ ] **V2-01** — Divisions de niveau (Rookie / Regular / Savage / Elite)
+- [ ] **V2-02** — Variantes officielles / scaling par challenge
+- [ ] **V2-03** — Weekly Global Challenge
+- [ ] **V2-04** — Leaderboards par division, faction, ville, pays
+- [ ] **V2-05** — Truegrynd Rating (Engine / Power / Strength / Grit / Consistency)
+- [ ] **V2-06** — Challenge Passport / palmarès amateur
+- [ ] **V2-07** — Rival Matches (1v1 / petits groupes)
+- [ ] **V2-08** — Team Wars / Faction Wars par division
+- [ ] **V2-09** — Micro-events async (24h / 7j / 30j)
+- [ ] **V2-10** — Proof Levels (Honor / Video / Community / Judge / Event)
+- [ ] **V2-11** — Growth loops (cards, invitations, comeback weeks)
+- [ ] **V2-12** — Monétisation exploratoire (après signal d'usage)
 
 ---
 
@@ -215,6 +231,117 @@ L’IA n’a pas besoin d’être “hors du repo” au sens code : le **code** 
 
 ---
 
+## H. V2 — Accessible Competitive Fitness
+
+**Décision produit :** ne pas copier les gros events fitness. Truegrynd attaque leur angle mort : **l'énergie compétition sans ticket à 110 €, sans déplacement, sans élitisme**. Les gens jouent **dans leur division**, avec **leur team**, contre des gens de niveau comparable. Le leaderboard global reste une vitrine, pas l'expérience principale.
+
+Référence stratégie : [docs/V2_STRATEGY.md](../V2_STRATEGY.md).
+
+### V2-01. Divisions De Niveau
+
+- [ ] **Produit** : définir les divisions canoniques V2 : `rookie`, `regular`, `savage`, `elite` (noms finaux à confirmer).
+- [ ] **Règle d'entrée** : chaque utilisateur a une division par défaut (`rookie`) puis peut monter selon performance / rating.
+- [ ] **DB** : ajouter une représentation stable des divisions (enum/check ou table `divisions`) + champ dérivé côté profil ou rating.
+- [ ] **UI** : badge division visible sur profil, leaderboard, finisher card.
+- [ ] **Leaderboard** : filtre division par défaut, global disponible mais secondaire.
+- [ ] **i18n EN/FR** + tests de mapping division.
+
+### V2-02. Variantes Officielles / Scaling Par Challenge
+
+- [ ] **Produit** : chaque challenge important peut avoir des variantes officielles : no equipment, bodyweight, dumbbell, standard, savage.
+- [ ] **DB** : modèle `challenge_variants` ou champ structuré validé (éviter texte libre non exploitable).
+- [ ] **Création défi** : auteur choisit au moins une variante ; admin voit le niveau de friction / matériel.
+- [ ] **Soumission** : score attaché à une variante précise.
+- [ ] **Leaderboard** : classement par variante + division.
+- [ ] **UX** : copy claire : scaling officiel ≠ mode honteux.
+
+### V2-03. Weekly Global Challenge
+
+- [ ] **Produit** : un défi global par semaine, simple, partageable, jouable partout.
+- [ ] **DB** : table ou champs pour `weekly_challenges` (challenge_id, starts_at, ends_at, status).
+- [ ] **App** : bloc homepage/overview “Weekly Challenge” avec CTA score.
+- [ ] **Leaderboards** : division + faction + ville/pays.
+- [ ] **Finisher Card** : variante weekly avec badge semaine.
+- [ ] **Admin** : choisir / programmer le weekly sans migration.
+
+### V2-04. Leaderboards Par Division, Faction, Ville, Pays
+
+- [ ] **Produit** : permettre “Top Rookie Paris”, “Horde Regular France”, “Savage Global”.
+- [ ] **Profil** : ajouter ville/pays optionnels ou inférés prudemment (pas de géoloc invasive V2.1).
+- [ ] **DB / query** : index et filtres performants pour division + faction + location.
+- [ ] **UI leaderboard** : presets simples plutôt qu'un panneau de filtres monstrueux.
+- [ ] **Privacy** : ne pas afficher une localisation trop précise par défaut.
+
+### V2-05. Truegrynd Rating
+
+- [ ] **Produit** : rating global + axes `engine`, `power`, `strength`, `grit`, `consistency`.
+- [ ] **Algorithme V1** : commencer simple (percentiles validés + catégories de challenge), pas d'Elo opaque au début.
+- [ ] **DB** : table `profile_ratings` ou colonnes dédiées + historique minimal.
+- [ ] **Jobs/triggers** : recalcul à la soumission validée ou job périodique.
+- [ ] **UI** : carte rating sur profil + explication lisible.
+- [ ] **Tests** : fonctions pures de calcul rating + cas de bord (peu de scores, anciens scores, changement division).
+
+### V2-06. Challenge Passport / Palmarès Amateur
+
+- [ ] **Produit** : transformer le profil en CV compétitif amateur.
+- [ ] **Contenu** : divisions atteintes, meilleurs scores, badges, weekly complétés, rival matches gagnés, finisher cards.
+- [ ] **UI** : page/onglet “Passport” mobile-first.
+- [ ] **Share** : lien public optionnel ou image partageable.
+- [ ] **Privacy** : permettre de masquer certains détails.
+
+### V2-07. Rival Matches
+
+- [ ] **Produit** : 1v1 ou petit groupe sur 1 à 3 challenges, durée 24h/7j.
+- [ ] **Matching** : même division par défaut ; option faction adverse / ami / ville.
+- [ ] **DB** : `rival_matches`, participants, challenge set, status, winner.
+- [ ] **UX** : créer, accepter, soumettre, résultat.
+- [ ] **Notifications** : minimal V2 (email/toast/polling), pas besoin d'un réseau social complet.
+- [ ] **Anti-abus** : refuser spam d'invitations.
+
+### V2-08. Team Wars / Faction Wars Par Division
+
+- [ ] **Produit** : guerre collective hebdo : faction x division x challenge.
+- [ ] **Score équipe** : agrégat robuste (ex. top N scores + participation) pour éviter qu'une grosse faction écrase tout.
+- [ ] **UI** : scoreboard faction, contribution personnelle, reward/badge.
+- [ ] **Fairness** : divisions séparées, pas Rookie contre Elite.
+- [ ] **Finisher Card** : “I scored for Horde Rookie”.
+
+### V2-09. Micro-Events Async
+
+- [ ] **Produit** : events 24h / 7j / 30j sans lieu physique : Rookie Week, No Equipment Cup, Faction War Weekend.
+- [ ] **DB** : `events`, `event_challenges`, `event_scores`, status.
+- [ ] **Admin** : créer/programmer un event depuis l'admin.
+- [ ] **Classements** : event leaderboard + divisions.
+- [ ] **Fin** : recap, badges, cards, classement final.
+- [ ] **Ops** : pas de paiement au départ ; prouver l'engagement avant monétisation.
+
+### V2-10. Proof Levels
+
+- [ ] **Produit** : niveaux de preuve : Honor, Video Ranked, Community Verified, Judge Verified, Event Verified.
+- [ ] **DB** : champ `proof_level` côté score + audit de validation.
+- [ ] **UI** : badge preuve sur leaderboard et profil.
+- [ ] **Règles** : certains classements peuvent filtrer `video_ranked+` ou `judge_verified+`.
+- [ ] **Admin/judge** : validation manuelle sans service_role client.
+- [ ] **Trust** : reporting abus lié au score.
+
+### V2-11. Growth Loops
+
+- [ ] **Finisher cards V2** : division, rating delta, faction contribution, weekly badge.
+- [ ] **Invitations** : inviter quelqu'un sur un rival match ou weekly challenge.
+- [ ] **Comeback weeks** : relancer ceux qui ont raté 1-2 semaines sans culpabilisation.
+- [ ] **Referral V2** : faction + division context (“Join Horde Rookie Week”).
+- [ ] **Analytics** : mesurer share → signup → first score.
+
+### V2-12. Monétisation Exploratoire
+
+- [ ] **Principe** : ne pas bloquer le core compétitif trop tôt.
+- [ ] **Hypothèses** : premium passport, cosmetics cards, micro-event packs, sponsor challenges, gym/team dashboards.
+- [ ] **Validation** : attendre signal d'usage (weekly retention, rival completion, share rate).
+- [ ] **Stripe** : seulement après choix clair d'une offre.
+- [ ] **No pay-to-win** : payer ne doit jamais améliorer un rang sportif.
+
+---
+
 ## Légende
 
 🔴 not started · 🟡 in progress · 🟢 done · ⏸️ blocked · 🔵 QA · 🟣 on hold  
@@ -245,8 +372,10 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | Referral                                 | 🟢 [#52](https://github.com/igorms-pro/truegrynd/issues/52) mergé — PR [#53](https://github.com/igorms-pro/truegrynd/pull/53) |
 | Confiance / plateforme                   | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55) |
 | Mouvements / prescription (mix)          | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45) |
+| **V2 — Accessible competition**          | 🔴 cadré dans [docs/V2_STRATEGY.md](../V2_STRATEGY.md) — issues candidates **V2-01 → V2-12** en section **H**                 |
+| **QA V1 (manuel)**                       | 🟡 [docs/QA_V1_CHECKLIST.md](../QA_V1_CHECKLIST.md) — à cocher avant V2-01                                                    |
 
-**Suite produit :** V1 macro **terminée**. Prochaine priorité = **QA smoke** (manuel) puis backlog **V1.1** (Sentry, file admin reports, rate limit IA, polish admin UX, etc.) — à définir dans une nouvelle section ou issues GitHub dédiées.
+**Suite produit :** V1 macro **terminée**. Prochaine priorité = **QA V1** ([checklist](../QA_V1_CHECKLIST.md)), puis choisir le premier lot **V2** : recommandation produit = **V2-01 → V2-03** (divisions, scaling, weekly challenge).
 
 ---
 

--- a/src/app/[locale]/app/finish/page.tsx
+++ b/src/app/[locale]/app/finish/page.tsx
@@ -2,26 +2,22 @@
 
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
-import { useEffect, useMemo, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useRef } from 'react';
 
 import { FinisherCardActions } from '@/features/finisher-card/components/FinisherCardActions';
 import { drawFinisherCard } from '@/features/finisher-card/lib/drawCard';
 import { useFinisherCard } from '@/features/finisher-card/hooks/useFinisherCard';
 
-type SearchParams = {
-  challengeId?: string;
-  ranked?: string;
-  scoreId?: string;
-};
-
-export default function FinishPage({ searchParams }: { searchParams: SearchParams }) {
+function FinishPageContent() {
   const t = useTranslations('finisher');
   const locale = useLocale();
+  const searchParams = useSearchParams();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const ranked = searchParams.ranked === 'true';
-  const scoreId = searchParams.scoreId ?? null;
-  const challengeId = searchParams.challengeId ?? null;
+  const ranked = searchParams.get('ranked') === 'true';
+  const scoreId = searchParams.get('scoreId');
+  const challengeId = searchParams.get('challengeId');
   const state = useFinisherCard({ ranked, scoreId, challengeId });
 
   const cardOptions = useMemo(() => {
@@ -35,6 +31,8 @@ export default function FinishPage({ searchParams }: { searchParams: SearchParam
       scoreType: state.challenge.score_type,
       scoreValue: state.score.value,
       topPercent: state.topPercent,
+      rankTextOverride: state.score.is_validated ? 'RANKED' : 'SAVED',
+      rankSubOverride: state.score.is_validated ? 'VALIDATED' : 'NO VIDEO',
     };
   }, [state]);
 
@@ -116,5 +114,21 @@ export default function FinishPage({ searchParams }: { searchParams: SearchParam
         {t('backToArena')}
       </Link>
     </section>
+  );
+}
+
+export default function FinishPage() {
+  const t = useTranslations('finisher');
+
+  return (
+    <Suspense
+      fallback={
+        <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+          {t('loading')}
+        </p>
+      }
+    >
+      <FinishPageContent />
+    </Suspense>
   );
 }

--- a/src/app/[locale]/app/u/[username]/page.tsx
+++ b/src/app/[locale]/app/u/[username]/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { PublicProfileScreen } from '@/features/profile/components/PublicProfileScreen';
+
+export default function PublicProfilePage() {
+  const params = useParams();
+  const raw = params.username;
+  const username = typeof raw === 'string' ? decodeURIComponent(raw) : '';
+
+  return <PublicProfileScreen username={username} />;
+}

--- a/src/features/admin/components/AdminChallengeQueue.tsx
+++ b/src/features/admin/components/AdminChallengeQueue.tsx
@@ -14,9 +14,10 @@ import { AdminPendingChallengesTable } from '@/features/admin/components/AdminPe
 import { AdminQueueBatchToolbar } from '@/features/admin/components/AdminQueueBatchToolbar';
 import { AdminQueueFilters } from '@/features/admin/components/AdminQueueFilters';
 import { AdminQueuePagination } from '@/features/admin/components/AdminQueuePagination';
+import { AdminQueueStatusTabs } from '@/features/admin/components/AdminQueueStatusTabs';
 import { useAdminChallengeQueueUi } from '@/features/admin/hooks/useAdminChallengeQueueUi';
 import { useAdminPendingChallenges } from '@/features/admin/hooks/useAdminPendingChallenges';
-import { useAdminQueueSubmittedLabels } from '@/features/admin/hooks/useAdminQueueSubmittedLabels';
+import { useAdminQueueRowLabels } from '@/features/admin/hooks/useAdminQueueRowLabels';
 import { adminQueueMaxPage } from '@/features/admin/lib/adminQueueConstants';
 import { formatAdminAnalyzeError } from '@/features/admin/lib/formatAdminAnalyzeError';
 import type { AdminPendingChallenge as PendingRow } from '@/features/admin/services/adminChallenges';
@@ -33,6 +34,8 @@ export function AdminChallengeQueue() {
     page,
     setPage,
     pageSize,
+    statusFilter,
+    setStatusFilter,
     tierFilter,
     setTierFilter,
     riskFirst,
@@ -41,22 +44,24 @@ export function AdminChallengeQueue() {
     approveOne,
     batchApprove,
     rejectOne,
+    closeOne,
     analyzeOne,
     analyzeBusyId,
+    statusCounts,
   } = useAdminPendingChallenges();
 
   const [batchGreenOnly, setBatchGreenOnly] = useState(false);
   const [analyzeError, setAnalyzeError] = useState<string | null>(null);
 
+  const isPendingTab = statusFilter === 'pending';
   const rows = useMemo((): PendingRow[] => {
     return state.status === 'ready' ? state.rows : [];
   }, [state]);
 
   const totalCount = state.status === 'ready' ? state.totalCount : 0;
   const totalPages = adminQueueMaxPage(totalCount, pageSize);
-
   const allIds = useMemo(() => rows.map((r) => r.id), [rows]);
-  const rowsWithLabels = useAdminQueueSubmittedLabels(rows, locale);
+  const rowsWithLabels = useAdminQueueRowLabels(rows, locale, statusFilter);
 
   const formatActionError = useCallback(
     (message: string) => `${tErr('actionFailed')} (${message})`,
@@ -89,6 +94,19 @@ export function AdminChallengeQueue() {
     formatActionError,
     batchGreenOnly,
   });
+
+  const handleCloseRow = useCallback(
+    async (id: string) => {
+      setAnalyzeError(null);
+      try {
+        await closeOne(id);
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        setAnalyzeError(formatActionError(message));
+      }
+    },
+    [closeOne, formatActionError],
+  );
 
   const handleAnalyzeRow = useCallback(
     async (id: string) => {
@@ -125,57 +143,83 @@ export function AdminChallengeQueue() {
     setApproveTarget(null);
   }, [setApproveTarget]);
 
-  if (state.status === 'loading') {
-    return <AdminChallengeQueueLoading />;
-  }
-
-  if (state.status === 'error') {
-    return <AdminChallengeQueueFetchError message={state.error} onRetry={refetch} />;
-  }
-
-  if (state.status === 'ready' && state.totalCount === 0) {
-    return <AdminChallengeQueueEmpty />;
-  }
+  const showTable = state.status === 'ready' && totalCount > 0;
+  const showEmpty = state.status === 'ready' && totalCount === 0;
 
   return (
     <div className="space-y-4">
-      <AdminChallengeQueueBanner message={actionError ?? analyzeError} />
-      <AdminQueueFilters
-        tierFilter={tierFilter}
-        onTierFilterChange={setTierFilter}
-        riskFirst={riskFirst}
-        onRiskFirstChange={setRiskFirst}
-        batchGreenOnly={batchGreenOnly}
-        onBatchGreenOnlyChange={setBatchGreenOnly}
-        disabled={interactionLocked}
+      <AdminQueueStatusTabs
+        active={statusFilter}
+        counts={statusCounts}
+        onChange={setStatusFilter}
+        disabled={interactionLocked || state.status === 'loading'}
       />
-      <AdminQueueBatchToolbar
-        batchBusy={batchBusy}
-        rowBusy={interactionLocked}
-        selectedCount={selected.size}
-        onSelectAll={handleSelectAll}
-        onClearSelection={clearSelection}
-        onRequestBatchApprove={handleBatchClick}
-      />
-      <AdminPendingChallengesTable
-        rowsWithLabels={rowsWithLabels}
-        selected={selected}
-        busyId={busyId}
-        analyzeBusyId={analyzeBusyId}
-        analyzeDisabled={!accessToken}
-        onToggle={toggle}
-        onApproveRow={requestApproveRow}
-        onRejectRow={openReject}
-        onAnalyzeRow={handleAnalyzeRow}
-      />
-      <AdminQueuePagination
-        page={page}
-        totalPages={totalPages}
-        totalCount={totalCount}
-        disabled={interactionLocked}
-        onPrev={goPrevPage}
-        onNext={goNextPage}
-      />
+
+      {state.status === 'loading' ? <AdminChallengeQueueLoading /> : null}
+
+      {state.status === 'error' ? (
+        <AdminChallengeQueueFetchError message={state.error} onRetry={refetch} />
+      ) : null}
+
+      {state.status === 'ready' ? (
+        <>
+          <AdminChallengeQueueBanner message={actionError ?? analyzeError} />
+
+          {isPendingTab ? (
+            <>
+              <AdminQueueFilters
+                tierFilter={tierFilter}
+                onTierFilterChange={setTierFilter}
+                riskFirst={riskFirst}
+                onRiskFirstChange={setRiskFirst}
+                batchGreenOnly={batchGreenOnly}
+                onBatchGreenOnlyChange={setBatchGreenOnly}
+                disabled={interactionLocked}
+              />
+              <AdminQueueBatchToolbar
+                batchBusy={batchBusy}
+                rowBusy={interactionLocked}
+                selectedCount={selected.size}
+                onSelectAll={handleSelectAll}
+                onClearSelection={clearSelection}
+                onRequestBatchApprove={handleBatchClick}
+              />
+            </>
+          ) : null}
+
+          {showEmpty ? <AdminChallengeQueueEmpty statusFilter={statusFilter} /> : null}
+
+          {showTable ? (
+            <AdminPendingChallengesTable
+              locale={locale}
+              statusFilter={statusFilter}
+              rowsWithLabels={rowsWithLabels}
+              selected={selected}
+              busyId={busyId}
+              analyzeBusyId={analyzeBusyId}
+              analyzeDisabled={!accessToken}
+              onToggle={toggle}
+              onApproveRow={requestApproveRow}
+              onRejectRow={openReject}
+              onCloseRow={handleCloseRow}
+              onAnalyzeRow={handleAnalyzeRow}
+            />
+          ) : null}
+
+          {showTable ? (
+            <AdminQueuePagination
+              page={page}
+              totalPages={totalPages}
+              totalCount={totalCount}
+              statusFilter={statusFilter}
+              disabled={interactionLocked}
+              onPrev={goPrevPage}
+              onNext={goNextPage}
+            />
+          ) : null}
+        </>
+      ) : null}
+
       <AdminChallengeQueueDialogs
         approveModalOpen={approveTarget !== null}
         approveVariant={approveTarget?.kind === 'batch' ? 'batch' : 'single'}

--- a/src/features/admin/components/AdminChallengeQueueStates.tsx
+++ b/src/features/admin/components/AdminChallengeQueueStates.tsx
@@ -30,7 +30,18 @@ export function AdminChallengeQueueFetchError({ message, onRetry }: FetchErrorPr
   );
 }
 
-export function AdminChallengeQueueEmpty() {
+import type { AdminQueueTabStatus } from '@/features/admin/services/adminChallenges';
+
+type EmptyProps = {
+  statusFilter: AdminQueueTabStatus;
+};
+
+export function AdminChallengeQueueEmpty({ statusFilter }: EmptyProps) {
   const t = useTranslations('admin.queue');
-  return <p className="text-sm text-muted-foreground">{t('empty')}</p>;
+
+  return (
+    <div className="rounded-md border border-border bg-card p-6 text-center">
+      <p className="text-sm text-muted-foreground">{t(`empty.${statusFilter}`)}</p>
+    </div>
+  );
 }

--- a/src/features/admin/components/AdminPendingChallengeRow.tsx
+++ b/src/features/admin/components/AdminPendingChallengeRow.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import Link from 'next/link';
 import { useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 
+import { arenaDisplayStatus, type ArenaDisplayStatus } from '@/features/admin/lib/arenaLifecycle';
 import type { AdminPendingChallenge as PendingRow } from '@/features/admin/services/adminChallenges';
 import type { ChallengeAiTier } from '@/lib/types/database.types';
 
@@ -39,13 +41,24 @@ function tierHelpLabel(t: TierHelpFn, tier: ChallengeAiTier | null): string {
   }
 }
 
+function statusBadgeClass(display: ArenaDisplayStatus): string {
+  if (display === 'arena_live') return 'border-emerald-500/50 text-emerald-400';
+  if (display === 'arena_done') return 'border-border text-muted-foreground';
+  if (display === 'rejected') return 'border-primary/60 text-primary';
+  return 'border-accent/50 text-accent';
+}
+
 type Props = {
+  locale: string;
   row: PendingRow;
-  submittedLabel: string;
+  dateLabel: string;
+  isPendingTab: boolean;
+  isArenaLiveTab: boolean;
   checked: boolean;
   onToggle: (id: string) => void;
   onApproveRow: (id: string) => void | Promise<void>;
   onRejectRow: (id: string) => void;
+  onCloseRow: (id: string) => void | Promise<void>;
   onAnalyzeRow: (id: string) => void;
   busyId: string | null;
   analyzeBusyId: string | null;
@@ -53,12 +66,16 @@ type Props = {
 };
 
 export function AdminPendingChallengeRow({
+  locale,
   row,
-  submittedLabel,
+  dateLabel,
+  isPendingTab,
+  isArenaLiveTab,
   checked,
   onToggle,
   onApproveRow,
   onRejectRow,
+  onCloseRow,
   onAnalyzeRow,
   busyId,
   analyzeBusyId,
@@ -67,12 +84,18 @@ export function AdminPendingChallengeRow({
   const t = useTranslations('admin.queue');
   const disabled = busyId !== null || analyzeBusyId !== null;
   const analyzing = analyzeBusyId === row.id;
+  const viewHref = `/${locale}/app/arena/${row.id}`;
+  const displayStatus = arenaDisplayStatus(row);
+
   const onApprove = useCallback(() => {
     void onApproveRow(row.id);
   }, [onApproveRow, row.id]);
   const onReject = useCallback(() => {
     onRejectRow(row.id);
   }, [onRejectRow, row.id]);
+  const onClose = useCallback(() => {
+    void onCloseRow(row.id);
+  }, [onCloseRow, row.id]);
   const onCheckboxChange = useCallback(() => {
     onToggle(row.id);
   }, [onToggle, row.id]);
@@ -88,63 +111,94 @@ export function AdminPendingChallengeRow({
 
   return (
     <tr className="border-b border-border">
-      <td className="py-3 pr-2">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={onCheckboxChange}
-          disabled={disabled}
-          aria-label={t('selectRow', { title: row.title })}
-          className="h-4 w-4 accent-primary"
-        />
-      </td>
+      {isPendingTab ? (
+        <td className="py-3 pr-2">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={onCheckboxChange}
+            disabled={disabled}
+            aria-label={t('selectRow', { title: row.title })}
+            className="h-4 w-4 accent-primary"
+          />
+        </td>
+      ) : null}
       <td className="py-3 pr-2 text-sm font-semibold">{row.title}</td>
-      <td className="py-3 pr-2 max-w-[14rem]">
-        <div className="flex items-start gap-2">
-          <span
-            className={`inline-flex min-w-[1.5rem] justify-center rounded-sm border px-1 py-0.5 text-[10px] font-black tracking-wider ${tierBadgeClass(tier)}`}
-            title={tierHelp}
-          >
-            {badgeLetter}
-          </span>
-          {summary ? (
-            <span className="line-clamp-2 text-[11px] text-muted-foreground" title={fullSummary}>
-              {summary}
-            </span>
-          ) : (
-            <span className="text-[11px] text-muted-foreground">—</span>
-          )}
-        </div>
+      <td className="py-3 pr-2">
+        <span
+          className={`inline-flex rounded-sm border px-1.5 py-0.5 text-[10px] font-black uppercase tracking-wider ${statusBadgeClass(displayStatus)}`}
+        >
+          {t(`statusLabel.${displayStatus}`)}
+        </span>
       </td>
+      {isPendingTab ? (
+        <td className="py-3 pr-2 max-w-[14rem]">
+          <div className="flex items-start gap-2">
+            <span
+              className={`inline-flex min-w-[1.5rem] justify-center rounded-sm border px-1 py-0.5 text-[10px] font-black tracking-wider ${tierBadgeClass(tier)}`}
+              title={tierHelp}
+            >
+              {badgeLetter}
+            </span>
+            {summary ? (
+              <span className="line-clamp-2 text-[11px] text-muted-foreground" title={fullSummary}>
+                {summary}
+              </span>
+            ) : (
+              <span className="text-[11px] text-muted-foreground">—</span>
+            )}
+          </div>
+        </td>
+      ) : null}
       <td className="py-3 pr-2 text-xs uppercase text-muted-foreground">{row.score_type}</td>
       <td className="py-3 pr-2 text-xs text-muted-foreground">{creatorLabel(row)}</td>
-      <td className="py-3 pr-2 text-xs text-muted-foreground">{submittedLabel}</td>
+      <td className="py-3 pr-2 text-xs text-muted-foreground">{dateLabel}</td>
       <td className="py-3 text-right">
-        <button
-          type="button"
-          onClick={onApprove}
-          disabled={disabled}
-          className="mr-2 rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-wider hover:bg-muted disabled:opacity-50"
+        {isPendingTab ? (
+          <>
+            <button
+              type="button"
+              onClick={onApprove}
+              disabled={disabled}
+              className="mr-2 rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-wider hover:bg-muted disabled:opacity-50"
+            >
+              {t('approve')}
+            </button>
+            <button
+              type="button"
+              onClick={onReject}
+              disabled={disabled}
+              className="mr-2 rounded-sm border border-primary/40 bg-primary/10 px-2 py-1 text-[10px] font-black uppercase tracking-wider text-primary hover:bg-primary/20 disabled:opacity-50"
+            >
+              {t('reject')}
+            </button>
+            <button
+              type="button"
+              onClick={onAnalyze}
+              disabled={disabled || analyzeDisabled || analyzing}
+              aria-label={t('analyzeAria', { title: row.title })}
+              className="mr-2 rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-wider hover:bg-muted disabled:opacity-50"
+            >
+              {analyzing ? t('analyzing') : t('analyze')}
+            </button>
+          </>
+        ) : null}
+        {isArenaLiveTab ? (
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={disabled}
+            className="mr-2 rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-wider hover:bg-muted disabled:opacity-50"
+          >
+            {t('closeArena')}
+          </button>
+        ) : null}
+        <Link
+          href={viewHref}
+          className="inline-flex rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-wider hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          {t('approve')}
-        </button>
-        <button
-          type="button"
-          onClick={onReject}
-          disabled={disabled}
-          className="mr-2 rounded-sm border border-primary/40 bg-primary/10 px-2 py-1 text-[10px] font-black uppercase tracking-wider text-primary hover:bg-primary/20 disabled:opacity-50"
-        >
-          {t('reject')}
-        </button>
-        <button
-          type="button"
-          onClick={onAnalyze}
-          disabled={disabled || analyzeDisabled || analyzing}
-          aria-label={t('analyzeAria', { title: row.title })}
-          className="rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-wider hover:bg-muted disabled:opacity-50"
-        >
-          {analyzing ? t('analyzing') : t('analyze')}
-        </button>
+          {t('view')}
+        </Link>
       </td>
     </tr>
   );

--- a/src/features/admin/components/AdminPendingChallengesTable.tsx
+++ b/src/features/admin/components/AdminPendingChallengesTable.tsx
@@ -3,26 +3,27 @@
 import { useTranslations } from 'next-intl';
 
 import { AdminPendingChallengeRow } from '@/features/admin/components/AdminPendingChallengeRow';
-import type { AdminPendingChallenge as PendingRow } from '@/features/admin/services/adminChallenges';
-
-type RowWithLabel = {
-  row: PendingRow;
-  submittedLabel: string;
-};
+import type { RowWithDateLabel } from '@/features/admin/hooks/useAdminQueueRowLabels';
+import type { AdminQueueTabStatus } from '@/features/admin/services/adminChallenges';
 
 type Props = {
-  rowsWithLabels: RowWithLabel[];
+  locale: string;
+  statusFilter: AdminQueueTabStatus;
+  rowsWithLabels: RowWithDateLabel[];
   selected: Set<string>;
   busyId: string | null;
   analyzeBusyId: string | null;
   analyzeDisabled: boolean;
   onToggle: (id: string) => void;
-  onApproveRow: (id: string) => void;
+  onApproveRow: (id: string) => void | Promise<void>;
   onRejectRow: (id: string) => void;
+  onCloseRow: (id: string) => void | Promise<void>;
   onAnalyzeRow: (id: string) => void;
 };
 
 export function AdminPendingChallengesTable({
+  locale,
+  statusFilter,
   rowsWithLabels,
   selected,
   busyId,
@@ -31,24 +32,40 @@ export function AdminPendingChallengesTable({
   onToggle,
   onApproveRow,
   onRejectRow,
+  onCloseRow,
   onAnalyzeRow,
 }: Props) {
   const t = useTranslations('admin.queue');
+  const isPendingTab = statusFilter === 'pending';
+  const isArenaLiveTab = statusFilter === 'arena_live';
+  const dateCol =
+    statusFilter === 'pending'
+      ? t('colSubmitted')
+      : statusFilter === 'arena_done'
+        ? t('colClosed')
+        : t('colReviewed');
 
   return (
     <div className="overflow-x-auto rounded-md border border-border">
       <table className="w-full min-w-[880px] text-left">
         <thead>
           <tr className="border-b border-border bg-muted/40 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
-            <th className="py-2 pr-2 w-10" scope="col">
-              {' '}
-            </th>
+            {isPendingTab ? (
+              <th className="w-10 py-2 pr-2" scope="col">
+                {' '}
+              </th>
+            ) : null}
             <th className="py-2 pr-2" scope="col">
               {t('colTitle')}
             </th>
             <th className="py-2 pr-2" scope="col">
-              {t('colAi')}
+              {t('colStatus')}
             </th>
+            {isPendingTab ? (
+              <th className="py-2 pr-2" scope="col">
+                {t('colAi')}
+              </th>
+            ) : null}
             <th className="py-2 pr-2" scope="col">
               {t('colType')}
             </th>
@@ -56,7 +73,7 @@ export function AdminPendingChallengesTable({
               {t('colCreator')}
             </th>
             <th className="py-2 pr-2" scope="col">
-              {t('colSubmitted')}
+              {dateCol}
             </th>
             <th className="py-2 text-right" scope="col">
               {t('colActions')}
@@ -64,15 +81,19 @@ export function AdminPendingChallengesTable({
           </tr>
         </thead>
         <tbody>
-          {rowsWithLabels.map(({ row, submittedLabel }) => (
+          {rowsWithLabels.map(({ row, dateLabel }) => (
             <AdminPendingChallengeRow
               key={row.id}
+              locale={locale}
               row={row}
-              submittedLabel={submittedLabel}
+              dateLabel={dateLabel}
+              isPendingTab={isPendingTab}
+              isArenaLiveTab={isArenaLiveTab}
               checked={selected.has(row.id)}
               onToggle={onToggle}
               onApproveRow={onApproveRow}
               onRejectRow={onRejectRow}
+              onCloseRow={onCloseRow}
               onAnalyzeRow={onAnalyzeRow}
               busyId={busyId}
               analyzeBusyId={analyzeBusyId}

--- a/src/features/admin/components/AdminQueuePagination.tsx
+++ b/src/features/admin/components/AdminQueuePagination.tsx
@@ -2,10 +2,13 @@
 
 import { useTranslations } from 'next-intl';
 
+import type { AdminQueueTabStatus } from '@/features/admin/services/adminChallenges';
+
 type Props = {
   page: number;
   totalPages: number;
   totalCount: number;
+  statusFilter: AdminQueueTabStatus;
   disabled: boolean;
   onPrev: () => void;
   onNext: () => void;
@@ -15,6 +18,7 @@ export function AdminQueuePagination({
   page,
   totalPages,
   totalCount,
+  statusFilter,
   disabled,
   onPrev,
   onNext,
@@ -24,7 +28,7 @@ export function AdminQueuePagination({
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
       <p className="text-[11px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-        {t('paginationSummary', { page, totalPages, totalCount })}
+        {t(`paginationSummary.${statusFilter}`, { page, totalPages, totalCount })}
       </p>
       <div className="flex gap-2">
         <button

--- a/src/features/admin/components/AdminQueueStatusTabs.tsx
+++ b/src/features/admin/components/AdminQueueStatusTabs.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type {
+  AdminQueueTabStatus,
+  AdminUgcQueueCounts,
+} from '@/features/admin/services/adminChallenges';
+
+const STATUS_TABS: AdminQueueTabStatus[] = ['pending', 'arena_live', 'arena_done', 'rejected'];
+
+type Props = {
+  active: AdminQueueTabStatus;
+  counts: AdminUgcQueueCounts | null;
+  onChange: (value: AdminQueueTabStatus) => void;
+  disabled: boolean;
+};
+
+function formatCount(counts: AdminUgcQueueCounts | null, status: AdminQueueTabStatus): string {
+  if (counts === null) return '—';
+  return String(counts[status]);
+}
+
+export function AdminQueueStatusTabs({ active, counts, onChange, disabled }: Props) {
+  const t = useTranslations('admin.queue');
+  const total =
+    counts === null
+      ? null
+      : counts.pending + counts.arena_live + counts.arena_done + counts.rejected;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2" role="tablist" aria-label={t('statusTabsLabel')}>
+        {STATUS_TABS.map((status) => {
+          const isActive = active === status;
+          const countLabel = formatCount(counts, status);
+          const tabLabel = t(`statusTab.${status}`);
+          return (
+            <button
+              key={status}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-label={t('statusTabAria', { label: tabLabel, count: countLabel })}
+              disabled={disabled}
+              onClick={() => onChange(status)}
+              className={[
+                'inline-flex items-center gap-2 rounded-sm border px-3 py-1.5 text-[11px] font-black uppercase tracking-[0.14em] transition-colors',
+                isActive
+                  ? 'border-primary bg-primary/15 text-primary'
+                  : 'border-border bg-background text-muted-foreground hover:text-foreground',
+              ].join(' ')}
+            >
+              <span>{tabLabel}</span>
+              <span
+                className={[
+                  'min-w-[1.25rem] rounded-sm px-1 py-0.5 text-center font-mono text-[10px] tabular-nums',
+                  isActive ? 'bg-primary/25 text-primary' : 'bg-muted text-foreground',
+                ].join(' ')}
+                aria-hidden
+              >
+                {countLabel}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {total !== null ? (
+        <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+          {t('ugcTotal', { count: total })}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/admin/hooks/useAdminPendingChallenges.ts
+++ b/src/features/admin/hooks/useAdminPendingChallenges.ts
@@ -6,10 +6,14 @@ import { ADMIN_QUEUE_PAGE_SIZE, adminQueueMaxPage } from '@/features/admin/lib/a
 import {
   adminApproveChallenge,
   adminBatchApproveChallenges,
+  adminCloseChallenge,
   adminRejectChallenge,
   adminRunChallengeAiReview,
-  listPendingChallengesForAdmin,
+  getAdminUgcQueueCounts,
+  listChallengesForAdmin,
   type AdminPendingChallenge,
+  type AdminQueueTabStatus,
+  type AdminUgcQueueCounts,
   type AiTierFilter,
 } from '@/features/admin/services/adminChallenges';
 
@@ -30,6 +34,8 @@ export function useAdminPendingChallenges(): {
   page: number;
   setPage: (page: number) => void;
   pageSize: number;
+  statusFilter: AdminQueueTabStatus;
+  setStatusFilter: (value: AdminQueueTabStatus) => void;
   tierFilter: AiTierFilter;
   setTierFilter: (value: AiTierFilter) => void;
   riskFirst: boolean;
@@ -38,15 +44,24 @@ export function useAdminPendingChallenges(): {
   approveOne: (id: string) => Promise<void>;
   batchApprove: (ids: string[], options?: { onlyGreen?: boolean }) => Promise<number>;
   rejectOne: (id: string, reason: string) => Promise<void>;
+  closeOne: (id: string) => Promise<void>;
   analyzeOne: (id: string) => Promise<void>;
   analyzeBusyId: string | null;
+  statusCounts: AdminUgcQueueCounts | null;
 } {
   const [state, setState] = useState<State>(initial);
   const [page, setPage] = useState(1);
   const [reloadKey, setReloadKey] = useState(0);
+  const [statusFilter, setStatusFilterState] = useState<AdminQueueTabStatus>('pending');
   const [tierFilter, setTierFilterState] = useState<AiTierFilter>('all');
   const [riskFirst, setRiskFirstState] = useState(true);
   const [analyzeBusyId, setAnalyzeBusyId] = useState<string | null>(null);
+  const [statusCounts, setStatusCounts] = useState<AdminUgcQueueCounts | null>(null);
+
+  const setStatusFilter = useCallback((value: AdminQueueTabStatus) => {
+    setStatusFilterState(value);
+    setPage(1);
+  }, []);
 
   const setTierFilter = useCallback((value: AiTierFilter) => {
     setTierFilterState(value);
@@ -62,9 +77,25 @@ export function useAdminPendingChallenges(): {
     let cancelled = false;
     void (async () => {
       try {
-        const { rows, totalCount } = await listPendingChallengesForAdmin({
+        const counts = await getAdminUgcQueueCounts();
+        if (!cancelled) setStatusCounts(counts);
+      } catch {
+        if (!cancelled) setStatusCounts(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { rows, totalCount } = await listChallengesForAdmin({
           page,
           pageSize: ADMIN_QUEUE_PAGE_SIZE,
+          statusFilter,
           tierFilter,
           riskFirst,
         });
@@ -85,7 +116,7 @@ export function useAdminPendingChallenges(): {
     return () => {
       cancelled = true;
     };
-  }, [page, reloadKey, tierFilter, riskFirst]);
+  }, [page, reloadKey, statusFilter, tierFilter, riskFirst]);
 
   const refetch = useCallback(() => {
     setState({ status: 'loading', rows: [], error: null });
@@ -95,6 +126,18 @@ export function useAdminPendingChallenges(): {
   const approveOne = useCallback(
     async (id: string) => {
       await adminApproveChallenge(id);
+      setStatusFilterState('arena_live');
+      setPage(1);
+      refetch();
+    },
+    [refetch],
+  );
+
+  const closeOne = useCallback(
+    async (id: string) => {
+      await adminCloseChallenge(id);
+      setStatusFilterState('arena_done');
+      setPage(1);
       refetch();
     },
     [refetch],
@@ -112,6 +155,8 @@ export function useAdminPendingChallenges(): {
   const rejectOne = useCallback(
     async (id: string, reason: string) => {
       await adminRejectChallenge({ challengeId: id, reason });
+      setStatusFilterState('rejected');
+      setPage(1);
       refetch();
     },
     [refetch],
@@ -135,6 +180,8 @@ export function useAdminPendingChallenges(): {
     page,
     setPage,
     pageSize: ADMIN_QUEUE_PAGE_SIZE,
+    statusFilter,
+    setStatusFilter,
     tierFilter,
     setTierFilter,
     riskFirst,
@@ -143,7 +190,9 @@ export function useAdminPendingChallenges(): {
     approveOne,
     batchApprove,
     rejectOne,
+    closeOne,
     analyzeOne,
     analyzeBusyId,
+    statusCounts,
   };
 }

--- a/src/features/admin/hooks/useAdminQueueRowLabels.ts
+++ b/src/features/admin/hooks/useAdminQueueRowLabels.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import type {
+  AdminPendingChallenge,
+  AdminQueueTabStatus,
+} from '@/features/admin/services/adminChallenges';
+
+export type RowWithDateLabel = {
+  row: AdminPendingChallenge;
+  dateLabel: string;
+};
+
+export function useAdminQueueRowLabels(
+  rows: AdminPendingChallenge[],
+  locale: string,
+  statusFilter: AdminQueueTabStatus,
+): RowWithDateLabel[] {
+  const dateFmt = useMemo(() => new Intl.DateTimeFormat(locale, { dateStyle: 'short' }), [locale]);
+
+  return useMemo(
+    () =>
+      rows.map((row) => {
+        const raw =
+          statusFilter === 'pending'
+            ? row.created_at
+            : statusFilter === 'arena_done'
+              ? (row.ends_at ?? row.reviewed_at ?? row.created_at)
+              : (row.reviewed_at ?? row.created_at);
+        return {
+          row,
+          dateLabel: dateFmt.format(new Date(raw)),
+        };
+      }),
+    [dateFmt, rows, statusFilter],
+  );
+}

--- a/src/features/admin/lib/arenaLifecycle.test.ts
+++ b/src/features/admin/lib/arenaLifecycle.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { arenaDisplayStatus, isArenaDone, isArenaLive } from '@/features/admin/lib/arenaLifecycle';
+
+describe('arenaLifecycle', () => {
+  it('treats approved without ends_at as live', () => {
+    const c = { status: 'approved' as const, ends_at: null };
+    expect(isArenaLive(c)).toBe(true);
+    expect(isArenaDone(c)).toBe(false);
+    expect(arenaDisplayStatus(c)).toBe('arena_live');
+  });
+
+  it('treats approved with past ends_at as done', () => {
+    const c = { status: 'approved' as const, ends_at: '2020-01-01T00:00:00Z' };
+    expect(isArenaDone(c)).toBe(true);
+    expect(isArenaLive(c)).toBe(false);
+    expect(arenaDisplayStatus(c)).toBe('arena_done');
+  });
+});

--- a/src/features/admin/lib/arenaLifecycle.ts
+++ b/src/features/admin/lib/arenaLifecycle.ts
@@ -1,0 +1,22 @@
+import type { Challenge } from '@/lib/types/database.types';
+
+export function isArenaDone(challenge: Pick<Challenge, 'status' | 'ends_at'>): boolean {
+  if (challenge.status !== 'approved') return false;
+  const endsAt = challenge.ends_at;
+  if (!endsAt) return false;
+  return new Date(endsAt).getTime() <= Date.now();
+}
+
+export function isArenaLive(challenge: Pick<Challenge, 'status' | 'ends_at'>): boolean {
+  return challenge.status === 'approved' && !isArenaDone(challenge);
+}
+
+export type ArenaDisplayStatus = 'pending' | 'rejected' | 'arena_live' | 'arena_done';
+
+export function arenaDisplayStatus(
+  challenge: Pick<Challenge, 'status' | 'ends_at'>,
+): ArenaDisplayStatus {
+  if (challenge.status === 'pending') return 'pending';
+  if (challenge.status === 'rejected') return 'rejected';
+  return isArenaDone(challenge) ? 'arena_done' : 'arena_live';
+}

--- a/src/features/admin/services/adminChallenges.ts
+++ b/src/features/admin/services/adminChallenges.ts
@@ -4,9 +4,12 @@ import { supabase } from '@/lib/supabase';
 import type { Challenge, ChallengeAiTier } from '@/lib/types/database.types';
 
 const PENDING_CHALLENGE_SELECT =
-  'id,title,description,rules,score_type,equipment_tags,is_official,status,creator_id,max_duration_seconds,rejection_reason,reviewed_at,reviewed_by,ai_tier,ai_summary,ai_model,ai_checked_at,created_at,creator:profiles!challenges_creator_id_fkey(username)';
+  'id,title,description,rules,score_type,equipment_tags,is_official,status,creator_id,max_duration_seconds,rejection_reason,reviewed_at,reviewed_by,ai_tier,ai_summary,ai_model,ai_checked_at,ends_at,created_at,creator:profiles!challenges_creator_id_fkey(username)';
 
 export type AiTierFilter = 'all' | ChallengeAiTier | 'none';
+
+/** Moderation + arena lifecycle tabs on the MOD queue page. */
+export type AdminQueueTabStatus = 'pending' | 'arena_live' | 'arena_done' | 'rejected';
 
 export type AdminPendingChallenge = Challenge & {
   creator: { username: string | null } | null;
@@ -17,9 +20,49 @@ export type AdminPendingListResult = {
   totalCount: number;
 };
 
-export async function listPendingChallengesForAdmin(options?: {
+export type AdminUgcQueueCounts = Record<AdminQueueTabStatus, number>;
+
+const UGC_MOD_QUEUE_TABS: AdminQueueTabStatus[] = [
+  'pending',
+  'arena_live',
+  'arena_done',
+  'rejected',
+];
+
+function arenaCountsQuery(status: AdminQueueTabStatus, nowIso: string) {
+  const base = supabase
+    .from('challenges')
+    .select('id', { count: 'exact', head: true })
+    .eq('is_official', false);
+
+  if (status === 'pending') {
+    return base.eq('status', 'pending');
+  }
+  if (status === 'rejected') {
+    return base.eq('status', 'rejected');
+  }
+  if (status === 'arena_live') {
+    return base.eq('status', 'approved').or(`ends_at.is.null,ends_at.gt.${nowIso}`);
+  }
+  return base.eq('status', 'approved').not('ends_at', 'is', null).lte('ends_at', nowIso);
+}
+
+export async function getAdminUgcQueueCounts(): Promise<AdminUgcQueueCounts> {
+  const nowIso = new Date().toISOString();
+  const pairs = await Promise.all(
+    UGC_MOD_QUEUE_TABS.map(async (status) => {
+      const { count, error } = await arenaCountsQuery(status, nowIso);
+      if (error) throw new Error(error.message);
+      return [status, count ?? 0] as const;
+    }),
+  );
+  return Object.fromEntries(pairs) as AdminUgcQueueCounts;
+}
+
+export async function listChallengesForAdmin(options?: {
   page?: number;
   pageSize?: number;
+  statusFilter?: AdminQueueTabStatus;
   tierFilter?: AiTierFilter;
   riskFirst?: boolean;
 }): Promise<AdminPendingListResult> {
@@ -27,25 +70,38 @@ export async function listPendingChallengesForAdmin(options?: {
   const page = Math.max(1, options?.page ?? 1);
   const from = (page - 1) * pageSize;
   const to = from + pageSize - 1;
+  const statusFilter = options?.statusFilter ?? 'pending';
   const tierFilter = options?.tierFilter ?? 'all';
   const riskFirst = options?.riskFirst ?? true;
+  const nowIso = new Date().toISOString();
 
   let query = supabase
     .from('challenges')
     .select(PENDING_CHALLENGE_SELECT, { count: 'exact' })
-    .eq('status', 'pending');
+    .eq('is_official', false);
 
-  if (tierFilter === 'green') query = query.eq('ai_tier', 'green');
-  else if (tierFilter === 'orange') query = query.eq('ai_tier', 'orange');
-  else if (tierFilter === 'red') query = query.eq('ai_tier', 'red');
-  else if (tierFilter === 'none') query = query.is('ai_tier', null);
+  if (statusFilter === 'pending') {
+    query = query.eq('status', 'pending');
+    if (tierFilter === 'green') query = query.eq('ai_tier', 'green');
+    else if (tierFilter === 'orange') query = query.eq('ai_tier', 'orange');
+    else if (tierFilter === 'red') query = query.eq('ai_tier', 'red');
+    else if (tierFilter === 'none') query = query.is('ai_tier', null);
+  } else if (statusFilter === 'rejected') {
+    query = query.eq('status', 'rejected');
+  } else if (statusFilter === 'arena_live') {
+    query = query.eq('status', 'approved').or(`ends_at.is.null,ends_at.gt.${nowIso}`);
+  } else {
+    query = query.eq('status', 'approved').not('ends_at', 'is', null).lte('ends_at', nowIso);
+  }
 
-  if (riskFirst) {
+  if (statusFilter === 'pending' && riskFirst) {
     query = query
       .order('ai_tier_rank', { ascending: true })
       .order('created_at', { ascending: true });
   } else {
-    query = query.order('created_at', { ascending: true });
+    query = query
+      .order('reviewed_at', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false });
   }
 
   const { data, error, count } = await query.range(from, to);
@@ -56,6 +112,13 @@ export async function listPendingChallengesForAdmin(options?: {
     creator: normalizePostgrestCreator((row as { creator?: unknown }).creator),
   }));
   return { rows, totalCount: count ?? 0 };
+}
+
+/** @deprecated Use listChallengesForAdmin */
+export async function listPendingChallengesForAdmin(
+  options?: Omit<Parameters<typeof listChallengesForAdmin>[0], 'statusFilter'>,
+): Promise<AdminPendingListResult> {
+  return listChallengesForAdmin({ ...options, statusFilter: 'pending' });
 }
 
 export async function adminApproveChallenge(challengeId: string): Promise<void> {
@@ -75,6 +138,13 @@ export async function adminRejectChallenge(input: {
     p_challenge_id: input.challengeId,
     p_status: 'rejected',
     p_rejection_reason: input.reason.trim(),
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function adminCloseChallenge(challengeId: string): Promise<void> {
+  const { error } = await supabase.rpc('admin_close_challenge', {
+    p_challenge_id: challengeId,
   });
   if (error) throw new Error(error.message);
 }

--- a/src/features/challenges/components/ArenaPendingSection.tsx
+++ b/src/features/challenges/components/ArenaPendingSection.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import type { Challenge } from '@/lib/types/database.types';
+
+type Props = {
+  challenges: Challenge[];
+};
+
+export function ArenaPendingSection({ challenges }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('arena');
+
+  return (
+    <div className="rounded-md border border-accent/30 bg-accent/10 p-4 space-y-3">
+      <div>
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-accent">
+          {t('pendingSectionTitle')}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">{t('pendingSectionHint')}</p>
+      </div>
+      <ul className="space-y-2">
+        {challenges.map((challenge) => (
+          <li key={challenge.id}>
+            <Link
+              href={`/${locale}/app/arena/${challenge.id}`}
+              className="flex items-center justify-between gap-3 rounded-md border border-border bg-card px-3 py-2 hover:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span className="truncate text-sm font-black uppercase tracking-tight">
+                {challenge.title}
+              </span>
+              <span className="shrink-0 rounded-sm border border-accent/40 bg-accent/15 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-accent">
+                {t('pendingBadge')}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/challenges/components/ArenaScreen.tsx
+++ b/src/features/challenges/components/ArenaScreen.tsx
@@ -5,26 +5,34 @@ import { Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { ArenaPendingSection } from '@/features/challenges/components/ArenaPendingSection';
 import { ChallengeList } from '@/features/challenges/components/ChallengeList';
 import { useChallenges } from '@/features/challenges/hooks/useChallenges';
+import { useMyPendingChallenges } from '@/features/challenges/hooks/useMyPendingChallenges';
 import { rankChallenges, type ArenaTab } from '@/features/challenges/lib/arenaRanking';
 
-function ArenaHeader() {
+function ArenaHeader({
+  showCreateCta,
+  createHref,
+}: {
+  showCreateCta: boolean;
+  createHref: string;
+}) {
   const t = useTranslations('arena');
-  const locale = useLocale();
-  const createHref = `/${locale}/app/arena/create`;
   return (
     <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="space-y-1">
         <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
         <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </div>
-      <Link
-        href={createHref}
-        className="hidden min-h-11 shrink-0 items-center justify-center rounded-sm border border-primary bg-primary/10 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-primary hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex"
-      >
-        {t('create.cta')}
-      </Link>
+      {showCreateCta ? (
+        <Link
+          href={createHref}
+          className="hidden min-h-11 shrink-0 items-center justify-center rounded-sm border border-primary bg-primary/10 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-primary hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex"
+        >
+          {t('create.cta')}
+        </Link>
+      ) : null}
     </header>
   );
 }
@@ -38,11 +46,20 @@ function ArenaLoading() {
   );
 }
 
-function ArenaEmpty() {
+function ArenaEmpty({ createHref }: { createHref: string }) {
   const t = useTranslations('arena');
   return (
-    <div className="rounded-md border border-border bg-card p-6 text-center">
-      <p className="text-sm text-muted-foreground">{t('empty')}</p>
+    <div className="rounded-md border border-border bg-card p-6 text-center space-y-4">
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">{t('empty')}</p>
+        <p className="text-xs text-muted-foreground/80">{t('emptyHint')}</p>
+      </div>
+      <Link
+        href={createHref}
+        className="inline-flex w-full max-w-xs items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-auto"
+      >
+        {t('create.cta')}
+      </Link>
     </div>
   );
 }
@@ -115,30 +132,51 @@ export function ArenaScreen() {
   const locale = useLocale();
   const createHref = `/${locale}/app/arena/create`;
   const { data, loading, error, refetch } = useChallenges();
+  const pending = useMyPendingChallenges();
   const [tab, setTab] = useState<ArenaTab>('trending');
 
   const ranked = useMemo(() => rankChallenges(data, tab), [data, tab]);
+  const feedReady = !loading && !error;
+  const feedEmpty = feedReady && data.length === 0;
+  const hasPending = !pending.loading && pending.data.length > 0;
+  const showHeaderCreate = feedReady && data.length > 0;
 
   return (
     <section className="relative space-y-5 pb-24 md:pb-5">
-      <ArenaHeader />
+      <ArenaHeader showCreateCta={showHeaderCreate} createHref={createHref} />
+      {!pending.loading && hasPending ? <ArenaPendingSection challenges={pending.data} /> : null}
+
       <ArenaTabs activeTab={tab} onChange={setTab} />
 
       {loading ? <ArenaLoading /> : null}
 
       {!loading && error ? <ArenaError onRetry={() => void refetch()} /> : null}
 
-      {!loading && !error && data.length === 0 ? <ArenaEmpty /> : null}
+      {feedEmpty && !hasPending ? <ArenaEmpty createHref={createHref} /> : null}
 
-      {!loading && !error && ranked.length > 0 ? <ChallengeList challenges={ranked} /> : null}
+      {feedEmpty && hasPending ? (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">{t('emptyLiveFeed')}</p>
+          <Link
+            href={createHref}
+            className="inline-flex min-h-11 items-center justify-center rounded-sm border border-primary bg-primary/10 px-4 py-2 text-xs font-black uppercase tracking-[0.16em] text-primary hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('create.cta')}
+          </Link>
+        </div>
+      ) : null}
 
-      <Link
-        href={createHref}
-        className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-30 flex h-14 w-14 items-center justify-center rounded-sm border border-primary bg-primary text-primary-foreground shadow-[0_12px_28px_rgba(0,0,0,0.35)] hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:hidden"
-        aria-label={t('create.fab')}
-      >
-        <Plus className="h-7 w-7" strokeWidth={2.4} aria-hidden />
-      </Link>
+      {feedReady && ranked.length > 0 ? <ChallengeList challenges={ranked} /> : null}
+
+      {showHeaderCreate ? (
+        <Link
+          href={createHref}
+          className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-30 flex h-14 w-14 items-center justify-center rounded-sm border border-primary bg-primary text-primary-foreground shadow-[0_12px_28px_rgba(0,0,0,0.35)] hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:hidden"
+          aria-label={t('create.fab')}
+        >
+          <Plus className="h-7 w-7" strokeWidth={2.4} aria-hidden />
+        </Link>
+      ) : null}
     </section>
   );
 }

--- a/src/features/challenges/components/ChallengeDetail.tsx
+++ b/src/features/challenges/components/ChallengeDetail.tsx
@@ -2,11 +2,16 @@
 
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
+import { useMemo } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { ChallengeDetailCircuitPanel } from '@/features/challenges/components/ChallengeDetailCircuitPanel';
+import { ChallengeDetailHero } from '@/features/challenges/components/ChallengeDetailHero';
+import { ChallengeDetailLockedPanel } from '@/features/challenges/components/ChallengeDetailLockedPanel';
+import { ChallengeDetailSpecPanels } from '@/features/challenges/components/ChallengeDetailSpecPanels';
 import { Leaderboard } from '@/features/challenges/components/Leaderboard';
-import { formatTime } from '@/features/challenges/lib/scoreFormat';
 import { useChallenge } from '@/features/challenges/hooks/useChallenge';
+import { parseChallengeRules } from '@/features/challenges/lib/parseChallengeRules';
 
 type Props = {
   challengeId: string;
@@ -37,134 +42,45 @@ function NotFound() {
   );
 }
 
-export function ChallengeDetail({ challengeId }: Props) {
+function DetailSkeleton() {
   const t = useTranslations('challenge');
-  const tArena = useTranslations('arena');
-  const locale = useLocale();
-  const { data: challenge, loading, error } = useChallenge(challengeId);
-
-  if (loading) {
-    return (
+  return (
+    <section className="space-y-5" aria-busy="true">
+      <BackLink />
       <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
         {t('loading')}
       </p>
-    );
-  }
+      <div className="h-48 animate-pulse rounded-md border border-border bg-muted/40" />
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="h-32 animate-pulse rounded-md border border-border bg-muted/30" />
+        <div className="h-32 animate-pulse rounded-md border border-border bg-muted/30" />
+      </div>
+    </section>
+  );
+}
 
+export function ChallengeDetail({ challengeId }: Props) {
+  const locale = useLocale();
+  const { data: challenge, loading, error } = useChallenge(challengeId);
+  const parsedRules = useMemo(
+    () => parseChallengeRules(challenge?.rules ?? ''),
+    [challenge?.rules],
+  );
+
+  if (loading) return <DetailSkeleton />;
   if (error || !challenge) return <NotFound />;
 
   const isApproved = challenge.status === 'approved';
 
   return (
-    <section className="space-y-6">
+    <section className="space-y-5">
       <BackLink />
-
-      <header className="space-y-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="inline-flex items-center rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {tArena(`scoreType.${challenge.score_type}`)}
-          </span>
-          {challenge.is_official ? (
-            <span className="inline-flex items-center rounded-sm bg-primary/15 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-primary">
-              {tArena('officialBadge')}
-            </span>
-          ) : null}
-          {!challenge.is_official && isApproved ? (
-            <span className="inline-flex items-center rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
-              {tArena('badges.community')}
-            </span>
-          ) : null}
-          {challenge.status === 'pending' ? (
-            <span className="inline-flex items-center rounded-sm border border-accent/40 bg-accent/15 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-accent">
-              {tArena('badges.pendingReview')}
-            </span>
-          ) : null}
-          {challenge.status === 'rejected' ? (
-            <span className="inline-flex items-center rounded-sm border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-primary">
-              {tArena('badges.rejected')}
-            </span>
-          ) : null}
-        </div>
-        <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
-          {challenge.title}
-        </h1>
-        <p className="text-sm text-foreground/80">{challenge.description}</p>
-        {isApproved &&
-        challenge.score_type === 'time' &&
-        challenge.max_duration_seconds != null &&
-        challenge.max_duration_seconds > 0 ? (
-          <p className="text-xs font-black uppercase tracking-[0.14em] text-accent">
-            {t('maxTimeCap', { cap: formatTime(challenge.max_duration_seconds) })}
-          </p>
-        ) : null}
-      </header>
-
-      <div className="grid gap-4 md:grid-cols-2">
-        <article className="space-y-2 rounded-md border border-border bg-card p-4">
-          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {t('rulesHeading')}
-          </h2>
-          <p className="whitespace-pre-line text-sm text-foreground/90">{challenge.rules}</p>
-        </article>
-
-        <article className="space-y-2 rounded-md border border-border bg-card p-4">
-          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {t('equipmentHeading')}
-          </h2>
-          {challenge.equipment_tags.length > 0 ? (
-            <ul className="flex flex-wrap gap-1.5">
-              {challenge.equipment_tags.map((tag) => (
-                <li
-                  key={tag}
-                  className="rounded-sm border border-border bg-background px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
-                >
-                  #{tag}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-sm text-muted-foreground">{t('noEquipment')}</p>
-          )}
-        </article>
-      </div>
-
-      {isApproved ? (
-        <div className="rounded-md border border-border bg-card p-4">
-          <Link
-            href={`/${locale}/app/arena/${challenge.id}/submit`}
-            className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {t('ctaStart')}
-          </Link>
-        </div>
-      ) : (
-        <div
-          className={
-            challenge.status === 'rejected'
-              ? 'rounded-md border border-primary/30 bg-primary/10 p-4'
-              : 'rounded-md border border-accent/30 bg-accent/10 p-4'
-          }
-        >
-          <p
-            className={
-              challenge.status === 'rejected'
-                ? 'text-xs font-black uppercase tracking-[0.18em] text-primary'
-                : 'text-xs font-black uppercase tracking-[0.18em] text-accent'
-            }
-          >
-            {challenge.status === 'rejected' ? t('rejectedTitle') : t('pendingTitle')}
-          </p>
-          <p className="mt-2 text-sm text-muted-foreground">
-            {challenge.status === 'rejected' ? t('rejectedBody') : t('pendingBody')}
-          </p>
-          {challenge.status === 'rejected' && challenge.rejection_reason?.trim() ? (
-            <p className="mt-3 whitespace-pre-line rounded-sm border border-border bg-background/60 p-3 text-sm text-foreground/90">
-              {t('rejectionModeratorNote', { note: challenge.rejection_reason.trim() })}
-            </p>
-          ) : null}
-        </div>
-      )}
-
+      <ChallengeDetailHero challenge={challenge} locale={locale} isApproved={isApproved} />
+      {!isApproved ? <ChallengeDetailLockedPanel challenge={challenge} /> : null}
+      {parsedRules.circuitLines.length > 0 ? (
+        <ChallengeDetailCircuitPanel lines={parsedRules.circuitLines} />
+      ) : null}
+      <ChallengeDetailSpecPanels challenge={challenge} parsed={parsedRules} />
       {isApproved ? (
         <Leaderboard challengeId={challenge.id} scoreType={challenge.score_type} />
       ) : null}

--- a/src/features/challenges/components/ChallengeDetailCircuitPanel.tsx
+++ b/src/features/challenges/components/ChallengeDetailCircuitPanel.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Layers } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { ChallengeDetailSection } from '@/features/challenges/components/ChallengeDetailSection';
+
+type Props = {
+  lines: string[];
+};
+
+function parseMovementLine(line: string): { index: string; label: string; amount: string } {
+  const match = /^(\d+)\.\s*(.+?)\s*[—–-]\s*(.+)$/u.exec(line.trim());
+  if (!match) {
+    return { index: '', label: line, amount: '' };
+  }
+  return { index: match[1], label: match[2].trim(), amount: match[3].trim() };
+}
+
+export function ChallengeDetailCircuitPanel({ lines }: Props) {
+  const t = useTranslations('challenge');
+
+  return (
+    <ChallengeDetailSection tone="primary" icon={Layers} title={t('circuitHeading')} withWash>
+      <ol className="space-y-2">
+        {lines.map((line) => {
+          const { index, label, amount } = parseMovementLine(line);
+          const key = `${index}-${label}`;
+          return (
+            <li
+              key={key}
+              className="flex items-center gap-3 rounded-sm border border-border bg-background/80 px-3 py-3"
+            >
+              {index ? (
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-sm font-black tabular-nums text-primary">
+                  {index}
+                </span>
+              ) : null}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-black uppercase tracking-tight text-foreground">
+                  {label}
+                </p>
+                {amount ? (
+                  <p className="mt-0.5 text-xs font-black uppercase tracking-[0.14em] text-accent">
+                    {amount}
+                  </p>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </ChallengeDetailSection>
+  );
+}

--- a/src/features/challenges/components/ChallengeDetailHero.tsx
+++ b/src/features/challenges/components/ChallengeDetailHero.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { Swords, Timer, Trophy } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { formatTime } from '@/features/challenges/lib/scoreFormat';
+import type { Challenge } from '@/lib/types/database.types';
+
+type Props = {
+  challenge: Challenge;
+  locale: string;
+  isApproved: boolean;
+};
+
+function DetailBadge({
+  children,
+  tone,
+}: {
+  children: ReactNode;
+  tone: 'muted' | 'primary' | 'accent' | 'community';
+}) {
+  const tones = {
+    muted: 'border-border bg-muted text-muted-foreground',
+    primary: 'border-primary/50 bg-primary/15 text-primary',
+    accent: 'border-accent/50 bg-accent/15 text-accent',
+    community: 'border-border bg-background text-muted-foreground',
+  };
+  return (
+    <span
+      className={[
+        'inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+        tones[tone],
+      ].join(' ')}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function ChallengeDetailHero({ challenge, locale, isApproved }: Props) {
+  const t = useTranslations('challenge');
+  const tArena = useTranslations('arena');
+
+  const kickerKey =
+    challenge.status === 'rejected'
+      ? 'heroKickerRejected'
+      : challenge.status === 'pending'
+        ? 'heroKickerPending'
+        : 'heroKickerApproved';
+
+  const ScoreIcon = challenge.score_type === 'time' ? Timer : Trophy;
+
+  return (
+    <header className="relative overflow-hidden rounded-md border border-border bg-card">
+      <div
+        className="pointer-events-none absolute inset-0 bg-[linear-gradient(135deg,rgba(220,38,38,0.22)_0%,transparent_45%,rgba(255,184,0,0.12)_100%)]"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute -right-16 -top-20 h-48 w-48 rounded-full bg-primary/25 blur-3xl"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute -bottom-24 -left-10 h-40 w-40 rounded-full bg-accent/15 blur-3xl"
+        aria-hidden
+      />
+
+      <div className="relative space-y-3 py-4 pl-5 pr-4 md:py-5">
+        <p className="text-[11px] font-black uppercase tracking-[0.28em] text-primary">
+          {t(kickerKey)}
+        </p>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <DetailBadge tone="muted">
+            <ScoreIcon className="h-3 w-3" aria-hidden />
+            {tArena(`scoreType.${challenge.score_type}`)}
+          </DetailBadge>
+          {challenge.is_official ? (
+            <DetailBadge tone="primary">{tArena('officialBadge')}</DetailBadge>
+          ) : null}
+          {!challenge.is_official && isApproved ? (
+            <DetailBadge tone="community">{tArena('badges.community')}</DetailBadge>
+          ) : null}
+          {challenge.status === 'pending' ? (
+            <DetailBadge tone="accent">{tArena('badges.pendingReview')}</DetailBadge>
+          ) : null}
+          {challenge.status === 'rejected' ? (
+            <DetailBadge tone="primary">{tArena('badges.rejected')}</DetailBadge>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-black uppercase leading-[0.95] tracking-tight text-foreground md:text-3xl">
+            {challenge.title}
+          </h1>
+          {challenge.description.trim().length > 0 ? (
+            <p className="max-w-2xl text-sm leading-snug text-foreground/85">
+              {challenge.description}
+            </p>
+          ) : null}
+          {isApproved &&
+          challenge.score_type === 'time' &&
+          challenge.max_duration_seconds != null &&
+          challenge.max_duration_seconds > 0 ? (
+            <p className="text-xs font-black uppercase tracking-[0.14em] text-accent">
+              {t('maxTimeCap', { cap: formatTime(challenge.max_duration_seconds) })}
+            </p>
+          ) : null}
+        </div>
+
+        {isApproved ? (
+          <div className="space-y-2 pt-1">
+            <Link
+              href={`/${locale}/app/arena/${challenge.id}/submit`}
+              className="inline-flex w-full min-h-12 items-center justify-center gap-2 rounded-md bg-primary px-5 py-4 text-sm font-black uppercase tracking-[0.2em] text-primary-foreground shadow-[0_0_32px_rgba(220,38,38,0.35)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:w-auto md:min-w-[16rem]"
+            >
+              <Swords className="h-4 w-4" aria-hidden />
+              {t('ctaStart')}
+            </Link>
+            <p className="text-xs font-black uppercase tracking-[0.16em] text-muted-foreground">
+              {t('ctaSubline')}
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/src/features/challenges/components/ChallengeDetailLockedPanel.tsx
+++ b/src/features/challenges/components/ChallengeDetailLockedPanel.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { ChallengeDetailSection } from '@/features/challenges/components/ChallengeDetailSection';
+import type { Challenge } from '@/lib/types/database.types';
+
+type Props = {
+  challenge: Challenge;
+};
+
+type PendingStep = {
+  key: 'pendingStep1' | 'pendingStep2' | 'pendingStep3';
+  done: boolean;
+  active?: boolean;
+};
+
+function PendingSteps() {
+  const t = useTranslations('challenge');
+  const steps: PendingStep[] = [
+    { key: 'pendingStep1', done: true },
+    { key: 'pendingStep2', done: true, active: true },
+    { key: 'pendingStep3', done: false },
+  ];
+
+  return (
+    <ol className="flex flex-col gap-2 sm:flex-row sm:items-stretch sm:gap-0">
+      {steps.map((step, index) => (
+        <li
+          key={step.key}
+          className={[
+            'flex flex-1 items-center gap-2 rounded-sm border px-3 py-2 sm:rounded-none sm:border-y sm:border-l-0 sm:first:rounded-l-sm sm:first:border-l sm:last:rounded-r-sm',
+            step.active
+              ? 'border-accent/50 bg-accent/10'
+              : step.done
+                ? 'border-border bg-background/80'
+                : 'border-border bg-background/40 text-muted-foreground',
+          ].join(' ')}
+        >
+          <span
+            className={[
+              'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-black',
+              step.active ? 'bg-accent text-accent-foreground' : 'bg-muted text-muted-foreground',
+            ].join(' ')}
+          >
+            {index + 1}
+          </span>
+          <span className="text-[10px] font-black uppercase tracking-[0.14em]">{t(step.key)}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function ChallengeDetailLockedPanel({ challenge }: Props) {
+  const t = useTranslations('challenge');
+  const isRejected = challenge.status === 'rejected';
+
+  return (
+    <ChallengeDetailSection
+      tone={isRejected ? 'primary' : 'accent'}
+      icon={isRejected ? ShieldAlert : ShieldCheck}
+      title={isRejected ? t('rejectedTitle') : t('pendingTitle')}
+      withWash
+    >
+      <p className="text-sm leading-relaxed text-foreground/85">
+        {isRejected ? t('rejectedBody') : t('pendingBody')}
+      </p>
+      {!isRejected ? <PendingSteps /> : null}
+      {isRejected && challenge.rejection_reason?.trim() ? (
+        <p className="whitespace-pre-line rounded-sm border border-border bg-background/60 p-3 text-sm text-foreground/90">
+          {t('rejectionModeratorNote', { note: challenge.rejection_reason.trim() })}
+        </p>
+      ) : null}
+    </ChallengeDetailSection>
+  );
+}

--- a/src/features/challenges/components/ChallengeDetailSection.tsx
+++ b/src/features/challenges/components/ChallengeDetailSection.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+type Tone = 'primary' | 'accent' | 'neutral';
+
+const TONE_STYLES: Record<
+  Tone,
+  { border: string; bar: string; icon: string; title: string; wash: string }
+> = {
+  primary: {
+    border: 'border-primary/40',
+    bar: 'bg-primary',
+    icon: 'text-primary',
+    title: 'text-primary',
+    wash: 'bg-[linear-gradient(90deg,rgba(220,38,38,0.1)_0%,transparent_55%)]',
+  },
+  accent: {
+    border: 'border-accent/40',
+    bar: 'bg-accent',
+    icon: 'text-accent',
+    title: 'text-accent',
+    wash: 'bg-[linear-gradient(90deg,rgba(255,184,0,0.1)_0%,transparent_55%)]',
+  },
+  neutral: {
+    border: 'border-border',
+    bar: 'bg-muted-foreground',
+    icon: 'text-muted-foreground',
+    title: 'text-muted-foreground',
+    wash: '',
+  },
+};
+
+type Props = {
+  tone: Tone;
+  icon: LucideIcon;
+  title: string;
+  children: ReactNode;
+  withWash?: boolean;
+};
+
+export function ChallengeDetailSection({
+  tone,
+  icon: Icon,
+  title,
+  children,
+  withWash = true,
+}: Props) {
+  const styles = TONE_STYLES[tone];
+
+  return (
+    <article
+      className={['relative overflow-hidden rounded-md border bg-card', styles.border].join(' ')}
+    >
+      {withWash && styles.wash.length > 0 ? (
+        <div className={`pointer-events-none absolute inset-0 ${styles.wash}`} aria-hidden />
+      ) : null}
+      <span className={`absolute inset-y-0 left-0 w-1 ${styles.bar}`} aria-hidden />
+
+      <div className="relative space-y-3 py-4 pl-5 pr-4">
+        <div className="flex items-center gap-2">
+          <Icon className={`h-5 w-5 shrink-0 ${styles.icon}`} aria-hidden />
+          <h2 className={`text-sm font-black uppercase tracking-[0.22em] ${styles.title}`}>
+            {title}
+          </h2>
+        </div>
+        {children}
+      </div>
+    </article>
+  );
+}

--- a/src/features/challenges/components/ChallengeDetailSpecPanels.tsx
+++ b/src/features/challenges/components/ChallengeDetailSpecPanels.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Dumbbell, ScrollText } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { ChallengeDetailSection } from '@/features/challenges/components/ChallengeDetailSection';
+import type { ParsedChallengeRules } from '@/features/challenges/lib/parseChallengeRules';
+import type { Challenge } from '@/lib/types/database.types';
+
+type Props = {
+  challenge: Challenge;
+  parsed: ParsedChallengeRules;
+};
+
+export function ChallengeDetailSpecPanels({ challenge, parsed }: Props) {
+  const t = useTranslations('challenge');
+  const hasScoring = parsed.scoring.trim().length > 0;
+  const hasStandards = parsed.standards.trim().length > 0;
+  const hasEquipment = challenge.equipment_tags.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <div
+        className={
+          hasScoring && hasStandards
+            ? 'grid gap-4 lg:grid-cols-2'
+            : hasScoring
+              ? 'grid gap-4 md:grid-cols-2'
+              : 'grid gap-4'
+        }
+      >
+        {hasScoring ? (
+          <ChallengeDetailSection
+            tone="primary"
+            icon={ScrollText}
+            title={t('scoringHeading')}
+            withWash
+          >
+            <p className="whitespace-pre-line text-sm leading-relaxed text-foreground/90">
+              {parsed.scoring}
+            </p>
+          </ChallengeDetailSection>
+        ) : null}
+
+        <ChallengeDetailSection
+          tone="accent"
+          icon={Dumbbell}
+          title={t('equipmentHeading')}
+          withWash
+        >
+          {hasEquipment ? (
+            <ul className="flex flex-wrap gap-2">
+              {challenge.equipment_tags.map((tag) => (
+                <li
+                  key={tag}
+                  className="rounded-sm border border-border bg-background px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground"
+                >
+                  #{tag}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm font-black uppercase tracking-[0.12em] text-foreground/80">
+              {t('noEquipment')}
+            </p>
+          )}
+        </ChallengeDetailSection>
+      </div>
+
+      {hasStandards ? (
+        <ChallengeDetailSection
+          tone="neutral"
+          icon={ScrollText}
+          title={t('standardsHeading')}
+          withWash={false}
+        >
+          <p className="whitespace-pre-line text-sm leading-relaxed text-foreground/90">
+            {parsed.standards}
+          </p>
+        </ChallengeDetailSection>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/challenges/hooks/useMyPendingChallenges.ts
+++ b/src/features/challenges/hooks/useMyPendingChallenges.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { listMyPendingChallenges } from '@/features/challenges/services/challenges';
+import type { Challenge } from '@/lib/types/database.types';
+
+type State = {
+  data: Challenge[];
+  loading: boolean;
+  error: string | null;
+};
+
+const initialState: State = { data: [], loading: true, error: null };
+
+export function useMyPendingChallenges(): State & { refetch: () => void } {
+  const [state, setState] = useState<State>(initialState);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await listMyPendingChallenges();
+        if (!cancelled) setState({ data, loading: false, error: null });
+      } catch (e: unknown) {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : 'unknown';
+          setState({ data: [], loading: false, error: message });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  return { ...state, refetch };
+}

--- a/src/features/challenges/lib/parseChallengeRules.test.ts
+++ b/src/features/challenges/lib/parseChallengeRules.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFullChallengeRules } from '@/features/challenges/lib/circuitBlocks';
+import { parseChallengeRules } from '@/features/challenges/lib/parseChallengeRules';
+
+describe('parseChallengeRules', () => {
+  it('parses rules built by buildFullChallengeRules', () => {
+    const rules = buildFullChallengeRules({
+      scoringMode: 'amrap',
+      amrapCap: '10:00',
+      forTimeFinishCap: '',
+      circuitBlocks: [{ label: 'Burpee', kind: 'reps', amount: '10', movementSlug: 'burpee' }],
+      rulesDetail: 'Full lockout at the top.',
+    });
+
+    const parsed = parseChallengeRules(rules);
+    expect(parsed.scoring).toContain('AMRAP');
+    expect(parsed.circuitLines).toEqual(['1. Burpee — 10 reps']);
+    expect(parsed.standards).toContain('lockout');
+  });
+
+  it('handles scoring-only text', () => {
+    const parsed = parseChallengeRules('SCORING\nFORMAT: FOR TIME\nFinish fast.');
+    expect(parsed.scoring).toContain('FOR TIME');
+    expect(parsed.circuitLines).toEqual([]);
+  });
+});

--- a/src/features/challenges/lib/parseChallengeRules.ts
+++ b/src/features/challenges/lib/parseChallengeRules.ts
@@ -1,0 +1,66 @@
+export type ParsedChallengeRules = {
+  scoring: string;
+  circuitLines: string[];
+  standards: string;
+};
+
+const CIRCUIT_HEADER = 'CIRCUIT';
+const MOVEMENT_LINE_RE = /^\d+\.\s/;
+
+function splitScoringAndBody(text: string): { scoring: string; body: string } {
+  const parts = text.split(/\n\n+/);
+  if (parts.length > 1 && parts[0].includes('SCORING')) {
+    return { scoring: parts[0].trim(), body: parts.slice(1).join('\n\n').trim() };
+  }
+  if (text.includes('SCORING') && text.includes(CIRCUIT_HEADER)) {
+    const idx = text.indexOf(`\n${CIRCUIT_HEADER}\n`);
+    if (idx >= 0) {
+      return { scoring: text.slice(0, idx).trim(), body: text.slice(idx + 1).trim() };
+    }
+  }
+  if (text.includes('SCORING') && !text.includes(CIRCUIT_HEADER)) {
+    return { scoring: text.trim(), body: '' };
+  }
+  return { scoring: '', body: text };
+}
+
+function parseBodyLines(body: string): { circuitLines: string[]; standards: string } {
+  let content = body.trim();
+  if (content.startsWith(CIRCUIT_HEADER)) {
+    content = content.slice(CIRCUIT_HEADER.length).trim();
+  }
+
+  const circuitLines: string[] = [];
+  const standardsLines: string[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    if (MOVEMENT_LINE_RE.test(trimmed)) {
+      circuitLines.push(trimmed);
+      continue;
+    }
+    standardsLines.push(line);
+  }
+
+  return { circuitLines, standards: standardsLines.join('\n').trim() };
+}
+
+export function parseChallengeRules(rules: string): ParsedChallengeRules {
+  const text = rules.trim();
+  if (text.length === 0) {
+    return { scoring: '', circuitLines: [], standards: '' };
+  }
+
+  const { scoring, body } = splitScoringAndBody(text);
+  const { circuitLines, standards } = parseBodyLines(body);
+
+  if (scoring.length === 0 && circuitLines.length === 0 && standards.length === 0) {
+    if (text.includes('SCORING')) {
+      return { scoring: text, circuitLines: [], standards: '' };
+    }
+    return { scoring: '', circuitLines: [], standards: text };
+  }
+
+  return { scoring, circuitLines, standards };
+}

--- a/src/features/challenges/services/challenges.ts
+++ b/src/features/challenges/services/challenges.ts
@@ -4,11 +4,28 @@ import type { Challenge, ScoreType } from '@/lib/types/database.types';
 const CHALLENGE_SELECT =
   'id,title,description,rules,score_type,equipment_tags,is_official,status,creator_id,max_duration_seconds,rejection_reason,reviewed_at,reviewed_by,created_at';
 
+export async function listMyPendingChallenges(): Promise<Challenge[]> {
+  const { data: auth, error: authError } = await supabase.auth.getUser();
+  if (authError || !auth.user) return [];
+
+  const { data, error } = await supabase
+    .from('challenges')
+    .select(CHALLENGE_SELECT)
+    .eq('creator_id', auth.user.id)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data ?? []) as Challenge[];
+}
+
+/** Approved challenges still open in Arena (excludes admin-closed UGC with past ends_at). */
 export async function listApprovedChallenges(): Promise<Challenge[]> {
+  const nowIso = new Date().toISOString();
   const { data, error } = await supabase
     .from('challenges')
     .select(CHALLENGE_SELECT)
     .eq('status', 'approved')
+    .or(`ends_at.is.null,ends_at.gt.${nowIso}`)
     .order('created_at', { ascending: false });
   if (error) throw new Error(error.message);
   return (data ?? []) as Challenge[];

--- a/src/features/factions/components/ClanArenaCta.tsx
+++ b/src/features/factions/components/ClanArenaCta.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+export function ClanArenaCta() {
+  const locale = useLocale();
+  const t = useTranslations('clan');
+
+  return (
+    <Link
+      href={`/${locale}/app/arena`}
+      className="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      {t('ctaArena')}
+    </Link>
+  );
+}

--- a/src/features/factions/components/ClanFactionWarCard.tsx
+++ b/src/features/factions/components/ClanFactionWarCard.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { CLAN_ROW_LINK_CLASS } from '@/features/factions/lib/clanRowLinkClass';
+import { formatClanPoints } from '@/features/factions/lib/formatClanPoints';
+import type { FactionRow } from '@/features/factions/services/clanHud';
+import { getFactionBadgeClasses } from '@/lib/factionStyles';
+import type { Faction } from '@/lib/types/database.types';
+
+type Props = {
+  rankings: FactionRow[];
+  userFaction: Faction;
+};
+
+export function ClanFactionWarCard({ rankings, userFaction }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('clan');
+  const arenaHref = `/${locale}/app/arena`;
+
+  return (
+    <article className="rounded-md border border-border bg-card p-4">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('factionsTitle')}
+      </p>
+      <ul className="mt-3 space-y-2">
+        {rankings.map((row, idx) => {
+          const isYours = row.faction === userFaction;
+          const styles = getFactionBadgeClasses(row.faction);
+          const rowClass = `flex items-center justify-between gap-3 rounded-md border border-l-4 bg-background px-3 py-2 ${styles.accent} ${
+            isYours ? `${styles.bg} ${styles.border} border-primary/40` : 'border-border'
+          }`;
+
+          const rowInner = (
+            <>
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="text-xs font-black tabular-nums text-muted-foreground">
+                  #{idx + 1}
+                </span>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className={`text-sm font-black uppercase tracking-[0.18em] ${styles.text}`}>
+                      {t(`faction.${row.faction}`)}
+                    </p>
+                    {isYours ? (
+                      <span
+                        className={`rounded-sm border px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.14em] ${styles.bg} ${styles.text} ${styles.border}`}
+                      >
+                        {t('yourFactionBadge')}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t('activeFighters', { count: row.members })}
+                  </p>
+                </div>
+              </div>
+              <div className="shrink-0 text-right">
+                <p className={`text-sm font-black tabular-nums ${styles.text}`}>
+                  {formatClanPoints(row.points)}
+                </p>
+                <p className="text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground">
+                  {t('pointsUnit')}
+                </p>
+              </div>
+            </>
+          );
+
+          return (
+            <li key={row.faction}>
+              {isYours ? (
+                <Link
+                  href={arenaHref}
+                  aria-label={t('yourFactionArenaAria')}
+                  className={`${rowClass} ${CLAN_ROW_LINK_CLASS}`}
+                >
+                  {rowInner}
+                </Link>
+              ) : (
+                <div className={rowClass}>{rowInner}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </article>
+  );
+}

--- a/src/features/factions/components/ClanScreen.tsx
+++ b/src/features/factions/components/ClanScreen.tsx
@@ -2,19 +2,20 @@
 
 import { useTranslations } from 'next-intl';
 
+import { ClanArenaCta } from '@/features/factions/components/ClanArenaCta';
+import { ClanFactionWarCard } from '@/features/factions/components/ClanFactionWarCard';
+import { ClanTopMembersCard } from '@/features/factions/components/ClanTopMembersCard';
 import { RecruitCta } from '@/features/factions/components/RecruitCta';
 import { useClanHud } from '@/features/factions/hooks/useClanHud';
-
-function formatPoints(points: number): string {
-  if (!Number.isFinite(points)) return '0';
-  return Math.round(points).toLocaleString();
-}
+import { useProfile } from '@/features/profile/hooks/useProfile';
 
 export function ClanScreen() {
   const tabs = useTranslations('app.tabs');
   const t = useTranslations('clan');
 
   const { state, refetch } = useClanHud();
+  const { state: profileState } = useProfile();
+  const currentUserId = profileState.status === 'ready' ? profileState.profile.id : null;
 
   return (
     <section className="space-y-6">
@@ -53,68 +54,17 @@ export function ClanScreen() {
       ) : null}
 
       {state.status === 'ready' ? (
-        <div className="grid gap-4 lg:grid-cols-2">
-          <article className="rounded-md border border-border bg-card p-4">
-            <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-              {t('factionsTitle')}
-            </p>
-            <ul className="mt-3 space-y-2">
-              {state.rankings.map((row, idx) => (
-                <li
-                  key={row.faction}
-                  className={`flex items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2 ${
-                    row.faction === state.faction ? 'border-primary/60' : ''
-                  }`}
-                >
-                  <div className="flex items-center gap-3">
-                    <span className="text-xs font-black tabular-nums text-muted-foreground">
-                      #{idx + 1}
-                    </span>
-                    <div>
-                      <p className="text-sm font-black uppercase tracking-[0.18em]">
-                        {t(`faction.${row.faction}`)}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {t('members', { count: row.members })}
-                      </p>
-                    </div>
-                  </div>
-                  <p className="text-sm font-black tabular-nums text-foreground">
-                    {formatPoints(row.points)}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </article>
-
-          <article className="rounded-md border border-border bg-card p-4">
-            <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-              {t('topMembersTitle')}
-            </p>
-            {state.members.length === 0 ? (
-              <p className="mt-3 text-sm text-muted-foreground">{t('emptyMembers')}</p>
-            ) : (
-              <ol className="mt-3 space-y-2">
-                {state.members.map((m, idx) => (
-                  <li
-                    key={m.userId}
-                    className="flex items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2"
-                  >
-                    <div className="flex items-center gap-3">
-                      <span className="text-xs font-black tabular-nums text-muted-foreground">
-                        #{idx + 1}
-                      </span>
-                      <p className="text-sm font-black uppercase tracking-tight">{m.username}</p>
-                    </div>
-                    <p className="text-sm font-black tabular-nums text-foreground">
-                      {formatPoints(m.points)}
-                    </p>
-                  </li>
-                ))}
-              </ol>
-            )}
-          </article>
-        </div>
+        <>
+          <div className="grid gap-4 lg:grid-cols-2">
+            <ClanFactionWarCard rankings={state.rankings} userFaction={state.faction} />
+            <ClanTopMembersCard
+              members={state.members}
+              userFaction={state.faction}
+              currentUserId={currentUserId}
+            />
+          </div>
+          <ClanArenaCta />
+        </>
       ) : null}
     </section>
   );

--- a/src/features/factions/components/ClanTopMembersCard.tsx
+++ b/src/features/factions/components/ClanTopMembersCard.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { CLAN_ROW_LINK_CLASS } from '@/features/factions/lib/clanRowLinkClass';
+import { formatClanPoints } from '@/features/factions/lib/formatClanPoints';
+import type { MemberRow } from '@/features/factions/services/clanHud';
+import { publicProfilePath } from '@/features/profile/lib/publicProfilePath';
+import { getFactionBadgeClasses } from '@/lib/factionStyles';
+import type { Faction } from '@/lib/types/database.types';
+
+type Props = {
+  members: MemberRow[];
+  userFaction: Faction;
+  currentUserId: string | null;
+};
+
+export function ClanTopMembersCard({ members, userFaction, currentUserId }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('clan');
+  const styles = getFactionBadgeClasses(userFaction);
+  const ownProfileHref = `/${locale}/app/profile`;
+
+  return (
+    <article
+      className={`rounded-md border border-l-4 bg-card p-4 ${styles.accent} ${styles.border}`}
+    >
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('topMembersTitle')}
+      </p>
+      <p className={`mt-1 text-xs font-black uppercase tracking-[0.14em] ${styles.text}`}>
+        {t(`faction.${userFaction}`)}
+      </p>
+      {members.length === 0 ? (
+        <p className="mt-3 text-sm text-muted-foreground">{t('emptyMembers')}</p>
+      ) : (
+        <ol className="mt-3 space-y-2">
+          {members.map((m, idx) => {
+            const isYou = currentUserId !== null && m.userId === currentUserId;
+            const href = isYou ? ownProfileHref : publicProfilePath(locale, m.username);
+            const rowClass =
+              'flex items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2';
+            const linkClass = `${rowClass} ${CLAN_ROW_LINK_CLASS} ${
+              isYou ? 'border-primary/40' : 'hover:border-muted-foreground/30'
+            }`;
+
+            return (
+              <li key={m.userId}>
+                <Link
+                  href={href}
+                  aria-label={
+                    isYou
+                      ? t('yourProfileLinkAria')
+                      : t('memberProfileLinkAria', { username: m.username })
+                  }
+                  className={linkClass}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs font-black tabular-nums text-muted-foreground">
+                      #{idx + 1}
+                    </span>
+                    <p className="text-sm font-black uppercase tracking-tight">{m.username}</p>
+                    {isYou ? (
+                      <span className="text-[10px] font-black uppercase tracking-[0.14em] text-primary">
+                        {t('youBadge')}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-black tabular-nums text-foreground">
+                      {formatClanPoints(m.points)}
+                    </p>
+                    <p className="text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground">
+                      {t('pointsUnit')}
+                    </p>
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </article>
+  );
+}

--- a/src/features/factions/components/RecruitCta.tsx
+++ b/src/features/factions/components/RecruitCta.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { buildReferralUrl } from '@/features/factions/lib/referral';
+import { getFactionBadgeClasses } from '@/lib/factionStyles';
 import type { Faction } from '@/lib/types/database.types';
 
 type Props = {
@@ -13,9 +14,13 @@ type Props = {
 
 export function RecruitCta({ faction, siteUrl }: Props) {
   const t = useTranslations('clan.recruit');
+  const tFaction = useTranslations('clan.faction');
   const [copied, setCopied] = useState(false);
 
   const referralUrl = buildReferralUrl(siteUrl, faction);
+  const factionName = tFaction(faction);
+  const factionParams = useMemo(() => ({ faction: factionName }), [factionName]);
+  const factionStyles = getFactionBadgeClasses(faction);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -31,8 +36,8 @@ export function RecruitCta({ faction, siteUrl }: Props) {
     if (typeof navigator.share === 'function') {
       try {
         await navigator.share({
-          title: t('shareTitle'),
-          text: t('shareText'),
+          title: t('shareTitle', factionParams),
+          text: t('shareText', factionParams),
           url: referralUrl,
         });
       } catch {
@@ -41,26 +46,35 @@ export function RecruitCta({ faction, siteUrl }: Props) {
     } else {
       await handleCopy();
     }
-  }, [handleCopy, referralUrl, t]);
+  }, [factionParams, handleCopy, referralUrl, t]);
 
   return (
-    <article className="rounded-md border border-border bg-card p-4">
+    <article
+      className={`rounded-md border border-l-4 bg-card p-4 ${factionStyles.accent} ${factionStyles.border}`}
+    >
       <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
         {t('title')}
       </p>
-      <p className="mt-2 text-sm text-muted-foreground">{t('body')}</p>
+      <p
+        className="mt-3 break-all rounded-md border border-border bg-muted/40 px-3 py-2 font-mono text-xs text-foreground"
+        title={referralUrl}
+      >
+        {referralUrl}
+      </p>
       <div className="mt-3 flex flex-wrap gap-2">
         <button
           type="button"
           onClick={() => void handleShare()}
-          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={t('shareAria', factionParams)}
+          className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {t('share')}
         </button>
         <button
           type="button"
           onClick={() => void handleCopy()}
-          className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={t('copyAria')}
+          className="inline-flex min-h-11 items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {copied ? t('copied') : t('copy')}
         </button>

--- a/src/features/factions/lib/clanRowLinkClass.ts
+++ b/src/features/factions/lib/clanRowLinkClass.ts
@@ -1,0 +1,2 @@
+export const CLAN_ROW_LINK_CLASS =
+  'transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';

--- a/src/features/factions/lib/formatClanPoints.ts
+++ b/src/features/factions/lib/formatClanPoints.ts
@@ -1,0 +1,4 @@
+export function formatClanPoints(points: number): string {
+  if (!Number.isFinite(points)) return '0';
+  return Math.round(points).toLocaleString();
+}

--- a/src/features/finisher-card/lib/drawCard.test.ts
+++ b/src/features/finisher-card/lib/drawCard.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { drawFinisherCard } from '@/features/finisher-card/lib/drawCard';
+
+function createCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.getContext = ((contextId: string) => {
+    if (contextId !== '2d') return null;
+    return {
+      measureText(text: string) {
+        return { width: text.length * 10 };
+      },
+      fillRect: () => undefined,
+      strokeRect: () => undefined,
+      fillText: () => undefined,
+      font: '',
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+      textBaseline: 'top',
+    } as unknown as CanvasRenderingContext2D;
+  }) as HTMLCanvasElement['getContext'];
+  return canvas;
+}
+
+describe('drawFinisherCard', () => {
+  it('renders thumb layout without throwing for long titles and time scores', () => {
+    const canvas = createCanvas();
+    expect(() =>
+      drawFinisherCard(canvas, {
+        width: 360,
+        height: 640,
+        faction: 'iron_alliance',
+        username: 'igorms',
+        challengeTitle: 'QA Official — Max Push-Ups (1 min)',
+        scoreType: 'time',
+        scoreValue: 430,
+        topPercent: null,
+        rankTextOverride: 'RANKED',
+        rankSubOverride: 'VALIDATED',
+      }),
+    ).not.toThrow();
+    expect(canvas.width).toBe(360);
+    expect(canvas.height).toBe(640);
+  });
+});

--- a/src/features/finisher-card/lib/drawCard.ts
+++ b/src/features/finisher-card/lib/drawCard.ts
@@ -19,6 +19,33 @@ function factionColor(faction: Faction): string {
   return '#7f8c8d';
 }
 
+function fitFontSize(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+  weight: number,
+  family: string,
+  startSize: number,
+  minSize = 18,
+): number {
+  let size = startSize;
+  while (size >= minSize) {
+    ctx.font = `${weight} ${size}px ${family}`;
+    if (ctx.measureText(text).width <= maxWidth) return size;
+    size -= 2;
+  }
+  return minSize;
+}
+
+function truncateToWidth(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  let trimmed = text;
+  while (trimmed.length > 0 && ctx.measureText(`${trimmed}…`).width > maxWidth) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  return trimmed.length > 0 ? `${trimmed}…` : '…';
+}
+
 export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): void {
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
@@ -41,64 +68,109 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
   const innerY = pad;
   const innerW = canvas.width - pad * 2;
   const innerH = canvas.height - pad * 2;
+  const textX = innerX + Math.floor(innerW * 0.08);
+  const maxTextW = innerW * 0.84;
+  const lineY = (pct: number) => innerY + Math.floor(innerH * pct);
 
-  // main panel
   ctx.fillStyle = card;
   ctx.fillRect(innerX, innerY, innerW, innerH);
 
-  // border
   ctx.strokeStyle = border;
-  ctx.lineWidth = 4;
+  ctx.lineWidth = Math.max(2, Math.floor(canvas.width * 0.011));
   ctx.strokeRect(innerX, innerY, innerW, innerH);
 
-  // faction slash
   ctx.fillStyle = accent;
-  ctx.fillRect(innerX, innerY, Math.floor(innerW * 0.02), innerH);
+  ctx.fillRect(innerX, innerY, Math.max(4, Math.floor(innerW * 0.02)), innerH);
 
-  // header branding
-  ctx.fillStyle = fg;
-  ctx.font = '900 54px system-ui, -apple-system, Segoe UI, sans-serif';
   ctx.textBaseline = 'top';
-  ctx.fillText('TRUEGRYND', innerX + 30, innerY + 28);
 
-  ctx.fillStyle = muted;
-  ctx.font = '900 22px system-ui, -apple-system, Segoe UI, sans-serif';
-  ctx.fillText(options.challengeTitle.toUpperCase(), innerX + 30, innerY + 96);
-
-  // main score
+  const brandSize = fitFontSize(
+    ctx,
+    'TRUEGRYND',
+    maxTextW,
+    900,
+    'system-ui, -apple-system, Segoe UI, sans-serif',
+    Math.floor(innerW * 0.15),
+  );
   ctx.fillStyle = fg;
-  ctx.font = '900 160px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+  ctx.font = `900 ${brandSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.fillText('TRUEGRYND', textX, lineY(0.04));
+
+  const titleSize = fitFontSize(
+    ctx,
+    options.challengeTitle.toUpperCase(),
+    maxTextW,
+    900,
+    'system-ui, -apple-system, Segoe UI, sans-serif',
+    Math.floor(innerW * 0.062),
+    14,
+  );
+  ctx.fillStyle = muted;
+  ctx.font = `900 ${titleSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  const title = truncateToWidth(ctx, options.challengeTitle.toUpperCase(), maxTextW);
+  ctx.fillText(title, textX, lineY(0.13));
+
   const scoreText =
     options.scoreType === 'time' ? formatSeconds(options.scoreValue) : String(options.scoreValue);
-  ctx.fillText(scoreText, innerX + 30, innerY + 190);
-
-  ctx.fillStyle = muted;
-  ctx.font = '900 26px system-ui, -apple-system, Segoe UI, sans-serif';
-  const label = options.scoreType === 'time' ? 'TIME (MM:SS)' : 'REPS';
-  ctx.fillText(label, innerX + 30, innerY + 370);
-
-  // rank
+  const scoreSize = fitFontSize(
+    ctx,
+    scoreText,
+    maxTextW,
+    900,
+    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+    Math.floor(innerW * 0.44),
+  );
   ctx.fillStyle = fg;
-  ctx.font = '900 72px system-ui, -apple-system, Segoe UI, sans-serif';
+  ctx.font = `900 ${scoreSize}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`;
+  ctx.fillText(scoreText, textX, lineY(0.26));
+
+  const labelSize = Math.floor(innerW * 0.072);
+  ctx.fillStyle = muted;
+  ctx.font = `900 ${labelSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  const label = options.scoreType === 'time' ? 'TIME (MM:SS)' : 'REPS';
+  ctx.fillText(label, textX, lineY(0.52));
+
   const rankText =
     options.rankTextOverride ?? (options.topPercent ? `TOP ${options.topPercent}%` : 'SAVED');
-  ctx.fillText(rankText, innerX + 30, innerY + 470);
+  const rankSize = fitFontSize(
+    ctx,
+    rankText,
+    maxTextW,
+    900,
+    'system-ui, -apple-system, Segoe UI, sans-serif',
+    Math.floor(innerW * 0.2),
+  );
+  ctx.fillStyle = fg;
+  ctx.font = `900 ${rankSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.fillText(rankText, textX, lineY(0.58));
 
-  ctx.fillStyle = muted;
-  ctx.font = '900 22px system-ui, -apple-system, Segoe UI, sans-serif';
   const rankSub =
     options.rankSubOverride ??
     (options.topPercent ? 'WORLDWIDE (VALIDATED)' : 'NOT RANKED (NO VIDEO)');
-  ctx.fillText(rankSub, innerX + 30, innerY + 560);
-
-  // footer identity
-  ctx.fillStyle = accent;
-  ctx.font = '900 26px system-ui, -apple-system, Segoe UI, sans-serif';
-  ctx.fillText(options.username.toUpperCase(), innerX + 30, innerY + innerH - 70);
-
+  const rankSubSize = fitFontSize(
+    ctx,
+    rankSub,
+    maxTextW,
+    900,
+    'system-ui, -apple-system, Segoe UI, sans-serif',
+    Math.floor(innerW * 0.058),
+    12,
+  );
   ctx.fillStyle = muted;
-  ctx.font = '900 22px system-ui, -apple-system, Segoe UI, sans-serif';
-  ctx.fillText(options.faction.replace('_', ' ').toUpperCase(), innerX + 30, innerY + innerH - 40);
+  ctx.font = `900 ${rankSubSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  const rankSubLine = truncateToWidth(ctx, rankSub, maxTextW);
+  ctx.fillText(rankSubLine, textX, lineY(0.68));
+
+  const usernameSize = Math.floor(innerW * 0.072);
+  ctx.fillStyle = accent;
+  ctx.font = `900 ${usernameSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.fillText(truncateToWidth(ctx, options.username.toUpperCase(), maxTextW), textX, lineY(0.78));
+
+  const factionLabel = options.faction.replace('_', ' ').toUpperCase();
+  const factionSize = Math.floor(innerW * 0.058);
+  ctx.fillStyle = muted;
+  ctx.font = `900 ${factionSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+  ctx.fillText(truncateToWidth(ctx, factionLabel, maxTextW), textX, lineY(0.85));
 }
 
 function formatSeconds(totalSeconds: number): string {

--- a/src/features/overview/components/OverviewScreen.tsx
+++ b/src/features/overview/components/OverviewScreen.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { Flame } from 'lucide-react';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
-import { useProfile } from '@/features/profile/hooks/useProfile';
 import { useChallengeOfTheDay } from '@/features/overview/hooks/useChallengeOfTheDay';
+import { useProfile } from '@/features/profile/hooks/useProfile';
+import { getFactionBadgeClasses } from '@/lib/factionStyles';
 
 function PrimaryButtonLink({ href, label }: { href: string; label: string }) {
   return (
@@ -21,11 +23,16 @@ export function OverviewScreen() {
   const locale = useLocale();
   const tApp = useTranslations('app');
   const t = useTranslations('overview');
+  const tFactions = useTranslations('factions');
 
   const { state: cotd, refetch: refetchCotd } = useChallengeOfTheDay();
   const { state: profile, refetch: refetchProfile } = useProfile();
 
   const clanHref = `/${locale}/app/clan`;
+  const readyProfile = profile.status === 'ready' ? profile.profile : null;
+  const userFaction = readyProfile?.faction ?? null;
+  const factionBadge = userFaction ? getFactionBadgeClasses(userFaction) : null;
+  const factionName = userFaction ? tFactions(userFaction) : null;
 
   return (
     <section className="space-y-6">
@@ -104,25 +111,54 @@ export function OverviewScreen() {
             </div>
           ) : null}
 
-          {profile.status === 'ready' ? (
-            <div className="mt-3 space-y-2">
-              <div className="flex items-baseline justify-between gap-3">
-                <p className="text-sm font-black uppercase tracking-[0.18em] text-foreground">
-                  {t('streakLabel')}
-                </p>
-                <p className="text-sm text-foreground/90">
-                  {t('streakValue', { days: profile.profile.streak_days })}
-                </p>
+          {readyProfile ? (
+            <div className="mt-3 space-y-4">
+              <div
+                className="flex items-center justify-end gap-2"
+                role="group"
+                aria-label={t('streakLine', { days: readyProfile.streak_days })}
+              >
+                <Flame
+                  className={
+                    readyProfile.streak_days > 0
+                      ? 'h-5 w-5 shrink-0 text-accent'
+                      : 'h-5 w-5 shrink-0 text-muted-foreground'
+                  }
+                  aria-hidden
+                />
+                <span className="text-lg font-black tabular-nums tracking-tight text-foreground">
+                  {t('streakValue', { days: readyProfile.streak_days })}
+                </span>
               </div>
 
-              <div className="rounded-md border border-border bg-background p-3">
-                <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
-                  {t('factionNudgeTitle')}
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {profile.profile.faction ? t('factionNudgeBody') : t('noFactionBody')}
-                </p>
-                <PrimaryButtonLink href={clanHref} label={t('ctaClan')} />
+              <div className="border-t border-border pt-4 space-y-2">
+                {userFaction && factionBadge && factionName ? (
+                  <>
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+                        {t('factionYourTeam')}
+                      </p>
+                      <span
+                        className={[
+                          'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+                          factionBadge.bg,
+                          factionBadge.text,
+                          factionBadge.border,
+                        ].join(' ')}
+                      >
+                        {factionName}
+                      </span>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {t('factionNudgeBody', { faction: factionName })}
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-sm text-muted-foreground">{t('noFactionBody')}</p>
+                )}
+                <div className="mt-3">
+                  <PrimaryButtonLink href={clanHref} label={t('ctaClan')} />
+                </div>
               </div>
             </div>
           ) : null}

--- a/src/features/profile/components/FinisherGallery.tsx
+++ b/src/features/profile/components/FinisherGallery.tsx
@@ -103,7 +103,7 @@ export function FinisherGallery({ userId, username, faction }: Props) {
       <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
         {t('title')}
       </p>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid max-w-sm grid-cols-2 gap-3">
         {state.data.map((s) => {
           const href = `/${locale}/app/finish?challengeId=${s.challengeId}&ranked=${String(
             s.isValidated,

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -5,29 +5,8 @@ import { useTranslations } from 'next-intl';
 import { CreatorScoreBadge } from '@/features/profile/components/CreatorScoreBadge';
 import { AVATAR_ACCEPT, useAvatarUpload } from '@/features/profile/hooks/useAvatarUpload';
 import { initialsFromUsername } from '@/features/profile/lib/initials';
-import type { Faction, Profile } from '@/lib/types/database.types';
-
-function factionClasses(faction: Faction): { bg: string; text: string; border: string } {
-  if (faction === 'nomads') {
-    return {
-      bg: 'bg-[var(--faction-nomads)]/15',
-      text: 'text-[var(--faction-nomads)]',
-      border: 'border-[var(--faction-nomads)]/40',
-    };
-  }
-  if (faction === 'horde') {
-    return {
-      bg: 'bg-[var(--faction-horde)]/15',
-      text: 'text-[var(--faction-horde)]',
-      border: 'border-[var(--faction-horde)]/40',
-    };
-  }
-  return {
-    bg: 'bg-[var(--faction-iron)]/15',
-    text: 'text-[var(--faction-iron)]',
-    border: 'border-[var(--faction-iron)]/40',
-  };
-}
+import { getFactionBadgeClasses } from '@/lib/factionStyles';
+import type { Profile } from '@/lib/types/database.types';
 
 function HudAvatarPlate({
   avatarUrl,
@@ -91,7 +70,7 @@ export function ProfileHeader({ profile, onAvatarUpdated }: Props) {
 
   const username = profile.username ?? t('unknownUser');
   const faction = profile.faction;
-  const badge = faction ? factionClasses(faction) : null;
+  const badge = faction ? getFactionBadgeClasses(faction) : null;
 
   return (
     <section className="rounded-sm border border-border bg-card p-4">

--- a/src/features/profile/components/PublicProfileHeader.tsx
+++ b/src/features/profile/components/PublicProfileHeader.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { CreatorScoreBadge } from '@/features/profile/components/CreatorScoreBadge';
+import { initialsFromUsername } from '@/features/profile/lib/initials';
+import { getFactionBadgeClasses } from '@/lib/factionStyles';
+import type { Profile } from '@/lib/types/database.types';
+
+type Props = {
+  profile: Profile;
+};
+
+export function PublicProfileHeader({ profile }: Props) {
+  const t = useTranslations('profile.header');
+  const ta = useTranslations('profile.public');
+
+  const username = profile.username ?? t('unknownUser');
+  const faction = profile.faction;
+  const badge = faction ? getFactionBadgeClasses(faction) : null;
+
+  return (
+    <section className="rounded-sm border border-border bg-card p-4">
+      <div className="flex items-start gap-4">
+        <div
+          className="h-20 w-20 shrink-0 overflow-hidden rounded-sm border border-border bg-muted shadow-[0_10px_30px_rgba(0,0,0,0.22)]"
+          aria-hidden={profile.avatar_url ? undefined : true}
+        >
+          {profile.avatar_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={profile.avatar_url}
+              alt={ta('avatarAlt', { username })}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-2xl font-black tracking-tight">
+              {initialsFromUsername(profile.username)}
+            </div>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-3 pt-1">
+          <div>
+            <p className="truncate text-xl font-black uppercase tracking-tight">{username}</p>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              {badge ? (
+                <span
+                  className={[
+                    'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+                    badge.bg,
+                    badge.text,
+                    badge.border,
+                  ].join(' ')}
+                >
+                  {t(`factions.${faction}`)}
+                </span>
+              ) : (
+                <span className="inline-flex items-center rounded-sm border border-border bg-muted px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+                  {t('noFaction')}
+                </span>
+              )}
+              <span className="text-xs text-muted-foreground">
+                {t('streak', { days: profile.streak_days })}
+              </span>
+              <CreatorScoreBadge score={profile.creator_score} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/profile/components/PublicProfileScreen.tsx
+++ b/src/features/profile/components/PublicProfileScreen.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { PublicProfileHeader } from '@/features/profile/components/PublicProfileHeader';
+import { ScoreHistory } from '@/features/profile/components/ScoreHistory';
+import { usePublicProfile } from '@/features/profile/hooks/usePublicProfile';
+
+type Props = {
+  username: string;
+};
+
+export function PublicProfileScreen({ username }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('profile.public');
+  const { state, refetch } = usePublicProfile(username);
+
+  if (state.status === 'loading') {
+    return (
+      <section className="space-y-3">
+        <p role="status" aria-live="polite" className="text-sm text-muted-foreground">
+          {t('loading')}
+        </p>
+      </section>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="space-y-4">
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+            {t('errorTitle')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">{t('errorBody')}</p>
+          <button
+            type="button"
+            onClick={refetch}
+            className="mt-4 inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('retry')}
+          </button>
+        </div>
+        <Link
+          href={`/${locale}/app/clan`}
+          className="inline-flex min-h-11 items-center justify-center rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.18em] hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('backClan')}
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">
+          {state.profile.username ?? t('unknownUser')}
+        </h1>
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('subtitle')}
+        </p>
+      </header>
+
+      <PublicProfileHeader profile={state.profile} />
+      <ScoreHistory userId={state.profile.id} />
+
+      <Link
+        href={`/${locale}/app/clan`}
+        className="inline-flex min-h-11 items-center justify-center rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.18em] hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t('backClan')}
+      </Link>
+    </section>
+  );
+}

--- a/src/features/profile/hooks/usePublicProfile.ts
+++ b/src/features/profile/hooks/usePublicProfile.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { getProfileByUsername } from '@/features/profile/services/profile';
+import type { Profile } from '@/lib/types/database.types';
+
+type State =
+  | { status: 'loading'; profile: null; error: null }
+  | { status: 'ready'; profile: Profile; error: null }
+  | { status: 'error'; profile: null; error: string };
+
+const initial: State = { status: 'loading', profile: null, error: null };
+
+const invalidUsernameState: State = {
+  status: 'error',
+  profile: null,
+  error: 'profile_not_found',
+};
+
+export function usePublicProfile(username: string): { state: State; refetch: () => void } {
+  const trimmed = username.trim();
+  const [state, setState] = useState<State>(initial);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!trimmed) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const profile = await getProfileByUsername(trimmed);
+        if (!cancelled) setState({ status: 'ready', profile, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', profile: null, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [trimmed, reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState(initial);
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  const resolvedState = trimmed ? state : invalidUsernameState;
+
+  return { state: resolvedState, refetch };
+}

--- a/src/features/profile/lib/publicProfilePath.ts
+++ b/src/features/profile/lib/publicProfilePath.ts
@@ -1,0 +1,3 @@
+export function publicProfilePath(locale: string, username: string): string {
+  return `/${locale}/app/u/${encodeURIComponent(username)}`;
+}

--- a/src/features/profile/services/profile.ts
+++ b/src/features/profile/services/profile.ts
@@ -2,6 +2,17 @@ import { supabase } from '@/lib/supabase';
 import { PROFILE_COLUMNS } from '@/lib/profileSelect';
 import type { Profile } from '@/lib/types/database.types';
 
+export async function getProfileByUsername(username: string): Promise<Profile> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select(PROFILE_COLUMNS)
+    .eq('username', username)
+    .maybeSingle<Profile>();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('profile_not_found');
+  return data;
+}
+
 export async function getProfileById(userId: string): Promise<Profile> {
   const { data, error } = await supabase
     .from('profiles')

--- a/src/lib/factionStyles.ts
+++ b/src/lib/factionStyles.ts
@@ -4,6 +4,7 @@ export type FactionBadgeClasses = {
   bg: string;
   text: string;
   border: string;
+  accent: string;
 };
 
 export function getFactionBadgeClasses(faction: Faction): FactionBadgeClasses {
@@ -12,6 +13,7 @@ export function getFactionBadgeClasses(faction: Faction): FactionBadgeClasses {
       bg: 'bg-[var(--faction-nomads)]/15',
       text: 'text-[var(--faction-nomads)]',
       border: 'border-[var(--faction-nomads)]/40',
+      accent: 'border-l-[var(--faction-nomads)]',
     };
   }
   if (faction === 'horde') {
@@ -19,11 +21,13 @@ export function getFactionBadgeClasses(faction: Faction): FactionBadgeClasses {
       bg: 'bg-[var(--faction-horde)]/15',
       text: 'text-[var(--faction-horde)]',
       border: 'border-[var(--faction-horde)]/40',
+      accent: 'border-l-[var(--faction-horde)]',
     };
   }
   return {
     bg: 'bg-[var(--faction-iron)]/15',
     text: 'text-[var(--faction-iron)]',
     border: 'border-[var(--faction-iron)]/40',
+    accent: 'border-l-[var(--faction-iron)]',
   };
 }

--- a/src/lib/factionStyles.ts
+++ b/src/lib/factionStyles.ts
@@ -1,0 +1,29 @@
+import type { Faction } from '@/lib/types/database.types';
+
+export type FactionBadgeClasses = {
+  bg: string;
+  text: string;
+  border: string;
+};
+
+export function getFactionBadgeClasses(faction: Faction): FactionBadgeClasses {
+  if (faction === 'nomads') {
+    return {
+      bg: 'bg-[var(--faction-nomads)]/15',
+      text: 'text-[var(--faction-nomads)]',
+      border: 'border-[var(--faction-nomads)]/40',
+    };
+  }
+  if (faction === 'horde') {
+    return {
+      bg: 'bg-[var(--faction-horde)]/15',
+      text: 'text-[var(--faction-horde)]',
+      border: 'border-[var(--faction-horde)]/40',
+    };
+  }
+  return {
+    bg: 'bg-[var(--faction-iron)]/15',
+    text: 'text-[var(--faction-iron)]',
+    border: 'border-[var(--faction-iron)]/40',
+  };
+}

--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -67,6 +67,8 @@ export interface Challenge {
   ai_summary?: string | null;
   ai_model?: string | null;
   ai_checked_at?: string | null;
+  /** When set and in the past, approved challenge is closed in Arena (done). */
+  ends_at?: string | null;
   created_at: string;
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -167,6 +167,14 @@
     "errorBody": "Try again.",
     "retry": "Retry",
     "factionsTitle": "FACTION WAR",
+    "pointsUnit": "pts",
+    "yourFactionBadge": "YOUR FACTION",
+    "youBadge": "YOU",
+    "yourProfileLinkAria": "Your profile",
+    "memberProfileLinkAria": "View {username} profile",
+    "yourFactionArenaAria": "Go to Arena for your faction",
+    "ctaArena": "POST A SCORE",
+    "activeFighters": "{count, plural, =0 {0 active fighters} =1 {1 active fighter} other {# active fighters}}",
     "topMembersTitle": "YOUR TOP DOGS",
     "emptyMembers": "No ranked members yet. Be the first to post proof.",
     "members": "{count, plural, =0 {0 members} =1 {1 member} other {# members}}",
@@ -177,12 +185,13 @@
     },
     "recruit": {
       "title": "RECRUIT AN ALLY",
-      "body": "Send this link to bring someone directly into your faction.",
       "share": "SHARE",
       "copy": "COPY LINK",
       "copied": "COPIED!",
-      "shareTitle": "Truegrynd — Join my faction",
-      "shareText": "Join my faction on Truegrynd and compete together."
+      "shareAria": "Share recruit link for {faction}",
+      "copyAria": "Copy recruit link to clipboard",
+      "shareTitle": "Truegrynd — Join {faction}",
+      "shareText": "Join {faction} on Truegrynd. Async fitness battles, no fluff."
     }
   },
   "arena": {
@@ -193,14 +202,19 @@
       "new": "New"
     },
     "loading": "Loading challenges...",
-    "empty": "No challenges yet. Check back soon.",
+    "empty": "No challenges in the Arena yet.",
+    "emptyHint": "Propose one — community challenges go live after review.",
+    "emptyLiveFeed": "No live challenges in the public feed yet.",
+    "pendingSectionTitle": "YOUR SUBMISSIONS",
+    "pendingSectionHint": "Only you see these until they're approved for the Arena.",
+    "pendingBadge": "IN REVIEW",
     "errorTitle": "Something went wrong",
     "errorBody": "We could not load the challenges.",
     "retry": "Retry",
     "officialBadge": "OFFICIAL",
     "badges": {
       "community": "COMMUNITY",
-      "pendingReview": "PENDING REVIEW",
+      "pendingReview": "IN REVIEW",
       "rejected": "NOT APPROVED"
     },
     "scoreType": {
@@ -222,6 +236,7 @@
         "title": "Title",
         "description": "Short pitch",
         "rulesDetail": "Standards & scoring (detail)",
+        "rulesDetailPlaceholder": "Standards, range of motion, no-rep rules, tie-breaks…",
         "equipmentTags": "Equipment (optional)",
         "equipmentPlaceholder": "kettlebell, pull-up bar…"
       },
@@ -283,12 +298,22 @@
     "notFoundTitle": "Challenge not found",
     "notFoundBody": "It may have been removed or unapproved.",
     "back": "Back to Arena",
+    "heroKickerApproved": "ENTER THE GRIND",
+    "heroKickerPending": "LOCKED — STILL YOURS",
+    "heroKickerRejected": "PULLED FROM THE ARENA",
+    "ctaSubline": "Post your score. Claim your rank.",
+    "pendingStep1": "SUBMITTED",
+    "pendingStep2": "IN REVIEW",
+    "pendingStep3": "GOES LIVE",
+    "circuitHeading": "THE CIRCUIT",
+    "scoringHeading": "SCORING",
+    "standardsHeading": "STANDARDS",
     "rulesHeading": "Rules",
     "equipmentHeading": "Equipment",
     "noEquipment": "Bodyweight only",
     "ctaStart": "I'M IN",
-    "pendingTitle": "WAITING ON REVIEW",
-    "pendingBody": "This challenge is locked until it is approved. Share the link with mods if needed.",
+    "pendingTitle": "NOT IN THE ARENA YET",
+    "pendingBody": "Saved and in review. It will show up in the public feed once approved — then anyone can post a score.",
     "rejectedTitle": "NOT PUBLISHED",
     "rejectedBody": "This challenge did not pass review. Create a new version or contact support.",
     "rejectionModeratorNote": "Moderator note:\n{note}",
@@ -296,7 +321,7 @@
   },
   "admin": {
     "title": "UGC MOD QUEUE",
-    "subtitle": "Approve or reject community challenges. Nothing goes live without you.",
+    "subtitle": "Moderation vs Arena. In review → approve. Live = open in Arena. Done = closed. Rejected = blocked.",
     "nav": {
       "link": "MOD",
       "dock": "MOD",
@@ -304,7 +329,38 @@
     },
     "queue": {
       "loading": "Loading queue…",
-      "empty": "No pending challenges.",
+      "statusTabsLabel": "Challenge status",
+      "statusTabAria": "{label}, {count} community challenges",
+      "ugcTotal": "{count} community challenges total (all statuses)",
+      "statusTab": {
+        "pending": "IN REVIEW",
+        "arena_live": "LIVE",
+        "arena_done": "DONE",
+        "rejected": "REJECTED"
+      },
+      "empty": {
+        "pending": "Nothing in review right now.",
+        "arena_live": "No challenges currently open in the Arena.",
+        "arena_done": "No closed challenges yet.",
+        "rejected": "No rejected challenges yet."
+      },
+      "statusLabel": {
+        "pending": "IN REVIEW",
+        "arena_live": "LIVE",
+        "arena_done": "DONE",
+        "rejected": "REJECTED"
+      },
+      "closeArena": "CLOSE",
+      "colStatus": "Status",
+      "colReviewed": "Published",
+      "colClosed": "Closed",
+      "view": "VIEW",
+      "paginationSummary": {
+        "pending": "Page {page} of {totalPages} · {totalCount} in review",
+        "arena_live": "Page {page} of {totalPages} · {totalCount} live",
+        "arena_done": "Page {page} of {totalPages} · {totalCount} done",
+        "rejected": "Page {page} of {totalPages} · {totalCount} rejected"
+      },
       "selectAll": "Select all",
       "clearSelection": "Clear",
       "approveSelected": "Approve selected ({count})",
@@ -334,8 +390,7 @@
       "tierLongUnknown": "Not scanned yet.",
       "selectRow": "Select row: {title}",
       "paginationPrev": "Previous",
-      "paginationNext": "Next",
-      "paginationSummary": "Page {page} of {totalPages} · {totalCount} pending"
+      "paginationNext": "Next"
     },
     "approveConfirm": {
       "titleSingle": "Approve challenge?",
@@ -449,6 +504,16 @@
     "errorTitle": "Could not load profile",
     "errorBody": "Try again.",
     "retry": "Retry",
+    "public": {
+      "loading": "Loading fighter…",
+      "subtitle": "PUBLIC PROFILE",
+      "unknownUser": "Unknown",
+      "avatarAlt": "{username} avatar",
+      "errorTitle": "Fighter not found",
+      "errorBody": "This username does not exist or was removed.",
+      "retry": "Retry",
+      "backClan": "BACK TO CLAN"
+    },
     "signOut": {
       "label": "LOG OUT",
       "aria": "Log out of your account",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -153,10 +153,10 @@
     "ctaArena": "OPEN ARENA",
     "ctaClan": "OPEN CLAN",
     "empty": "No challenges available yet.",
-    "streakLabel": "STREAK",
+    "streakLine": "Streak: {days}d",
     "streakValue": "{days}d",
-    "factionNudgeTitle": "FACTION",
-    "factionNudgeBody": "Your faction needs points today. Post a ranked score.",
+    "factionYourTeam": "YOUR TEAM",
+    "factionNudgeBody": "{faction} needs points today. Post a ranked score.",
     "noFactionBody": "No faction on file. Complete onboarding.",
     "noFactionCta": "GO TO ONBOARDING"
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -167,6 +167,14 @@
     "errorBody": "Réessaie.",
     "retry": "Réessayer",
     "factionsTitle": "GUERRE DES FACTIONS",
+    "pointsUnit": "pts",
+    "yourFactionBadge": "TA FACTION",
+    "youBadge": "TOI",
+    "yourProfileLinkAria": "Ton profil",
+    "memberProfileLinkAria": "Voir le profil de {username}",
+    "yourFactionArenaAria": "Aller à l’Arène pour ta faction",
+    "ctaArena": "POSTER UN SCORE",
+    "activeFighters": "{count, plural, =0 {0 combattants actifs} =1 {1 combattant actif} other {# combattants actifs}}",
     "topMembersTitle": "TES TOP SOLDATS",
     "emptyMembers": "Aucun membre classé pour l’instant. Sois le premier à poster une preuve.",
     "members": "{count, plural, =0 {0 membres} =1 {1 membre} other {# membres}}",
@@ -177,12 +185,13 @@
     },
     "recruit": {
       "title": "RECRUTER UN ALLIÉ",
-      "body": "Envoie ce lien pour amener quelqu'un directement dans ta faction.",
       "share": "PARTAGER",
       "copy": "COPIER LE LIEN",
       "copied": "COPIÉ !",
-      "shareTitle": "Truegrynd — Rejoins ma faction",
-      "shareText": "Rejoins ma faction sur Truegrynd et compétis ensemble."
+      "shareAria": "Partager le lien de recrutement {faction}",
+      "copyAria": "Copier le lien de recrutement",
+      "shareTitle": "Truegrynd — Rejoins {faction}",
+      "shareText": "Rejoins {faction} sur Truegrynd. Compétition fitness async, sans blabla."
     }
   },
   "arena": {
@@ -193,14 +202,19 @@
       "new": "Nouveaux"
     },
     "loading": "Chargement des défis...",
-    "empty": "Aucun défi pour l'instant. Reviens bientôt.",
+    "empty": "Aucun défi dans l'Arène pour l'instant.",
+    "emptyHint": "Propose-en un — les défis communauté passent en revue avant publication.",
+    "emptyLiveFeed": "Aucun défi live dans le feed public pour l'instant.",
+    "pendingSectionTitle": "TES ENVOIS",
+    "pendingSectionHint": "Visible seulement par toi jusqu'à validation dans l'Arène.",
+    "pendingBadge": "EN REVUE",
     "errorTitle": "Une erreur est survenue",
     "errorBody": "Impossible de charger les défis.",
     "retry": "Réessayer",
     "officialBadge": "OFFICIEL",
     "badges": {
       "community": "COMMUNAUTÉ",
-      "pendingReview": "EN ATTENTE",
+      "pendingReview": "EN REVUE",
       "rejected": "NON VALIDÉ"
     },
     "scoreType": {
@@ -222,6 +236,7 @@
         "title": "Titre",
         "description": "Accroche courte",
         "rulesDetail": "Standards & scoring (détail)",
+        "rulesDetailPlaceholder": "Standards, amplitude, no-rep, départage…",
         "equipmentTags": "Équipement (optionnel)",
         "equipmentPlaceholder": "kettlebell, barre de traction…"
       },
@@ -283,12 +298,22 @@
     "notFoundTitle": "Défi introuvable",
     "notFoundBody": "Il a peut-être été supprimé ou n'est pas approuvé.",
     "back": "Retour à l'Arène",
+    "heroKickerApproved": "ENTRE DANS LE GRIND",
+    "heroKickerPending": "VERROUILLÉ — C'EST LE TIEN",
+    "heroKickerRejected": "RETIRÉ DE L'ARÈNE",
+    "ctaSubline": "Poste ton score. Prends ta place.",
+    "pendingStep1": "ENVOYÉ",
+    "pendingStep2": "EN REVUE",
+    "pendingStep3": "PUBLICATION",
+    "circuitHeading": "LE CIRCUIT",
+    "scoringHeading": "SCORING",
+    "standardsHeading": "STANDARDS",
     "rulesHeading": "Règles",
     "equipmentHeading": "Équipement",
     "noEquipment": "Poids du corps uniquement",
     "ctaStart": "JE M'INSCRIS",
-    "pendingTitle": "EN ATTENTE DE VALIDATION",
-    "pendingBody": "Ce défi est verrouillé jusqu'à validation. Partage le lien avec un admin si besoin.",
+    "pendingTitle": "PAS ENCORE DANS L'ARÈNE",
+    "pendingBody": "Enregistré, en cours de validation. Il apparaîtra dans le feed public une fois approuvé — ensuite tout le monde pourra poster un score.",
     "rejectedTitle": "NON PUBLIÉ",
     "rejectedBody": "Ce défi n'a pas été validé. Crée une nouvelle version ou contacte le support.",
     "rejectionModeratorNote": "Note modération :\n{note}",
@@ -296,7 +321,7 @@
   },
   "admin": {
     "title": "FILE MODÉRATION UGC",
-    "subtitle": "Approuve ou refuse les défis communautaires. Rien ne passe en ligne sans toi.",
+    "subtitle": "Modération vs Arène. En revue → approuver. Live = ouvert dans l’Arène. Terminé = fermé. Refusé = bloqué.",
     "nav": {
       "link": "MOD",
       "dock": "MOD",
@@ -304,7 +329,38 @@
     },
     "queue": {
       "loading": "Chargement de la file…",
-      "empty": "Aucun défi en attente.",
+      "statusTabsLabel": "Statut des défis",
+      "statusTabAria": "{label}, {count} défis communauté",
+      "ugcTotal": "{count} défis communauté au total (tous statuts)",
+      "statusTab": {
+        "pending": "EN REVUE",
+        "arena_live": "EN COURS",
+        "arena_done": "TERMINÉ",
+        "rejected": "REFUSÉ"
+      },
+      "empty": {
+        "pending": "Rien en revue pour l'instant.",
+        "arena_live": "Aucun défi ouvert dans l’Arène pour l’instant.",
+        "arena_done": "Aucun défi fermé pour l’instant.",
+        "rejected": "Aucun défi refusé pour l'instant."
+      },
+      "statusLabel": {
+        "pending": "EN REVUE",
+        "arena_live": "EN COURS",
+        "arena_done": "TERMINÉ",
+        "rejected": "REFUSÉ"
+      },
+      "closeArena": "FERMER",
+      "colStatus": "Statut",
+      "colReviewed": "Publié",
+      "colClosed": "Fermé",
+      "view": "VOIR",
+      "paginationSummary": {
+        "pending": "Page {page} sur {totalPages} · {totalCount} en revue",
+        "arena_live": "Page {page} sur {totalPages} · {totalCount} en cours",
+        "arena_done": "Page {page} sur {totalPages} · {totalCount} terminés",
+        "rejected": "Page {page} sur {totalPages} · {totalCount} refusés"
+      },
       "selectAll": "Tout sélectionner",
       "clearSelection": "Effacer",
       "approveSelected": "Approuver la sélection ({count})",
@@ -334,8 +390,7 @@
       "tierLongUnknown": "Pas encore scanné.",
       "selectRow": "Sélectionner la ligne : {title}",
       "paginationPrev": "Précédent",
-      "paginationNext": "Suivant",
-      "paginationSummary": "Page {page} sur {totalPages} · {totalCount} en attente"
+      "paginationNext": "Suivant"
     },
     "approveConfirm": {
       "titleSingle": "Approuver ce défi ?",
@@ -449,6 +504,16 @@
     "errorTitle": "Impossible de charger le profil",
     "errorBody": "Réessaie.",
     "retry": "Réessayer",
+    "public": {
+      "loading": "Chargement du combattant…",
+      "subtitle": "PROFIL PUBLIC",
+      "unknownUser": "Inconnu",
+      "avatarAlt": "Avatar de {username}",
+      "errorTitle": "Combattant introuvable",
+      "errorBody": "Ce pseudo n’existe pas ou a été supprimé.",
+      "retry": "Réessayer",
+      "backClan": "RETOUR AU CLAN"
+    },
     "signOut": {
       "label": "DÉCONNEXION",
       "aria": "Se déconnecter du compte",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -153,10 +153,10 @@
     "ctaArena": "OUVRIR L’ARÈNE",
     "ctaClan": "OUVRIR CLAN",
     "empty": "Aucun défi disponible pour l’instant.",
-    "streakLabel": "SÉRIE",
+    "streakLine": "Série : {days}j",
     "streakValue": "{days}j",
-    "factionNudgeTitle": "FACTION",
-    "factionNudgeBody": "Ta faction a besoin de points aujourd’hui. Poste un score classé.",
+    "factionYourTeam": "TON ÉQUIPE",
+    "factionNudgeBody": "{faction} a besoin de points aujourd’hui. Poste un score classé.",
     "noFactionBody": "Aucune faction enregistrée. Termine l’onboarding.",
     "noFactionCta": "ALLER À L’ONBOARDING"
   },

--- a/supabase/migrations/013_challenge_arena_ends_at.sql
+++ b/supabase/migrations/013_challenge_arena_ends_at.sql
@@ -1,0 +1,42 @@
+-- Arena lifecycle: approved UGC challenges can be closed (no new era end date enforced in app yet).
+-- ends_at NULL = still open in Arena; ends_at <= now() = done / closed.
+
+ALTER TABLE public.challenges
+  ADD COLUMN IF NOT EXISTS ends_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.challenges.ends_at IS
+  'When set, challenge is closed in Arena (done). NULL = open-ended (live). Only meaningful for approved UGC.';
+
+CREATE INDEX IF NOT EXISTS idx_challenges_arena_open
+  ON public.challenges (reviewed_at DESC NULLS LAST, created_at DESC)
+  WHERE status = 'approved' AND is_official = FALSE AND ends_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.admin_close_challenge(p_challenge_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_app_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  UPDATE public.challenges
+  SET ends_at = NOW()
+  WHERE id = p_challenge_id
+    AND status = 'approved'
+    AND is_official = FALSE
+    AND (ends_at IS NULL OR ends_at > NOW());
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'challenge_not_closable';
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.admin_close_challenge IS
+  'Admin only: close an approved community challenge (sets ends_at = now).';
+
+REVOKE ALL ON FUNCTION public.admin_close_challenge(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_close_challenge(uuid) TO authenticated;

--- a/supabase/scripts/seed-qa-dummy-data.sql
+++ b/supabase/scripts/seed-qa-dummy-data.sql
@@ -1,0 +1,308 @@
+-- QA dummy data: Clan HUD, Arena feed, UGC by igorms
+-- Run in Supabase Dashboard → SQL Editor (postgres role).
+--
+-- Prerequisite: you have signed up and your profile username is `igorms`.
+-- Safe to re-run: removes previous rows with the fixed QA UUIDs first.
+--
+-- Creates:
+--   • 2 minimal official challenges (QA seed — no seed.sql needed)
+--   • 8 dummy members (3 factions) — not meant for login
+--   • 2 approved live UGC challenges by igorms
+--   • 1 pending UGC by igorms
+--   • Validated scores (with video URLs) for Clan + leaderboards
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ── Fixed IDs (do not reuse elsewhere) ───────────────────────────────────────
+
+-- Dummy auth users / profiles
+-- a0000001 … a0000008
+-- Dummy UGC challenges
+-- b0000001 pending, b0000002 + b0000003 approved live
+-- Minimal official challenges (created if your DB has none)
+-- c0000001 time, c0000002 reps
+
+DO $$
+DECLARE
+  v_igorms_id UUID;
+  v_official_time UUID;
+  v_official_reps UUID;
+  v_official_qa UUID[] := ARRAY[
+    'c0000001-0000-4000-8000-000000000001'::uuid,
+    'c0000002-0000-4000-8000-000000000002'::uuid
+  ];
+  v_dummy_users UUID[] := ARRAY[
+    'a0000001-0000-4000-8000-000000000001'::uuid,
+    'a0000002-0000-4000-8000-000000000002'::uuid,
+    'a0000003-0000-4000-8000-000000000003'::uuid,
+    'a0000004-0000-4000-8000-000000000004'::uuid,
+    'a0000005-0000-4000-8000-000000000005'::uuid,
+    'a0000006-0000-4000-8000-000000000006'::uuid,
+    'a0000007-0000-4000-8000-000000000007'::uuid,
+    'a0000008-0000-4000-8000-000000000008'::uuid
+  ];
+  v_dummy_challenges UUID[] := ARRAY[
+    'b0000001-0000-4000-8000-000000000001'::uuid,
+    'b0000002-0000-4000-8000-000000000002'::uuid,
+    'b0000003-0000-4000-8000-000000000003'::uuid
+  ];
+  u UUID;
+  c UUID;
+BEGIN
+  SELECT id INTO v_igorms_id
+  FROM public.profiles
+  WHERE lower(username) = 'igorms';
+
+  IF v_igorms_id IS NULL THEN
+    RAISE EXCEPTION 'Profile username igorms not found. Sign up first, then re-run.';
+  END IF;
+
+  -- Cleanup previous QA seed (order matters for FKs)
+  DELETE FROM public.scores
+  WHERE user_id = ANY (v_dummy_users)
+     OR challenge_id = ANY (v_dummy_challenges)
+     OR challenge_id = ANY (v_official_qa);
+
+  DELETE FROM public.challenges
+  WHERE id = ANY (v_dummy_challenges)
+     OR id = ANY (v_official_qa);
+
+  FOREACH u IN ARRAY v_dummy_users LOOP
+    DELETE FROM public.profiles WHERE id = u;
+    DELETE FROM auth.users WHERE id = u;
+  END LOOP;
+
+  -- Minimal official challenges (self-contained — no seed.sql required)
+  INSERT INTO public.challenges (
+    id,
+    title,
+    description,
+    rules,
+    score_type,
+    equipment_tags,
+    is_official,
+    status,
+    creator_id
+  ) VALUES
+  (
+    v_official_qa[1],
+    'QA Official — 50 Burpees',
+    'Complete 50 burpees for time. QA seed challenge.',
+    'Full burpee each rep. Record time in seconds.',
+    'time',
+    '{}',
+    true,
+    'approved',
+    NULL
+  ),
+  (
+    v_official_qa[2],
+    'QA Official — Max Push-Ups (1 min)',
+    'Max push-ups in 60 seconds. QA seed challenge.',
+    'Chest to floor, full lockout at top. Count reps in 60 seconds.',
+    'reps',
+    '{}',
+    true,
+    'approved',
+    NULL
+  );
+
+  v_official_time := v_official_qa[1];
+  v_official_reps := v_official_qa[2];
+
+  -- ── Dummy auth.users (display-only; password = dummy123 if you ever need login) ──
+
+  INSERT INTO auth.users (
+    id,
+    instance_id,
+    aud,
+    role,
+    email,
+    encrypted_password,
+    email_confirmed_at,
+    created_at,
+    updated_at,
+    confirmation_token,
+    email_change,
+    email_change_token_new,
+    recovery_token,
+    raw_app_meta_data,
+    raw_user_meta_data,
+    is_super_admin
+  )
+  SELECT
+    u.id,
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    u.email,
+    crypt('dummy123', gen_salt('bf')),
+    NOW(),
+    NOW(),
+    NOW(),
+    '',
+    '',
+    '',
+    '',
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    false
+  FROM (
+    VALUES
+      (v_dummy_users[1], 'qa-nomad1@truegrynd.test'),
+      (v_dummy_users[2], 'qa-nomad2@truegrynd.test'),
+      (v_dummy_users[3], 'qa-horde1@truegrynd.test'),
+      (v_dummy_users[4], 'qa-horde2@truegrynd.test'),
+      (v_dummy_users[5], 'qa-horde3@truegrynd.test'),
+      (v_dummy_users[6], 'qa-iron1@truegrynd.test'),
+      (v_dummy_users[7], 'qa-iron2@truegrynd.test'),
+      (v_dummy_users[8], 'qa-iron3@truegrynd.test')
+  ) AS u(id, email);
+
+  -- handle_new_user trigger created bare profiles — enrich them
+  UPDATE public.profiles SET
+    username = v.username,
+    sex = v.sex,
+    age = v.age,
+    weight_kg = v.weight_kg,
+    faction = v.faction,
+    initiation_completed = true,
+    updated_at = NOW()
+  FROM (
+    VALUES
+      (v_dummy_users[1], 'nomad_runner', 'male',   26, 78.0, 'nomads'),
+      (v_dummy_users[2], 'nomad_grit',   'female', 31, 62.0, 'nomads'),
+      (v_dummy_users[3], 'horde_alpha',  'male',   24, 85.0, 'horde'),
+      (v_dummy_users[4], 'horde_beast',  'male',   29, 92.0, 'horde'),
+      (v_dummy_users[5], 'horde_lynx',   'female', 22, 58.0, 'horde'),
+      (v_dummy_users[6], 'iron_ghost',   'male',   35, 88.0, 'iron_alliance'),
+      (v_dummy_users[7], 'iron_plate',   'female', 27, 70.0, 'iron_alliance'),
+      (v_dummy_users[8], 'iron_maul',    'other',  33, 95.0, 'iron_alliance')
+  ) AS v(id, username, sex, age, weight_kg, faction)
+  WHERE public.profiles.id = v.id;
+
+  -- ── UGC challenges by igorms ───────────────────────────────────────────────
+
+  INSERT INTO public.challenges (
+    id,
+    title,
+    description,
+    rules,
+    score_type,
+    equipment_tags,
+    is_official,
+    status,
+    creator_id,
+    max_duration_seconds,
+    reviewed_at,
+    reviewed_by,
+    ends_at,
+    created_at
+  ) VALUES
+  (
+    v_dummy_challenges[1],
+    'QA — Death by Burpees',
+    'AMRAP burpees in 10 minutes. Community test challenge by igorms.',
+    'Full burpee each rep: chest to floor, jump, hands overhead. Count total reps in 10:00.',
+    'reps',
+    '{}',
+    false,
+    'pending',
+    v_igorms_id,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NOW() - INTERVAL '2 days'
+  ),
+  (
+    v_dummy_challenges[2],
+    'QA — 400m Sandbag Carry',
+    '400 meters for time with a sandbag on shoulder. UGC live in Arena.',
+    'Men 50kg / women 35kg sandbag. One drop max. Record time in seconds.',
+    'time',
+    ARRAY['sandbag'],
+    false,
+    'approved',
+    v_igorms_id,
+    600,
+    NOW() - INTERVAL '1 day',
+    v_igorms_id,
+    NULL,
+    NOW() - INTERVAL '1 day'
+  ),
+  (
+    v_dummy_challenges[3],
+    'QA — Max Wall Balls (2 min)',
+    'Max unbroken wall-ball shots in 2 minutes. UGC live in Arena.',
+    '20/14 lb to 10 ft target. Full squat below parallel each rep. Count reps in 120 seconds.',
+    'reps',
+    ARRAY['wall ball'],
+    false,
+    'approved',
+    v_igorms_id,
+    NULL,
+    NOW() - INTERVAL '12 hours',
+    v_igorms_id,
+    NULL,
+    NOW() - INTERVAL '12 hours'
+  );
+
+  -- ── Validated scores (Clan counts only is_validated = true) ────────────────
+  -- Horde leads faction war, then Nomads, then Iron Alliance.
+
+  INSERT INTO public.scores (challenge_id, user_id, value, video_url, is_validated, submitted_at)
+  VALUES
+    -- Official time challenge
+    (v_official_time, v_dummy_users[3], 420, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '6 hours'),
+    (v_official_time, v_dummy_users[4], 395, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '5 hours'),
+    (v_official_time, v_dummy_users[5], 410, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '4 hours'),
+    (v_official_time, v_dummy_users[1], 450, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '3 hours'),
+    (v_official_time, v_dummy_users[2], 465, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '2 hours'),
+    (v_official_time, v_dummy_users[6], 480, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '2 hours'),
+    (v_official_time, v_dummy_users[7], 505, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '1 hour'),
+    (v_official_time, v_igorms_id,     430, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '30 minutes'),
+
+    -- Official reps challenge
+    (v_official_reps, v_dummy_users[3], 42, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '6 hours'),
+    (v_official_reps, v_dummy_users[4], 38, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '5 hours'),
+    (v_official_reps, v_dummy_users[5], 35, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '4 hours'),
+    (v_official_reps, v_dummy_users[1], 28, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '3 hours'),
+    (v_official_reps, v_dummy_users[2], 25, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '2 hours'),
+    (v_official_reps, v_dummy_users[6], 22, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '2 hours'),
+    (v_official_reps, v_dummy_users[8], 20, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '1 hour'),
+
+    -- igorms UGC challenges (boost creator_score on igorms)
+    (v_dummy_challenges[2], v_dummy_users[3], 95,  'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '3 hours'),
+    (v_dummy_challenges[2], v_dummy_users[4], 102, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '2 hours'),
+    (v_dummy_challenges[2], v_dummy_users[1], 118, 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '1 hour'),
+    (v_dummy_challenges[3], v_dummy_users[3], 48,  'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '4 hours'),
+    (v_dummy_challenges[3], v_dummy_users[5], 41,  'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '3 hours'),
+    (v_dummy_challenges[3], v_dummy_users[6], 36,  'https://www.youtube.com/watch?v=dQw4w9WgXcQ', true, NOW() - INTERVAL '2 hours'),
+
+    -- One unvalidated score (should NOT appear in Clan)
+    (v_official_reps, v_dummy_users[7], 99, NULL, false, NOW() - INTERVAL '30 minutes');
+
+  RAISE NOTICE 'QA seed OK — igorms_id=%, official_time=%, official_reps=%',
+    v_igorms_id, v_official_time, v_official_reps;
+END $$;
+
+-- Quick sanity check
+SELECT
+  p.faction,
+  count(DISTINCT s.user_id) AS active_members,
+  count(*) FILTER (WHERE s.is_validated) AS validated_scores,
+  round(sum(s.value) FILTER (WHERE s.is_validated)) AS raw_points_sum
+FROM public.scores s
+JOIN public.profiles p ON p.id = s.user_id
+WHERE s.user_id::text LIKE 'a000000%'
+   OR s.challenge_id::text LIKE 'b000000%'
+   OR s.challenge_id::text LIKE 'c000000%'
+GROUP BY p.faction
+ORDER BY raw_points_sum DESC NULLS LAST;
+
+SELECT id, title, status, is_official, creator_id, ends_at
+FROM public.challenges
+WHERE id::text LIKE 'b000000%'
+   OR id::text LIKE 'c000000%'
+ORDER BY created_at;


### PR DESCRIPTION
## Summary
- Public athlete pages at `/app/u/[username]` with `PublicProfileScreen`
- Clan screen refactor: Faction War card, Top Members with profile links, Arena CTA
- Challenge detail split into Hero + spec/circuit/locked panels; arena pending section
- Admin queue status tabs + `arenaLifecycle` helpers
- Migration `013` (`arena_ends_at`), QA seed script, docs (issues section I/K, V3 strategy)

## Remaining (section I — follow-up issue)
- `/app/faction/[slug]` page + Overview/Clan symmetric links
- Section **K** profile history page (separate branch)

## Test plan
- [x] `pnpm check` (lint + typecheck + 105 tests)
- [ ] Manual QA: public profile, clan top members links, arena pending
- [ ] Apply migration `013` on Supabase prod when merging


Made with [Cursor](https://cursor.com)