### PR TITLE
docs(v2): V2-00 — cadre factions & exclusions sociales

### DIFF
--- a/.cursor/rules/truegrynd-product-rules.mdc
+++ b/.cursor/rules/truegrynd-product-rules.mdc
@@ -12,6 +12,8 @@ A B2C web app for async fitness competition. Users submit scores on standardized
 - Not a workout tracker (no sets/reps logging for personal training)
 - Not a social network (no following, no DMs, no feed of activity)
 - Not a video hosting platform (we never store videos — only external URLs)
+- Not a team/clan builder — no custom squads or private friend groups outside the 3 global factions
+- Not faction-gated gameplay — no "Horde only" / "Iron only" challenge catalog; faction is a war camp, not a separate game mode
 
 ## MVP Scope (build only this)
 1. Auth (Google / Apple / Email via Supabase)
@@ -25,6 +27,16 @@ A B2C web app for async fitness competition. Users submit scores on standardized
 Three factions: `nomads`, `horde`, `iron_alliance`
 - User belongs to one faction (chosen at onboarding, cannot change in MVP)
 - Faction score = sum of individual member scores
+- Faction pages (`/app/faction/[slug]`), referral (`?faction=`), and Recruit CTA are the collective identity layer — already shipped in V1.5
+- V2 Team Wars (V2-08) adds server-side faction × division scoring — does not introduce custom teams
+
+## Social MVP (V1 → V2 early)
+Allowed social interactions only:
+- **Respect** (`+1`) on leaderboard rows
+- Faction referral links and public profile/faction vitrines
+- Rival Matches (V2-07) are competitive duels, not a social graph — no DMs or follow system
+
+Explicitly excluded in V2 early: private messaging, Follow/Unfollow, activity feeds, custom friend teams, faction-only challenge catalogs
 
 ## Smart Proof Logic
 - Users can submit scores **with or without** a video URL

--- a/docs/V2_STRATEGY.md
+++ b/docs/V2_STRATEGY.md
@@ -143,6 +143,37 @@ Garder la friction basse, mais donner des couches de crédibilité :
 
 Les leaderboards sérieux peuvent filtrer par niveau de preuve.
 
+## Cadre Factions & Exclusions Sociales (V2 early)
+
+**À lire avant V2-01 (divisions) et impératif avant V2-07 / V2-08 (rivals, Team Wars).**
+
+Truegrynd reste une **arène compétitive async**, pas un réseau social fitness. Les factions sont le seul vecteur d'appartenance collective ; V2 enrichit la compétition par **niveau** (divisions, scaling, weekly), pas par création de micro-communautés privées.
+
+### Ce que Truegrynd n'est pas (V2 early — ne pas coder)
+
+| Exclusion                 | Règle                                                                                                                                                                  |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Teams perso**           | Pas de sous-équipes ni de « team avec les potos » hors des **3 factions mondiales** (`nomads`, `horde`, `iron_alliance`).                                              |
+| **Réseau social**         | Pas de messagerie privée (DM), pas de graphe Follow/Unfollow, pas de fil d'activité.                                                                                   |
+| **Modes faction-only**    | Pas de catalogue de défis « Horde only » / « Iron only ». La faction est un **camp de guerre**, pas un mode de jeu séparé. Tous les challenges restent ouverts à tous. |
+| **Social au-delà du MVP** | Interaction sociale limitée au **👊 Respect** sur lignes de leaderboard, plus referral faction et vitrines publiques (profil, pages faction).                          |
+
+### Déjà livré (V1 / V1.5 — ne pas refaire)
+
+- Choix de faction à l'onboarding, **immuable** en MVP.
+- Referral `?faction=` + CTA Recruit.
+- Pages `/app/faction/[slug]` symétriques : overview rivale, hall of fame, CTA Arena (section I).
+- Respect leaderboard, streaks, creator score, finisher cards, profil/historique public.
+
+### Ce que V2 ajoute par-dessus (issues V2-01+)
+
+- **Divisions + scaling + weekly** (V2-01–03) : compétition **par niveau**, pas par team custom.
+- **Rival Matches** (V2-07) : duel 1v1 / petit groupe sur défis — compétition légère, **pas** remplacement des 3 factions.
+- **Faction Wars par division** (V2-08) : score équipe **serveur**, events, contribution perso — remplace l'heuristique Clan HUD.
+- **Micro-events** (V2-09) : Faction War Weekend, City Clash, etc. — formats async, pas de ticket physique.
+
+**Principe :** « avec **leur team** » dans le positionnement V2 = **faction mondiale + division**, jamais une équipe privée recrutée ad hoc.
+
 ## Roadmap V2 Recommandée
 
 ### V2.1 — Divisions + Weekly Challenge

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -73,7 +73,7 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 
 **Macro V2 proposée (à transformer en GitHub issues avant dev)**
 
