### PR TITLE
fix(finisher-card): resolve QA bugs B1–B3 (#65)

### DIFF
--- a/docs/QA_V1_CHECKLIST.md
+++ b/docs/QA_V1_CHECKLIST.md
@@ -197,11 +197,11 @@ Sinon si UI trouvée :
 
 ## Bugs trouvés
 
-| ID  | Sévérité | Parcours               | Description                                                                                                                                              | Repro                                  | Statut |
-| --- | -------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------ |
-| B1  | P1       | Profil → CARD / finish | `/app/finish` affiche toujours « Could not load… » (ranked **et** saved) — `FinishPage` client lit `searchParams` en prop au lieu de `useSearchParams()` | Profil → CARD ou galerie → `/finish?…` | ouvert |
-| B2  | P2       | Profil §6.4 galerie    | `FinisherGallery` en erreur : message seul, **pas de bouton Retry** (contrairement à `ScoreHistory`)                                                     | Simuler erreur fetch scores            | ouvert |
-| B3  | P3       | Profil galerie         | Miniature card SAVED : chevauchement texte faction / « NO VIDEO » sur le canvas                                                                          | Profil avec score non validé           | ouvert |
+| ID  | Sévérité | Parcours               | Description                                                                            | Repro                                  | Statut             |
+| --- | -------- | ---------------------- | -------------------------------------------------------------------------------------- | -------------------------------------- | ------------------ |
+| B1  | P1       | Profil → CARD / finish | `/app/finish` affiche « Could not load… » — rank fetch bloquait la card ; pas de Retry | Profil → CARD ou galerie → `/finish?…` | **corrigé PR #66** |
+| B2  | P2       | Profil §6.4 galerie    | `FinisherGallery` en erreur : bouton Retry + test RTL                                  | Simuler erreur fetch scores            | **corrigé PR #66** |
+| B3  | P3       | Profil galerie         | Miniature card SAVED : chevauchement score / faction / « NO VIDEO » sur thumb canvas   | Profil avec score non validé           | **corrigé PR #66** |
 
 **Sévérité :** P0 bloquant · P1 majeur · P2 mineur · P3 cosmétique
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -63,6 +63,7 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 **Macro pré-V2 (polish post-QA V1, avant V2-01)**
 
 - [x] **FIX UI** — Flow soumission score (POST SCORE → formulaire → SUBMIT) — section **J** — 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)
