### PR TITLE
feat(profile): V1.5 profile cleanup + history page (#59)

### DIFF
--- a/docs/QA_V1_CHECKLIST.md
+++ b/docs/QA_V1_CHECKLIST.md
@@ -29,7 +29,7 @@ Coche : `[ ]` à faire · `[x]` OK · `[!]` bug (noter en bas)
 | 1.2 | Page auth : magic link              | Formulaire visible, pas de crash                         | [ ] | [ ] |
 | 1.3 | OAuth Google / Apple (si configuré) | Login OK ou erreur claire                                | [ ] | [ ] |
 | 1.4 | Routes protégées sans session       | `/en/app/arena`, `/profile`, `/onboarding` → auth        | [ ] | [ ] |
-| 1.5 | **LOG OUT** (profil)                | Retour auth, session invalidée, routes app inaccessibles | [ ] | [ ] |
+| 1.5 | **LOG OUT** (profil → ⚙️ settings)  | Retour auth, session invalidée, routes app inaccessibles | [ ] | [ ] |
 
 ---
 
@@ -83,13 +83,15 @@ Coche : `[ ]` à faire · `[x]` OK · `[!]` bug (noter en bas)
 
 ## 6. Profil
 
-| #   | Test                                                              | Attendu                                                     | EN  | FR  |
-| --- | ----------------------------------------------------------------- | ----------------------------------------------------------- | --- | --- |
-| 6.1 | Affichage streak                                                  | `streak_days` cohérent après nouvelle soumission (jour UTC) | [x] | [x] |
-| 6.2 | **Creator score** + badge (bronze/silver/gold si seuils atteints) | Affichage + tooltip / copy                                  | [x] | [x] |
-| 6.3 | Historique scores                                                 | Liste avec états ranked / saved si applicable               | [x] | [x] |
-| 6.4 | Galerie finisher cards                                            | Chargement / empty / erreur + retry                         | [!] | [!] |
-| 6.5 | Changement avatar                                                 | Upload OK, erreur si fichier trop gros / mauvais type       | [x] | [x] |
+| #    | Test                                                              | Attendu                                                                                                       | EN  | FR  |
+| ---- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | --- | --- |
+| 6.1  | Affichage streak                                                  | `streak_days` cohérent après nouvelle soumission (jour UTC)                                                   | [x] | [x] |
+| 6.2  | **Creator score** + badge (bronze/silver/gold si seuils atteints) | Affichage + tooltip / copy                                                                                    | [x] | [x] |
+| 6.3  | Historique scores                                                 | Liste avec états ranked / saved si applicable                                                                 | [x] | [x] |
+| 6.3b | **Show More** → `/app/profile/history`                            | Page history : filtres Tout / En cours / Validés / Sauvegardés / Gagnés ; lignes badge + CARD ; retour profil | [ ] | [ ] |
+| 6.3c | Profil principal sans section HISTORY en bas                      | Carrousel CARDS max 3–4 ; Log out dans menu ⚙️ header                                                         | [ ] | [ ] |
+| 6.4  | Galerie finisher cards                                            | Chargement / empty / erreur + retry                                                                           | [!] | [!] |
+| 6.5  | Changement avatar                                                 | Upload OK, erreur si fichier trop gros / mauvais type                                                         | [x] | [x] |
 
 **Streak (DB) :** après 1ère soumission du jour → streak ≥ 1 ; 2e soumission même jour → pas de double incrément (idempotent).
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -57,7 +57,7 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 **Macro V1.5 (avant premier lot V2 compétitif)**
 
 - [x] **V1.5** — Pages `/app/faction/[slug]` + symétrie Clan / Overview — section **I** — 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57) PR [#58](https://github.com/igorms-pro/truegrynd/pull/58) (QA checklist §7 reste manuel)
-- [ ] **V1.5** — Profil épuré + page Historique dédiée (`Show More` → `/app/profile/history`) — section **K**
+- [ ] **V1.5** — Profil épuré + page Historique dédiée (`Show More` → `/app/profile/history`) — section **K** — 🟡 [#59](https://github.com/igorms-pro/truegrynd/issues/59) branche `feature/issue-59-profile-history`
 
 **Macro pré-V2 (polish post-QA V1, avant V2-01)**
 
@@ -589,7 +589,7 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | Confiance / plateforme                    | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55)                                                           |
 | Mouvements / prescription (mix)           | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45)                                                           |
 | **V1.5 — Pages Faction**                  | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57) — PR [#56](https://github.com/igorms-pro/truegrynd/pull/56) + [#58](https://github.com/igorms-pro/truegrynd/pull/58) mergés |
-| **V1.5 — Profil & Historique**            | 🔴 spec section **K** — carrousel 3–4 cartes + `/app/profile/history` + filtres (Show More)                                                                                             |
+| **V1.5 — Profil & Historique**            | 🟡 [#59](https://github.com/igorms-pro/truegrynd/issues/59) — carrousel 3–4 cartes + `/app/profile/history` + filtres (Show More) — branche `feature/issue-59-profile-history`          |
 | **Fix flow submit (I'M IN → formulaire)** | 🔴 section **J** — polish pré-V2 (QA V1 §4, copy CTA)                                                                                                                                   |
 | **V2 — Accessible competition**           | 🔴 [docs/V2_STRATEGY.md](../V2_STRATEGY.md) — **V2-00** (exclusions) puis **V2-01 → V2-12** section **H**                                                                               |
 | **QA V1 (manuel)**                        | 🟡 [docs/QA_V1_CHECKLIST.md](../QA_V1_CHECKLIST.md) — à cocher ; ajouter parcours faction après V1.5                                                                                    |

--- a/src/app/[locale]/app/profile/history/page.tsx
+++ b/src/app/[locale]/app/profile/history/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ProfileHistoryScreen } from '@/features/profile/components/ProfileHistoryScreen';
+
+export default function ProfileHistoryPage() {
+  return <ProfileHistoryScreen />;
+}

--- a/src/app/[locale]/app/profile/page.tsx
+++ b/src/app/[locale]/app/profile/page.tsx
@@ -2,10 +2,9 @@
 
 import { useTranslations } from 'next-intl';
 
-import { SignOutButton } from '@/features/auth/components/SignOutButton';
 import { FinisherGallery } from '@/features/profile/components/FinisherGallery';
 import { ProfileHeader } from '@/features/profile/components/ProfileHeader';
-import { ScoreHistory } from '@/features/profile/components/ScoreHistory';
+import { ProfileSettingsMenu } from '@/features/profile/components/ProfileSettingsMenu';
 import { useProfile } from '@/features/profile/hooks/useProfile';
 
 export default function ProfilePage() {
@@ -50,21 +49,20 @@ export default function ProfilePage() {
 
   return (
     <section className="space-y-6">
-      <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
-        {tabs('profile')}
-      </h1>
+      <div className="flex items-start justify-between gap-3">
+        <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
+          {tabs('profile')}
+        </h1>
+        <ProfileSettingsMenu />
+      </div>
 
       <ProfileHeader profile={state.profile} onAvatarUpdated={refetch} />
-
-      <SignOutButton />
 
       <FinisherGallery
         userId={state.profile.id}
         username={state.profile.username}
         faction={state.profile.faction}
       />
-
-      <ScoreHistory userId={state.profile.id} />
     </section>
   );
 }

--- a/src/features/auth/components/SignOutButton.tsx
+++ b/src/features/auth/components/SignOutButton.tsx
@@ -6,7 +6,12 @@ import { useLocale, useTranslations } from 'next-intl';
 
 import { signOut } from '@/features/auth/services/auth';
 
-export function SignOutButton(): ReactElement {
+type Props = {
+  variant?: 'card' | 'menu';
+  onSignedOut?: () => void;
+};
+
+export function SignOutButton({ variant = 'card', onSignedOut }: Props): ReactElement {
   const t = useTranslations('profile.signOut');
   const locale = useLocale();
   const router = useRouter();
@@ -18,6 +23,7 @@ export function SignOutButton(): ReactElement {
     setBusy(true);
     try {
       await signOut();
+      onSignedOut?.();
       router.push(`/${locale}/auth`);
       router.refresh();
     } catch {
@@ -25,11 +31,38 @@ export function SignOutButton(): ReactElement {
     } finally {
       setBusy(false);
     }
-  }, [locale, router, t]);
+  }, [locale, onSignedOut, router, t]);
 
   const onClick = useCallback(() => {
     void handleClick();
   }, [handleClick]);
+
+  const buttonClass =
+    variant === 'menu'
+      ? 'inline-flex w-full min-h-11 items-center justify-center rounded-md px-3 py-2 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+      : 'inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+  if (variant === 'menu') {
+    return (
+      <div>
+        {error ? (
+          <p className="mb-2 px-2 text-xs font-semibold text-primary" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={busy}
+          aria-label={t('aria')}
+          role="menuitem"
+          className={buttonClass}
+        >
+          {busy ? t('submitting') : t('label')}
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-sm border border-border bg-card p-4">
@@ -43,7 +76,7 @@ export function SignOutButton(): ReactElement {
         onClick={onClick}
         disabled={busy}
         aria-label={t('aria')}
-        className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className={buttonClass}
       >
         {busy ? t('submitting') : t('label')}
       </button>

--- a/src/features/profile/components/FinisherGallery.tsx
+++ b/src/features/profile/components/FinisherGallery.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { useEffect, useMemo, useRef } from 'react';
 
 import { drawFinisherCard } from '@/features/finisher-card/lib/drawCard';
 import { useMyScores } from '@/features/profile/hooks/useMyScores';
+import { PROFILE_CARD_PREVIEW_LIMIT } from '@/features/profile/types';
 import type { Faction } from '@/lib/types/database.types';
 
 type Props = {
@@ -59,7 +61,8 @@ function ThumbCanvas({
 export function FinisherGallery({ userId, username, faction }: Props) {
   const t = useTranslations('profile.gallery');
   const locale = useLocale();
-  const { state } = useMyScores(userId, { limit: 6 });
+  const { state, refetch } = useMyScores(userId, { limit: PROFILE_CARD_PREVIEW_LIMIT });
+  const historyHref = `/${locale}/app/profile/history`;
 
   if (!username || !faction) {
     return null;
@@ -83,6 +86,13 @@ export function FinisherGallery({ userId, username, faction }: Props) {
           {t('title')}
         </p>
         <p className="mt-2 text-sm text-muted-foreground">{t('error')}</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-3 inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('retry')}
+        </button>
       </section>
     );
   }
@@ -90,9 +100,19 @@ export function FinisherGallery({ userId, username, faction }: Props) {
   if (state.data.length === 0) {
     return (
       <section className="rounded-md border border-border bg-card p-4">
-        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-          {t('title')}
-        </p>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('title')}
+          </p>
+          <Link
+            href={historyHref}
+            aria-label={t('showMoreAria')}
+            className="inline-flex min-h-11 items-center gap-1 text-[11px] font-black uppercase tracking-[0.18em] text-primary hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('showMore')}
+            <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+          </Link>
+        </div>
         <p className="mt-2 text-sm text-muted-foreground">{t('empty')}</p>
       </section>
     );
@@ -100,10 +120,21 @@ export function FinisherGallery({ userId, username, faction }: Props) {
 
   return (
     <section className="space-y-3">
-      <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-        {t('title')}
-      </p>
-      <div className="grid max-w-sm grid-cols-2 gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <Link
+          href={historyHref}
+          aria-label={t('showMoreAria')}
+          className="inline-flex min-h-11 shrink-0 items-center gap-1 text-[11px] font-black uppercase tracking-[0.18em] text-primary hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('showMore')}
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+        </Link>
+      </div>
+
+      <div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-1 snap-x snap-mandatory">
         {state.data.map((s) => {
           const href = `/${locale}/app/finish?challengeId=${s.challengeId}&ranked=${String(
             s.isValidated,
@@ -113,7 +144,7 @@ export function FinisherGallery({ userId, username, faction }: Props) {
             <Link
               key={s.id}
               href={href}
-              className="rounded-md border border-border bg-card p-2 hover:border-primary/40"
+              className="w-[42%] min-w-[9.5rem] max-w-[11rem] shrink-0 snap-start rounded-md border border-border bg-card p-2 hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-label={t('open')}
             >
               <ThumbCanvas

--- a/src/features/profile/components/HistoryItemRow.tsx
+++ b/src/features/profile/components/HistoryItemRow.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { formatScore } from '@/features/challenges/lib/scoreFormat';
+import type { HistoryItem } from '@/features/profile/types';
+
+type BadgeTone = 'ranked' | 'saved' | 'in_progress' | 'won';
+
+function StatusBadge({ children, tone }: { children: string; tone: BadgeTone }) {
+  const tones: Record<BadgeTone, string> = {
+    ranked: 'border-primary bg-primary/10 text-primary',
+    saved: 'border-border bg-muted text-muted-foreground',
+    in_progress: 'border-accent/50 bg-accent/15 text-accent',
+    won: 'border-accent bg-accent/20 text-accent',
+  };
+
+  return (
+    <span
+      className={[
+        'inline-flex shrink-0 items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+        tones[tone],
+      ].join(' ')}
+    >
+      {children}
+    </span>
+  );
+}
+
+type Props = {
+  item: HistoryItem;
+};
+
+export function HistoryItemRow({ item }: Props) {
+  const t = useTranslations('profile.historyPage');
+  const locale = useLocale();
+
+  if (item.kind === 'in_progress') {
+    const submitHref = `/${locale}/app/arena/${item.challengeId}/submit`;
+
+    return (
+      <div className="rounded-sm border border-border bg-background p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-black uppercase tracking-tight">
+              {item.challengeTitle}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {new Date(item.committedAt).toLocaleDateString()}
+            </p>
+          </div>
+          <StatusBadge tone="in_progress">{t('badges.inProgress')}</StatusBadge>
+        </div>
+
+        <div className="mt-3 flex justify-end">
+          <Link
+            href={submitHref}
+            className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-3 py-2 text-[11px] font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('actions.submit')}
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const scoreLabel = item.isValidated ? t('badges.ranked') : t('badges.saved');
+  const badgeTone = item.isValidated ? 'ranked' : 'saved';
+  const toFinisher = `/${locale}/app/finish?challengeId=${item.challengeId}&ranked=${String(
+    item.isValidated,
+  )}&scoreId=${encodeURIComponent(item.id)}`;
+  const formattedScore = formatScore(item.value, item.scoreType);
+
+  return (
+    <div className="rounded-sm border border-border bg-background p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-black uppercase tracking-tight">
+            {item.challengeTitle}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {formattedScore} · {new Date(item.submittedAt).toLocaleDateString()}
+          </p>
+        </div>
+        <StatusBadge tone={badgeTone}>{scoreLabel}</StatusBadge>
+      </div>
+
+      <div className="mt-3 flex justify-end">
+        <Link
+          href={toFinisher}
+          className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-3 py-2 text-[11px] font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('actions.card')}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/features/profile/components/ProfileHistoryScreen.tsx
+++ b/src/features/profile/components/ProfileHistoryScreen.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { HistoryItemRow } from '@/features/profile/components/HistoryItemRow';
+import { ProfileHistoryTabs } from '@/features/profile/components/ProfileHistoryTabs';
+import { useProfile } from '@/features/profile/hooks/useProfile';
+import { useProfileHistory } from '@/features/profile/hooks/useProfileHistory';
+import type { HistoryTab } from '@/features/profile/types';
+
+function emptyCopyKey(tab: HistoryTab): string {
+  return `empty.${tab}`;
+}
+
+export function ProfileHistoryScreen() {
+  const locale = useLocale();
+  const t = useTranslations('profile.historyPage');
+  const { state: profileState } = useProfile();
+  const userId = profileState.status === 'ready' ? profileState.profile.id : null;
+  const { state, activeTab, setActiveTab, filteredItems, refetch } = useProfileHistory(userId);
+
+  const profileHref = `/${locale}/app/profile`;
+
+  if (profileState.status === 'loading' || state.status === 'loading') {
+    return (
+      <section className="space-y-4">
+        <Link
+          href={profileHref}
+          className="inline-flex min-h-11 items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          {t('back')}
+        </Link>
+        <p role="status" className="text-sm text-muted-foreground">
+          {t('loading')}
+        </p>
+      </section>
+    );
+  }
+
+  if (profileState.status === 'error' || state.status === 'error') {
+    const errorMessage =
+      profileState.status === 'error'
+        ? profileState.error
+        : state.status === 'error'
+          ? state.error
+          : '';
+
+    return (
+      <section className="space-y-4">
+        <Link
+          href={profileHref}
+          className="inline-flex min-h-11 items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          {t('back')}
+        </Link>
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+            {t('errorTitle')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">{t('errorBody')}</p>
+          {errorMessage ? (
+            <p className="mt-2 text-xs text-muted-foreground">{errorMessage}</p>
+          ) : null}
+          <button
+            type="button"
+            onClick={refetch}
+            className="mt-4 inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('retry')}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const emptyKey = emptyCopyKey(activeTab);
+
+  return (
+    <section className="space-y-4">
+      <Link
+        href={profileHref}
+        className="inline-flex min-h-11 items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label={t('backAria')}
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        {t('back')}
+      </Link>
+
+      <h1 className="text-2xl md:text-3xl font-black uppercase tracking-tight">{t('title')}</h1>
+
+      <ProfileHistoryTabs active={activeTab} onChange={setActiveTab} disabled={false} />
+
+      {filteredItems.length === 0 ? (
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">{t(emptyKey)}</p>
+        </div>
+      ) : (
+        <div className="space-y-2" role="tabpanel">
+          {filteredItems.map((item) => (
+            <HistoryItemRow
+              key={item.kind === 'score' ? item.id : `progress-${item.challengeId}`}
+              item={item}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/profile/components/ProfileHistoryTabs.test.tsx
+++ b/src/features/profile/components/ProfileHistoryTabs.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NextIntlClientProvider } from 'next-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ProfileHistoryTabs } from '@/features/profile/components/ProfileHistoryTabs';
+import en from '@/locales/en.json';
+
+function renderTabs(active: 'all' | 'validated' = 'all', onChange = vi.fn()) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={en}>
+      <ProfileHistoryTabs active={active} onChange={onChange} disabled={false} />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('ProfileHistoryTabs', () => {
+  it('renders filter tabs with ARIA roles', () => {
+    renderTabs();
+
+    expect(screen.getByRole('tablist', { name: /history filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /show all history/i })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: /show validated ranked scores/i })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('calls onChange when a tab is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderTabs('all', onChange);
+
+    await user.click(screen.getByRole('tab', { name: /show validated ranked scores/i }));
+
+    expect(onChange).toHaveBeenCalledWith('validated');
+  });
+});

--- a/src/features/profile/components/ProfileHistoryTabs.tsx
+++ b/src/features/profile/components/ProfileHistoryTabs.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { HISTORY_TABS, type HistoryTab } from '@/features/profile/types';
+
+type Props = {
+  active: HistoryTab;
+  onChange: (tab: HistoryTab) => void;
+  disabled: boolean;
+};
+
+export function ProfileHistoryTabs({ active, onChange, disabled }: Props) {
+  const t = useTranslations('profile.historyPage.tabs');
+
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-1" role="tablist" aria-label={t('listAria')}>
+      {HISTORY_TABS.map((tab) => {
+        const isActive = active === tab;
+        return (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-label={t(`aria.${tab}`)}
+            disabled={disabled}
+            onClick={() => onChange(tab)}
+            className={[
+              'shrink-0 rounded-sm border px-3 py-1.5 text-[11px] font-black uppercase tracking-[0.14em] transition-colors',
+              isActive
+                ? 'border-primary bg-primary/15 text-primary'
+                : 'border-border bg-background text-muted-foreground hover:text-foreground',
+            ].join(' ')}
+          >
+            {t(tab)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/profile/components/ProfileSettingsMenu.tsx
+++ b/src/features/profile/components/ProfileSettingsMenu.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Settings } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { SignOutButton } from '@/features/auth/components/SignOutButton';
+
+export function ProfileSettingsMenu() {
+  const t = useTranslations('profile.settings');
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+  const toggle = useCallback(() => setOpen((v) => !v), []);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const onPointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) close();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close();
+    };
+
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [close, open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label={t('aria')}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md border border-border bg-card text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Settings className="h-5 w-5" aria-hidden />
+      </button>
+
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-20 mt-2 min-w-[12rem] rounded-md border border-border bg-card p-2 shadow-lg"
+        >
+          <SignOutButton variant="menu" onSignedOut={close} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/profile/hooks/useProfileHistory.ts
+++ b/src/features/profile/hooks/useProfileHistory.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { listChallengeCommitments } from '@/features/profile/lib/challengeCommitments';
+import { enrichScoresWithTopPercent } from '@/features/profile/lib/enrichScoresWithTopPercent';
+import { buildHistoryItems, filterHistoryByTab } from '@/features/profile/lib/filterHistoryByTab';
+import { listMyScores } from '@/features/profile/services/scores';
+import type { HistoryItem, HistoryTab } from '@/features/profile/types';
+
+type State =
+  | { status: 'loading'; data: null; error: null }
+  | { status: 'error'; data: null; error: string }
+  | { status: 'ready'; data: HistoryItem[]; error: null };
+
+const initial: State = { status: 'loading', data: null, error: null };
+
+const SCORE_FETCH_LIMIT = 100;
+
+export function useProfileHistory(userId: string | null): {
+  state: State;
+  activeTab: HistoryTab;
+  setActiveTab: (tab: HistoryTab) => void;
+  filteredItems: HistoryItem[];
+  refetch: () => void;
+} {
+  const [state, setState] = useState<State>(initial);
+  const [activeTab, setActiveTab] = useState<HistoryTab>('all');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!userId) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const rawScores = await listMyScores(userId, SCORE_FETCH_LIMIT);
+        const enriched = await enrichScoresWithTopPercent(rawScores);
+        const scoreChallengeIds = new Set(enriched.map((s) => s.challengeId));
+        const commitments = listChallengeCommitments().filter(
+          (c) => !scoreChallengeIds.has(c.challengeId),
+        );
+        const scores = enriched.map((s) => ({ ...s, kind: 'score' as const }));
+        const inProgress = commitments.map((c) => ({
+          kind: 'in_progress' as const,
+          challengeId: c.challengeId,
+          challengeTitle: c.challengeTitle,
+          committedAt: c.committedAt,
+        }));
+        const items = buildHistoryItems(scores, inProgress);
+        if (!cancelled) setState({ status: 'ready', data: items, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', data: null, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey, userId]);
+
+  const refetch = useCallback(() => {
+    setState(initial);
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  const filteredItems = useMemo(() => {
+    if (state.status !== 'ready') return [];
+    return filterHistoryByTab(state.data, activeTab);
+  }, [activeTab, state]);
+
+  return { state, activeTab, setActiveTab, filteredItems, refetch };
+}

--- a/src/features/profile/lib/challengeCommitments.ts
+++ b/src/features/profile/lib/challengeCommitments.ts
@@ -1,0 +1,58 @@
+const STORAGE_KEY = 'tg-challenge-commitments';
+
+export type ChallengeCommitment = {
+  challengeId: string;
+  challengeTitle: string;
+  committedAt: string;
+};
+
+type StoredEntry = ChallengeCommitment;
+
+function readAll(): StoredEntry[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is StoredEntry =>
+        typeof e === 'object' &&
+        e !== null &&
+        typeof (e as StoredEntry).challengeId === 'string' &&
+        typeof (e as StoredEntry).challengeTitle === 'string' &&
+        typeof (e as StoredEntry).committedAt === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(entries: StoredEntry[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // ignore localStorage failures
+  }
+}
+
+export function listChallengeCommitments(): ChallengeCommitment[] {
+  return readAll().sort(
+    (a, b) => new Date(b.committedAt).getTime() - new Date(a.committedAt).getTime(),
+  );
+}
+
+export function recordChallengeCommitment(challengeId: string, challengeTitle: string): void {
+  const entries = readAll().filter((e) => e.challengeId !== challengeId);
+  entries.unshift({
+    challengeId,
+    challengeTitle,
+    committedAt: new Date().toISOString(),
+  });
+  writeAll(entries.slice(0, 50));
+}
+
+export function clearChallengeCommitment(challengeId: string): void {
+  writeAll(readAll().filter((e) => e.challengeId !== challengeId));
+}

--- a/src/features/profile/lib/enrichScoresWithTopPercent.ts
+++ b/src/features/profile/lib/enrichScoresWithTopPercent.ts
@@ -1,0 +1,24 @@
+import { formatTopPercent, percentileFromCounts } from '@/features/finisher-card/lib/percentile';
+import { getRankCounts } from '@/features/finisher-card/services/rank';
+import type { ProfileScoreItem } from '@/features/profile/types';
+
+export async function enrichScoresWithTopPercent(
+  scores: ProfileScoreItem[],
+): Promise<ProfileScoreItem[]> {
+  return Promise.all(
+    scores.map(async (score) => {
+      if (!score.isValidated) {
+        return { ...score, topPercent: null };
+      }
+
+      const counts = await getRankCounts({
+        challengeId: score.challengeId,
+        scoreType: score.scoreType,
+        value: score.value,
+      });
+      const pct = percentileFromCounts(counts.total, counts.better);
+      const topPercent = pct ? formatTopPercent(pct.percentile) : null;
+      return { ...score, topPercent };
+    }),
+  );
+}

--- a/src/features/profile/lib/filterHistoryByTab.test.ts
+++ b/src/features/profile/lib/filterHistoryByTab.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildHistoryItems,
+  filterHistoryByTab,
+  isWonScore,
+} from '@/features/profile/lib/filterHistoryByTab';
+import type { HistoryItem, HistoryScoreItem } from '@/features/profile/types';
+
+const rankedOfficial: HistoryScoreItem = {
+  kind: 'score',
+  id: 's1',
+  challengeId: 'c1',
+  challengeTitle: 'Burpees',
+  scoreType: 'time',
+  value: 430,
+  isValidated: true,
+  isOfficial: true,
+  topPercent: null,
+  submittedAt: '2026-06-01T10:00:00Z',
+};
+
+const rankedElite: HistoryScoreItem = {
+  kind: 'score',
+  id: 's2',
+  challengeId: 'c2',
+  challengeTitle: 'Sandbag',
+  scoreType: 'reps',
+  value: 50,
+  isValidated: true,
+  isOfficial: false,
+  topPercent: 8,
+  submittedAt: '2026-05-30T10:00:00Z',
+};
+
+const savedScore: HistoryScoreItem = {
+  kind: 'score',
+  id: 's3',
+  challengeId: 'c3',
+  challengeTitle: 'Push-ups',
+  scoreType: 'reps',
+  value: 40,
+  isValidated: false,
+  isOfficial: false,
+  topPercent: null,
+  submittedAt: '2026-05-28T10:00:00Z',
+};
+
+const inProgress: Extract<HistoryItem, { kind: 'in_progress' }> = {
+  kind: 'in_progress',
+  challengeId: 'c4',
+  challengeTitle: 'Plank',
+  committedAt: '2026-06-02T10:00:00Z',
+};
+
+const allItems = buildHistoryItems([rankedOfficial, rankedElite, savedScore], [inProgress]);
+
+describe('isWonScore', () => {
+  it('marks official validated scores as won', () => {
+    expect(isWonScore(rankedOfficial)).toBe(true);
+  });
+
+  it('marks top 10% validated scores as won', () => {
+    expect(isWonScore(rankedElite)).toBe(true);
+  });
+
+  it('rejects saved and non-elite validated scores', () => {
+    expect(isWonScore(savedScore)).toBe(false);
+    expect(
+      isWonScore({
+        ...rankedElite,
+        topPercent: 15,
+        isOfficial: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('filterHistoryByTab', () => {
+  it('returns all items for the all tab', () => {
+    expect(filterHistoryByTab(allItems, 'all')).toHaveLength(4);
+  });
+
+  it('filters in-progress commitments only', () => {
+    expect(filterHistoryByTab(allItems, 'in_progress')).toEqual([inProgress]);
+  });
+
+  it('filters validated ranked scores', () => {
+    const result = filterHistoryByTab(allItems, 'validated');
+    expect(result).toHaveLength(2);
+    expect(result.every((item) => item.kind === 'score' && item.isValidated)).toBe(true);
+  });
+
+  it('filters saved honor scores', () => {
+    expect(filterHistoryByTab(allItems, 'saved')).toEqual([savedScore]);
+  });
+
+  it('filters won highlights', () => {
+    const result = filterHistoryByTab(allItems, 'won');
+    expect(result).toHaveLength(2);
+    expect(result.map((item) => (item.kind === 'score' ? item.id : null))).toEqual(['s1', 's2']);
+  });
+});
+
+describe('buildHistoryItems', () => {
+  it('sorts by most recent activity first', () => {
+    expect(allItems[0]).toEqual(inProgress);
+    expect(allItems[1]).toEqual(rankedOfficial);
+  });
+});

--- a/src/features/profile/lib/filterHistoryByTab.ts
+++ b/src/features/profile/lib/filterHistoryByTab.ts
@@ -1,0 +1,41 @@
+import type { HistoryItem, HistoryScoreItem, HistoryTab } from '@/features/profile/types';
+
+export const WON_TOP_PERCENT_THRESHOLD = 10;
+
+export function isWonScore(item: HistoryScoreItem): boolean {
+  if (!item.isValidated) return false;
+  if (item.isOfficial) return true;
+  return item.topPercent !== null && item.topPercent <= WON_TOP_PERCENT_THRESHOLD;
+}
+
+export function filterHistoryByTab(items: HistoryItem[], tab: HistoryTab): HistoryItem[] {
+  switch (tab) {
+    case 'all':
+      return items;
+    case 'in_progress':
+      return items.filter((item) => item.kind === 'in_progress');
+    case 'validated':
+      return items.filter((item) => item.kind === 'score' && item.isValidated);
+    case 'saved':
+      return items.filter((item) => item.kind === 'score' && !item.isValidated);
+    case 'won':
+      return items.filter((item) => item.kind === 'score' && isWonScore(item));
+    default:
+      return items;
+  }
+}
+
+export function sortHistoryItems(items: HistoryItem[]): HistoryItem[] {
+  return [...items].sort((a, b) => {
+    const dateA = a.kind === 'score' ? a.submittedAt : a.committedAt;
+    const dateB = b.kind === 'score' ? b.submittedAt : b.committedAt;
+    return new Date(dateB).getTime() - new Date(dateA).getTime();
+  });
+}
+
+export function buildHistoryItems(
+  scores: HistoryScoreItem[],
+  inProgress: Extract<HistoryItem, { kind: 'in_progress' }>[],
+): HistoryItem[] {
+  return sortHistoryItems([...scores, ...inProgress]);
+}

--- a/src/features/profile/services/scores.ts
+++ b/src/features/profile/services/scores.ts
@@ -1,18 +1,11 @@
+import type { ProfileScoreItem } from '@/features/profile/types';
 import { supabase } from '@/lib/supabase';
 import type { ScoreType } from '@/lib/types/database.types';
 
-export type ProfileScoreItem = {
-  id: string;
-  challengeId: string;
-  challengeTitle: string;
-  scoreType: ScoreType;
-  value: number;
-  isValidated: boolean;
-  submittedAt: string;
-};
+export type { ProfileScoreItem };
 
 const SCORE_SELECT =
-  'id,challenge_id,value,is_validated,submitted_at,challenge:challenges!scores_challenge_id_fkey(id,title,score_type)';
+  'id,challenge_id,value,is_validated,submitted_at,challenge:challenges!scores_challenge_id_fkey(id,title,score_type,is_official)';
 
 type Row = {
   id: string;
@@ -20,7 +13,7 @@ type Row = {
   value: number;
   is_validated: boolean;
   submitted_at: string;
-  challenge: { id: string; title: string; score_type: ScoreType } | null;
+  challenge: { id: string; title: string; score_type: ScoreType; is_official: boolean } | null;
 };
 
 export async function listMyScores(userId: string, limit = 25): Promise<ProfileScoreItem[]> {
@@ -43,6 +36,8 @@ export async function listMyScores(userId: string, limit = 25): Promise<ProfileS
       scoreType: r.challenge!.score_type,
       value: Number(r.value),
       isValidated: r.is_validated,
+      isOfficial: r.challenge!.is_official,
+      topPercent: null,
       submittedAt: r.submitted_at,
     }));
 }

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -1,0 +1,30 @@
+import type { ScoreType } from '@/lib/types/database.types';
+
+export type HistoryTab = 'all' | 'in_progress' | 'validated' | 'saved' | 'won';
+
+export type ProfileScoreItem = {
+  id: string;
+  challengeId: string;
+  challengeTitle: string;
+  scoreType: ScoreType;
+  value: number;
+  isValidated: boolean;
+  isOfficial: boolean;
+  topPercent: number | null;
+  submittedAt: string;
+};
+
+export type HistoryScoreItem = ProfileScoreItem & { kind: 'score' };
+
+export type HistoryInProgressItem = {
+  kind: 'in_progress';
+  challengeId: string;
+  challengeTitle: string;
+  committedAt: string;
+};
+
+export type HistoryItem = HistoryScoreItem | HistoryInProgressItem;
+
+export const PROFILE_CARD_PREVIEW_LIMIT = 4;
+
+export const HISTORY_TABS: HistoryTab[] = ['all', 'in_progress', 'validated', 'saved', 'won'];

--- a/src/features/submission/components/ScoreSubmissionScreen.tsx
+++ b/src/features/submission/components/ScoreSubmissionScreen.tsx
@@ -3,10 +3,14 @@
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useChallenge } from '@/features/challenges/hooks/useChallenge';
+import {
+  clearChallengeCommitment,
+  recordChallengeCommitment,
+} from '@/features/profile/lib/challengeCommitments';
 import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
 
 type Props = {
@@ -34,6 +38,11 @@ export function ScoreSubmissionScreen({ challengeId }: Props) {
   const router = useRouter();
   const { data: challenge, loading, error } = useChallenge(challengeId);
   const [result, setResult] = useState<Result | null>(null);
+
+  useEffect(() => {
+    if (!challenge || challenge.status !== 'approved') return;
+    recordChallengeCommitment(challenge.id, challenge.title);
+  }, [challenge]);
 
   if (loading) {
     return (
@@ -107,6 +116,7 @@ export function ScoreSubmissionScreen({ challengeId }: Props) {
         scoreType={challenge.score_type}
         maxDurationSeconds={challenge.max_duration_seconds ?? null}
         onSubmitted={(r) => {
+          clearChallengeCommitment(challenge.id);
           setResult(r);
           router.push(
             `/${locale}/app/finish?challengeId=${challenge.id}&ranked=${String(r.ranked)}&scoreId=${encodeURIComponent(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -545,6 +545,9 @@
       "submitting": "Signing out...",
       "error": "Could not sign out. Try again."
     },
+    "settings": {
+      "aria": "Profile settings"
+    },
     "avatar": {
       "title": "AVATAR",
       "alt": "Profile avatar",
@@ -598,7 +601,50 @@
       "loading": "Loading cards...",
       "error": "Could not load cards.",
       "empty": "No cards yet.",
-      "open": "Open finisher card"
+      "open": "Open finisher card",
+      "showMore": "SHOW MORE",
+      "showMoreAria": "View full score history",
+      "retry": "Retry"
+    },
+    "historyPage": {
+      "title": "MY HISTORY",
+      "back": "PROFILE",
+      "backAria": "Back to profile",
+      "loading": "Loading history...",
+      "errorTitle": "Could not load history",
+      "errorBody": "Try again.",
+      "retry": "Retry",
+      "tabs": {
+        "listAria": "History filters",
+        "all": "ALL",
+        "in_progress": "IN PROGRESS",
+        "validated": "VALIDATED",
+        "saved": "SAVED",
+        "won": "WON",
+        "aria": {
+          "all": "Show all history",
+          "in_progress": "Show in-progress challenges",
+          "validated": "Show validated ranked scores",
+          "saved": "Show saved honor scores",
+          "won": "Show won highlights"
+        }
+      },
+      "badges": {
+        "ranked": "RANKED",
+        "saved": "SAVED",
+        "inProgress": "IN PROGRESS"
+      },
+      "actions": {
+        "card": "CARD",
+        "submit": "SUBMIT"
+      },
+      "empty": {
+        "all": "No history yet. Hit the Arena.",
+        "in_progress": "No challenges in progress. Tap I'M IN on a challenge to start.",
+        "validated": "No validated scores yet. Post proof to rank.",
+        "saved": "No saved honor scores yet.",
+        "won": "No wins yet. Rank top 10% or crush an official challenge."
+      }
     }
   },
   "movements": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -545,6 +545,9 @@
       "submitting": "Déconnexion...",
       "error": "Impossible de se déconnecter. Réessaie."
     },
+    "settings": {
+      "aria": "Paramètres du profil"
+    },
     "avatar": {
       "title": "AVATAR",
       "alt": "Avatar du profil",
@@ -598,7 +601,50 @@
       "loading": "Chargement des cards...",
       "error": "Impossible de charger les cards.",
       "empty": "Aucune card pour l'instant.",
-      "open": "Ouvrir la finisher card"
+      "open": "Ouvrir la finisher card",
+      "showMore": "VOIR PLUS",
+      "showMoreAria": "Voir l'historique complet",
+      "retry": "Réessayer"
+    },
+    "historyPage": {
+      "title": "MON HISTORIQUE",
+      "back": "PROFIL",
+      "backAria": "Retour au profil",
+      "loading": "Chargement de l'historique...",
+      "errorTitle": "Impossible de charger l'historique",
+      "errorBody": "Réessaie.",
+      "retry": "Réessayer",
+      "tabs": {
+        "listAria": "Filtres historique",
+        "all": "TOUT",
+        "in_progress": "EN COURS",
+        "validated": "VALIDÉS",
+        "saved": "SAUVEGARDÉS",
+        "won": "GAGNÉS",
+        "aria": {
+          "all": "Afficher tout l'historique",
+          "in_progress": "Afficher les défis en cours",
+          "validated": "Afficher les scores validés classés",
+          "saved": "Afficher les scores honor sauvegardés",
+          "won": "Afficher les coups d'éclat gagnés"
+        }
+      },
+      "badges": {
+        "ranked": "CLASSÉ",
+        "saved": "SAUVEGARDÉ",
+        "inProgress": "EN COURS"
+      },
+      "actions": {
+        "card": "CARD",
+        "submit": "SOUMETTRE"
+      },
+      "empty": {
+        "all": "Aucun historique pour l'instant. Va à l'Arène.",
+        "in_progress": "Aucun défi en cours. Clique JE M'INSCRIS sur un défi pour commencer.",
+        "validated": "Aucun score validé pour l'instant. Poste une preuve pour être classé.",
+        "saved": "Aucun score honor sauvegardé pour l'instant.",
+        "won": "Aucun coup d'éclat pour l'instant. Top 10 % ou écrase un défi officiel."
+      }
     }
   },
   "movements": {


### PR DESCRIPTION
## Summary
- Streamlines `/app/profile`: removes inline HISTORY, caps CARDS carousel at 4 with horizontal scroll, adds Show More → `/app/profile/history`, moves Log out into ⚙️ settings menu
- Adds dedicated history page with filter tabs (All · In progress · Validated · Saved · Won), badge + CARD actions, full loading/empty/error states
- Tracks in-progress challenges via localStorage when user opens submit flow (no `challenge_commitments` table yet)

## Test plan
- [x] `pnpm typecheck && pnpm test:run && pnpm lint`
- [x] MCP QA: profile → Show More → history tabs (EN)
- [ ] Manual FR copy check on profile + history
- [ ] Log out via ⚙️ settings menu

Fixes #59

Made with [Cursor](https://cursor.com)