-- [ ] **V2-00** — Cadre factions & **exclusions sociales** (pas teams perso / pas DM) + prérequis V1.5 — section **H**
+- [x] **V2-00** — Cadre factions & **exclusions sociales** (pas teams perso / pas DM) + prérequis V1.5 — section **H** — 🟡 [#71](https://github.com/igorms-pro/truegrynd/issues/71)
 - [ ] **V2-01** — Divisions de niveau (Rookie / Regular / Savage / Elite)
 - [ ] **V2-02** — Variantes officielles / scaling par challenge
 - [ ] **V2-03** — Weekly Global Challenge
@@ -583,16 +583,22 @@ Branche : `chore/issue-69-production-hardening`
 
 **Exclusions explicites (ne pas coder)**
 
-- [ ] **Pas** de sous-équipes / « team perso avec des potos » privée hors des 3 factions mondiales.
-- [ ] **Pas** de messagerie privée (DM), **pas** de graphe Follow/Unfollow.
-- [ ] **Pas** de catalogue de défis « Horde only » / « Iron only » — la faction est un **camp de guerre**, pas un mode de jeu séparé.
-- [ ] **Interaction sociale MVP** : uniquement **👊 Respect** (`+1`) sur lignes de leaderboard ; le reste = referral faction + vitrines publiques.
+- [x] **Pas** de sous-équipes / « team perso avec des potos » privée hors des 3 factions mondiales.
+- [x] **Pas** de messagerie privée (DM), **pas** de graphe Follow/Unfollow.
+- [x] **Pas** de catalogue de défis « Horde only » / « Iron only » — la faction est un **camp de guerre**, pas un mode de jeu séparé.
+- [x] **Interaction sociale MVP** : uniquement **👊 Respect** (`+1`) sur lignes de leaderboard ; le reste = referral faction + vitrines publiques.
 
 **Effet de groupe autorisé en V1 / V1.5**
 
 - Parrainage **faction globale** (`?faction=` + Recruit).
 - Affiliation **salle physique** (piste B2B → [docs/V3_STRATEGY.md](../V3_STRATEGY.md)).
 - Pages **`/app/faction/[slug]`** symétriques (section **I**) : overview rivale, hall of fame, CTA Arena.
+
+**Livrables V2-00 (doc / produit)**
+
+- [x] Valider les 4 exclusions ci-dessus (table + règles dans [V2_STRATEGY.md](../V2_STRATEGY.md)).
+- [x] Aligner `.cursor/rules/truegrynd-product-rules.mdc` (boundaries factions + social MVP).
+- [x] Prérequis confirmés : section **I (V1.5)** + **L (#69)** + QA Clan/faction OK.
 
 **Ce que V2 ajoute par-dessus (issues suivantes, pas en V1.5)**
 
@@ -743,10 +749,10 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | **Fix flow submit (POST SCORE → formulaire)** | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)                                                                                                                               |
 | **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                            |
 | **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                               |
-| **V2 — Accessible competition**               | 🔴 section **H** + [V2_STRATEGY.md](../V2_STRATEGY.md) — **prochaine : V2-00** (cadre factions) puis **V2-01**                                                                                                                                      |
+| **V2 — Accessible competition**               | 🟡 V2-00 [#71](https://github.com/igorms-pro/truegrynd/issues/71) — cadre factions doc ; **prochaine : V2-01** (divisions)                                                                                                                          |
 | **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                        |
 
-**Suite produit :** Produit **lancé** sur `main`, **#69** mergée (PR #70). **Prochaine action = V2-00** (section **H**, doc stratégie **V2_STRATEGY.md**) → créer Issue GitHub + branche avant code → **V2-01** (divisions).
+**Suite produit :** Produit **lancé** sur `main`, **#69** mergée (PR #70). **V2-00** en cours ([#71](https://github.com/igorms-pro/truegrynd/issues/71)) — cadre factions doc → merge PR → **V2-01** (divisions).
 
 ---
 


### PR DESCRIPTION
Fixes #71

## Summary

- Add **Cadre Factions & Exclusions Sociales** section to `docs/V2_STRATEGY.md` (V2 early boundaries, V1/V1.5 already shipped, V2-01+ roadmap pointers)
- Extend `.cursor/rules/truegrynd-product-rules.mdc` with faction/social MVP rules and explicit exclusions
- Check off V2-00 deliverables in `docs/issues/issues.md` section H + macro checklist l.76

## Exclusions frozen (no code)

- No custom teams outside 3 global factions
- No DMs / Follow-Unfollow
- No faction-only challenge catalog
- Social MVP = Respect + referral + public vitrines only

## Test plan

- [x] Doc-only PR — no migrations or app code
- [ ] Review V2_STRATEGY table aligns with section H exclusions
- [ ] Confirm product-rules boundaries match MVP shipped features

Made with [Cursor](https://cursor.com)