+- [ ] **FIX** — Bugs QA B1–B3 (finish page, gallery retry, thumb layout) — 🟡 [#65](https://github.com/igorms-pro/truegrynd/issues/65) branche `fix/issue-65-qa-finisher-bugs`
 
 **Macro V2 proposée (à transformer en GitHub issues avant dev)**
 

--- a/src/app/[locale]/app/finish/page.tsx
+++ b/src/app/[locale]/app/finish/page.tsx
@@ -18,7 +18,7 @@ function FinishPageContent() {
   const ranked = searchParams.get('ranked') === 'true';
   const scoreId = searchParams.get('scoreId');
   const challengeId = searchParams.get('challengeId');
-  const state = useFinisherCard({ ranked, scoreId, challengeId });
+  const { retry, ...state } = useFinisherCard({ ranked, scoreId, challengeId });
 
   const cardOptions = useMemo(() => {
     if (state.status !== 'ready') return null;
@@ -84,12 +84,21 @@ function FinishPageContent() {
           <p className="text-sm text-muted-foreground">{t('error')}</p>
         </header>
         <p className="text-xs text-muted-foreground">{state.message}</p>
-        <Link
-          href={`/${locale}/app/arena${challengeId ? `/${challengeId}` : ''}`}
-          className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted"
-        >
-          {t('backToArena')}
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={retry}
+            className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('retry')}
+          </button>
+          <Link
+            href={`/${locale}/app/arena${challengeId ? `/${challengeId}` : ''}`}
+            className="inline-flex min-h-11 items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('backToArena')}
+          </Link>
+        </div>
       </section>
     );
   }

--- a/src/features/finisher-card/hooks/useFinisherCard.test.ts
+++ b/src/features/finisher-card/hooks/useFinisherCard.test.ts
@@ -1,0 +1,115 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { useFinisherCard } from '@/features/finisher-card/hooks/useFinisherCard';
+
+const getScoreByIdMock = vi.fn();
+const getChallengeByIdMock = vi.fn();
+const getRankCountsMock = vi.fn();
+const useRequireAppAccessMock = vi.fn();
+
+vi.mock('@/features/finisher-card/services/scores', () => ({
+  getScoreById: (...args: unknown[]) => getScoreByIdMock(...args),
+}));
+
+vi.mock('@/features/challenges/services/challenges', () => ({
+  getChallengeById: (...args: unknown[]) => getChallengeByIdMock(...args),
+}));
+
+vi.mock('@/features/finisher-card/services/rank', () => ({
+  getRankCounts: (...args: unknown[]) => getRankCountsMock(...args),
+}));
+
+vi.mock('@/features/appshell', () => ({
+  useRequireAppAccess: () => useRequireAppAccessMock(),
+}));
+
+const profile = {
+  id: 'user-1',
+  username: 'grinder',
+  sex: 'male' as const,
+  age: 28,
+  weight_kg: 80,
+  faction: 'horde' as const,
+  initiation_completed: true,
+  creator_score: 0,
+  streak_days: 0,
+  last_activity_at: null,
+  avatar_url: null,
+  is_admin: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const score = {
+  id: 'score-1',
+  challenge_id: 'challenge-1',
+  user_id: 'user-1',
+  value: 42,
+  video_url: 'https://youtube.com/watch?v=abc',
+  is_validated: true,
+  submitted_at: '2026-06-01T00:00:00Z',
+};
+
+const challenge = {
+  id: 'challenge-1',
+  title: 'Burpee Blitz',
+  description: '',
+  rules: '',
+  score_type: 'reps' as const,
+  equipment_tags: [],
+  is_official: true,
+  status: 'approved' as const,
+  creator_id: null,
+  created_at: '2026-06-01T00:00:00Z',
+};
+
+describe('useFinisherCard', () => {
+  beforeEach(() => {
+    getScoreByIdMock.mockReset();
+    getChallengeByIdMock.mockReset();
+    getRankCountsMock.mockReset();
+    useRequireAppAccessMock.mockReturnValue({ status: 'ready', profile });
+    getScoreByIdMock.mockResolvedValue(score);
+    getChallengeByIdMock.mockResolvedValue(challenge);
+    getRankCountsMock.mockResolvedValue({ total: 10, better: 2 });
+  });
+
+  it('loads card when rank fetch fails (degrades without top percent)', async () => {
+    getRankCountsMock.mockRejectedValue(new Error('rank_down'));
+
+    const { result } = renderHook(() =>
+      useFinisherCard({
+        challengeId: 'challenge-1',
+        scoreId: 'score-1',
+        ranked: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('ready');
+    });
+
+    expect(result.current).toMatchObject({
+      status: 'ready',
+      topPercent: null,
+      username: 'grinder',
+    });
+  });
+
+  it('returns error when score does not belong to the current user', async () => {
+    getScoreByIdMock.mockResolvedValue({ ...score, user_id: 'other-user' });
+
+    const { result } = renderHook(() =>
+      useFinisherCard({
+        challengeId: 'challenge-1',
+        scoreId: 'score-1',
+        ranked: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+  });
+});

--- a/src/features/finisher-card/hooks/useFinisherCard.ts
+++ b/src/features/finisher-card/hooks/useFinisherCard.ts
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRequireAppAccess } from '@/features/appshell';
-import { getApprovedChallengeById } from '@/features/challenges/services/challenges';
+import { getChallengeById } from '@/features/challenges/services/challenges';
 import { formatTopPercent, percentileFromCounts } from '@/features/finisher-card/lib/percentile';
 import { getRankCounts } from '@/features/finisher-card/services/rank';
 import { getScoreById } from '@/features/finisher-card/services/scores';
@@ -31,39 +31,71 @@ export type FinisherCardState =
 
 type InnerState = Exclude<FinisherCardState, { status: 'gated' } | { status: 'missing_params' }>;
 
-export function useFinisherCard(params: Params): FinisherCardState {
+async function loadTopPercent(
+  ranked: boolean,
+  score: Score,
+  challenge: Challenge,
+): Promise<number | null> {
+  if (!ranked || !score.is_validated) return null;
+  try {
+    const counts = await getRankCounts({
+      challengeId: score.challenge_id,
+      scoreType: challenge.score_type,
+      value: score.value,
+    });
+    const pct = percentileFromCounts(counts.total, counts.better);
+    return pct ? formatTopPercent(pct.percentile) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function useFinisherCard(params: Params): FinisherCardState & { retry: () => void } {
   const access = useRequireAppAccess();
   const [state, setState] = useState<InnerState>({ status: 'loading' });
+  const [reloadKey, setReloadKey] = useState(0);
 
   const hasParams = !!params.challengeId && !!params.scoreId;
+  const userId = access.status === 'ready' ? access.profile.id : null;
+
+  const retry = useCallback(() => {
+    setState({ status: 'loading' });
+    setReloadKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
     if (access.status !== 'ready') return undefined;
-    if (!hasParams) return undefined;
+    if (!hasParams || !userId) return undefined;
 
     let cancelled = false;
+
     void (async () => {
+      setState({ status: 'loading' });
+
       try {
-        const [score, challenge] = await Promise.all([
-          getScoreById(params.scoreId!),
-          getApprovedChallengeById(params.challengeId!),
-        ]);
+        const score = await getScoreById(params.scoreId!);
         if (cancelled) return;
-        if (!score || !challenge) {
+
+        if (!score || score.user_id !== userId) {
           setState({ status: 'error', message: 'not_found' });
           return;
         }
 
-        let topPercent: number | null = null;
-        if (params.ranked && score.is_validated) {
-          const counts = await getRankCounts({
-            challengeId: score.challenge_id,
-            scoreType: challenge.score_type,
-            value: score.value,
-          });
-          const pct = percentileFromCounts(counts.total, counts.better);
-          topPercent = pct ? formatTopPercent(pct.percentile) : null;
+        if (score.challenge_id !== params.challengeId) {
+          setState({ status: 'error', message: 'not_found' });
+          return;
         }
+
+        const challenge = await getChallengeById(params.challengeId!);
+        if (cancelled) return;
+
+        if (!challenge) {
+          setState({ status: 'error', message: 'not_found' });
+          return;
+        }
+
+        const topPercent = await loadTopPercent(params.ranked, score, challenge);
+        if (cancelled) return;
 
         const { username, faction } = access.profile;
         if (!username || !faction) {
@@ -81,11 +113,22 @@ export function useFinisherCard(params: Params): FinisherCardState {
     return () => {
       cancelled = true;
     };
-  }, [access.status, access.profile, hasParams, params.challengeId, params.ranked, params.scoreId]);
+  }, [
+    access.status,
+    access.profile,
+    hasParams,
+    params.challengeId,
+    params.ranked,
+    params.scoreId,
+    reloadKey,
+    userId,
+  ]);
 
-  return useMemo(() => {
+  const cardState = useMemo((): FinisherCardState => {
     if (access.status !== 'ready') return { status: 'gated' };
     if (!hasParams) return { status: 'missing_params' };
     return state;
   }, [access.status, hasParams, state]);
+
+  return useMemo(() => ({ ...cardState, retry }), [cardState, retry]);
 }

--- a/src/features/finisher-card/lib/drawCard.test.ts
+++ b/src/features/finisher-card/lib/drawCard.test.ts
@@ -43,4 +43,22 @@ describe('drawFinisherCard', () => {
     expect(canvas.width).toBe(360);
     expect(canvas.height).toBe(640);
   });
+
+  it('renders saved thumb layout without throwing for large rep counts', () => {
+    const canvas = createCanvas();
+    expect(() =>
+      drawFinisherCard(canvas, {
+        width: 360,
+        height: 640,
+        faction: 'horde',
+        username: 'longusernamehere',
+        challengeTitle: 'QA Official — Burpees For Time',
+        scoreType: 'reps',
+        scoreValue: 999,
+        topPercent: null,
+        rankTextOverride: 'SAVED',
+        rankSubOverride: 'NO VIDEO',
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/features/finisher-card/lib/drawCard.ts
+++ b/src/features/finisher-card/lib/drawCard.ts
@@ -110,9 +110,13 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
   const title = truncateToWidth(ctx, options.challengeTitle.toUpperCase(), maxTextW);
   ctx.fillText(title, textX, lineY(0.13));
 
+  const scoreTop = lineY(0.26);
+  const labelTop = lineY(0.52);
+  const maxScoreHeight = Math.max(24, labelTop - scoreTop - Math.floor(innerH * 0.02));
+
   const scoreText =
     options.scoreType === 'time' ? formatSeconds(options.scoreValue) : String(options.scoreValue);
-  const scoreSize = fitFontSize(
+  let scoreSize = fitFontSize(
     ctx,
     scoreText,
     maxTextW,
@@ -120,15 +124,24 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
     'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
     Math.floor(innerW * 0.44),
   );
+  scoreSize = Math.min(scoreSize, maxScoreHeight);
+
   ctx.fillStyle = fg;
   ctx.font = `900 ${scoreSize}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`;
-  ctx.fillText(scoreText, textX, lineY(0.26));
+  ctx.fillText(scoreText, textX, scoreTop);
 
-  const labelSize = Math.floor(innerW * 0.072);
+  const compact = options.height <= 700;
+  const labelY = compact ? lineY(0.54) : lineY(0.52);
+  const rankY = compact ? lineY(0.6) : lineY(0.58);
+  const rankSubY = compact ? lineY(0.66) : lineY(0.68);
+  const usernameY = compact ? lineY(0.76) : lineY(0.78);
+  const factionY = compact ? lineY(0.84) : lineY(0.85);
+
+  const labelSize = Math.floor(innerW * (compact ? 0.06 : 0.072));
   ctx.fillStyle = muted;
   ctx.font = `900 ${labelSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
   const label = options.scoreType === 'time' ? 'TIME (MM:SS)' : 'REPS';
-  ctx.fillText(label, textX, lineY(0.52));
+  ctx.fillText(label, textX, labelY);
 
   const rankText =
     options.rankTextOverride ?? (options.topPercent ? `TOP ${options.topPercent}%` : 'SAVED');
@@ -138,11 +151,11 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
     maxTextW,
     900,
     'system-ui, -apple-system, Segoe UI, sans-serif',
-    Math.floor(innerW * 0.2),
+    Math.floor(innerW * (compact ? 0.16 : 0.2)),
   );
   ctx.fillStyle = fg;
   ctx.font = `900 ${rankSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
-  ctx.fillText(rankText, textX, lineY(0.58));
+  ctx.fillText(rankText, textX, rankY);
 
   const rankSub =
     options.rankSubOverride ??
@@ -153,24 +166,24 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
     maxTextW,
     900,
     'system-ui, -apple-system, Segoe UI, sans-serif',
-    Math.floor(innerW * 0.058),
-    12,
+    Math.floor(innerW * (compact ? 0.05 : 0.058)),
+    compact ? 10 : 12,
   );
   ctx.fillStyle = muted;
   ctx.font = `900 ${rankSubSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
   const rankSubLine = truncateToWidth(ctx, rankSub, maxTextW);
-  ctx.fillText(rankSubLine, textX, lineY(0.68));
+  ctx.fillText(rankSubLine, textX, rankSubY);
 
-  const usernameSize = Math.floor(innerW * 0.072);
+  const usernameSize = Math.floor(innerW * (compact ? 0.06 : 0.072));
   ctx.fillStyle = accent;
   ctx.font = `900 ${usernameSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
-  ctx.fillText(truncateToWidth(ctx, options.username.toUpperCase(), maxTextW), textX, lineY(0.78));
+  ctx.fillText(truncateToWidth(ctx, options.username.toUpperCase(), maxTextW), textX, usernameY);
 
   const factionLabel = options.faction.replace('_', ' ').toUpperCase();
-  const factionSize = Math.floor(innerW * 0.058);
+  const factionSize = Math.floor(innerW * (compact ? 0.05 : 0.058));
   ctx.fillStyle = muted;
   ctx.font = `900 ${factionSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
-  ctx.fillText(truncateToWidth(ctx, factionLabel, maxTextW), textX, lineY(0.85));
+  ctx.fillText(truncateToWidth(ctx, factionLabel, maxTextW), textX, factionY);
 }
 
 function formatSeconds(totalSeconds: number): string {

--- a/src/features/profile/components/FinisherGallery.test.tsx
+++ b/src/features/profile/components/FinisherGallery.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NextIntlClientProvider } from 'next-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FinisherGallery } from '@/features/profile/components/FinisherGallery';
+import en from '@/locales/en.json';
+
+const useMyScoresMock = vi.fn();
+
+vi.mock('@/features/profile/hooks/useMyScores', () => ({
+  useMyScores: (...args: unknown[]) => useMyScoresMock(...args),
+}));
+
+function renderGallery() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={en}>
+      <FinisherGallery userId="user-1" username="grinder" faction="horde" />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('FinisherGallery', () => {
+  it('shows retry button on error and calls refetch', async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    useMyScoresMock.mockReturnValue({
+      state: { status: 'error', data: null, error: 'network' },
+      refetch,
+    });
+
+    renderGallery();
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -518,6 +518,7 @@
     "title": "FINISHER CARD",
     "loading": "Loading...",
     "error": "Could not load your finisher card.",
+    "retry": "RETRY",
     "rankedBody": "Certified. You're ranked.",
     "savedBody": "Saved. Not ranked (no video).",
     "download": "DOWNLOAD",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -518,6 +518,7 @@
     "title": "FINISHER CARD",
     "loading": "Chargement...",
     "error": "Impossible de charger ta Finisher Card.",
+    "retry": "RÉESSAYER",
     "rankedBody": "Certifié. Tu es classé.",
     "savedBody": "Sauvegardé. Non classé (pas de vidéo).",
     "download": "TÉLÉCHARGER",


### PR DESCRIPTION
## Summary
- **B1**: `useFinisherCard` — rank fetch failure no longer blocks card render; validates score ownership + challenge match; uses `getChallengeById` (closed challenges OK); finish error state adds **Retry**
- **B2**: `FinisherGallery` error Retry covered by RTL test (UI already present)
- **B3**: `drawFinisherCard` — compact thumb layout with capped score height to prevent text overlap on SAVED cards

Fixes #65

## Test plan
- [x] `pnpm check` (127 tests)
- [ ] QA §4.5 + §6.4: profil → CARD → `/finish` ranked + saved
- [ ] Thumb SAVED card on profile — no overlap


Made with [Cursor](https://cursor.com)