### PR TITLE
feat(challenges): V2-02 official scaling variants

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -26,20 +26,20 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 
 ## Sommaire backlog
 
-| Bloc                                      | Détail dans ce fichier                                              |
-| ----------------------------------------- | ------------------------------------------------------------------- |
-| **`/app/admin` (UGC)**                    | Section **A** — tâches détaillées (+ **A9–A10** IA tri)             |
-| **Mouvements & prescription**             | Section **G** — catalogue mix + règles création                     |
-| **Creator Score**                         | Section **B**                                                       |
-| **Streaks**                               | Section **C**                                                       |
-| **Respect (leaderboard)**                 | Section **D**                                                       |
-| **Referral**                              | Section **E**                                                       |
-| **Confiance & plateforme**                | Section **F**                                                       |
-| **V1.5 — Pages Faction & symétrie UI**    | Section **I** — arbitrages dock / Clan / Overview                   |
-| **V1.5 — Profil épuré & page Historique** | Section **K** — carrousel CARDS + `/app/profile/history`            |
-| **Fix & polish pré-V2 (QA V1)**           | Section **J** — flow soumission score / copy CTA                    |
-| **Production hardening (10k users)**      | Section **L** — clean archi, DRY, limites feature                   |
-| **V2 — Accessible competition**           | Section **H** — V2-00 🟢 · V2-01 🟢 · **prochaine V2-02** (scaling) |
+| Bloc                                      | Détail dans ce fichier                                       |
+| ----------------------------------------- | ------------------------------------------------------------ |
+| **`/app/admin` (UGC)**                    | Section **A** — tâches détaillées (+ **A9–A10** IA tri)      |
+| **Mouvements & prescription**             | Section **G** — catalogue mix + règles création              |
+| **Creator Score**                         | Section **B**                                                |
+| **Streaks**                               | Section **C**                                                |
+| **Respect (leaderboard)**                 | Section **D**                                                |
+| **Referral**                              | Section **E**                                                |
+| **Confiance & plateforme**                | Section **F**                                                |
+| **V1.5 — Pages Faction & symétrie UI**    | Section **I** — arbitrages dock / Clan / Overview            |
+| **V1.5 — Profil épuré & page Historique** | Section **K** — carrousel CARDS + `/app/profile/history`     |
+| **Fix & polish pré-V2 (QA V1)**           | Section **J** — flow soumission score / copy CTA             |
+| **Production hardening (10k users)**      | Section **L** — clean archi, DRY, limites feature            |
+| **V2 — Accessible competition**           | Section **H** — V2-00 🟢 · V2-01 🟢 · **V2-02 🟡** (scaling) |
 
 **Macro-checklist**
 
@@ -75,7 +75,7 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 
 - [x] **V2-00** — Cadre factions & **exclusions sociales** (pas teams perso / pas DM) + prérequis V1.5 — section **H** — 🟢 [#71](https://github.com/igorms-pro/truegrynd/issues/71) PR [#72](https://github.com/igorms-pro/truegrynd/pull/72)
 - [x] **V2-01** — Divisions de niveau (Rookie / Regular / Savage / Elite) — 🟢 [#73](https://github.com/igorms-pro/truegrynd/issues/73) PR [#74](https://github.com/igorms-pro/truegrynd/pull/74)
-- [ ] **V2-02** — Variantes officielles / scaling par challenge
+- [ ] **V2-02** — Variantes officielles / scaling par challenge — 🟡 [#75](https://github.com/igorms-pro/truegrynd/issues/75) branche `feature/issue-75-v2-02-scaling`
 - [ ] **V2-03** — Weekly Global Challenge
 - [ ] **V2-04** — Leaderboards par division, faction, ville, pays
 - [ ] **V2-05** — Truegrynd Rating (Engine / Power / Strength / Grit / Consistency)
@@ -622,12 +622,12 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-02. Variantes Officielles / Scaling Par Challenge
 
-- [ ] **Produit** : chaque challenge important peut avoir des variantes officielles : no equipment, bodyweight, dumbbell, standard, savage.
-- [ ] **DB** : modèle `challenge_variants` ou champ structuré validé (éviter texte libre non exploitable).
-- [ ] **Création défi** : auteur choisit au moins une variante ; admin voit le niveau de friction / matériel.
-- [ ] **Soumission** : score attaché à une variante précise.
-- [ ] **Leaderboard** : classement par variante + division.
-- [ ] **UX** : copy claire : scaling officiel ≠ mode honteux.
+- [x] **Produit** : chaque challenge important peut avoir des variantes officielles : no equipment, bodyweight, dumbbell, standard, savage.
+- [x] **DB** : migration `016` — table `challenge_variants` + `scores.variant` CHECK + FK composite.
+- [x] **Création défi** : auteur choisit au moins une variante ; admin voit le niveau de friction / matériel.
+- [x] **Soumission** : score attaché à une variante précise.
+- [x] **Leaderboard** : classement par variante + division.
+- [x] **UX** : copy claire : scaling officiel ≠ mode honteux.
 
 ### V2-03. Weekly Global Challenge
 
@@ -734,27 +734,27 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 
 ## Suivi synthétique
 
-| Bloc                                          | Avancement                                                                                                                                                                                                                                                                               |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| UGC création + cap                            | 🟢 PR #30                                                                                                                                                                                                                                                                                |
-| Doc backlog V1 (ce fichier)                   | 🟢 [#31](https://github.com/igorms-pro/truegrynd/issues/31) mergé — PR [#32](https://github.com/igorms-pro/truegrynd/pull/32)                                                                                                                                                            |
-| Doc tri IA + mouvements mix (ce fichier)      | 🟢 [#35](https://github.com/igorms-pro/truegrynd/issues/35) mergé — PR [#36](https://github.com/igorms-pro/truegrynd/pull/36)                                                                                                                                                            |
-| **`/app/admin`**                              | 🟢 PR #41 mergé (admin + AI triage)                                                                                                                                                                                                                                                      |
-| Creator Score                                 | 🟢 [#46](https://github.com/igorms-pro/truegrynd/issues/46) mergé — PR [#47](https://github.com/igorms-pro/truegrynd/pull/47)                                                                                                                                                            |
-| Streaks                                       | 🟢 [#48](https://github.com/igorms-pro/truegrynd/issues/48) mergé — PR [#49](https://github.com/igorms-pro/truegrynd/pull/49)                                                                                                                                                            |
-| Respect                                       | 🟢 [#50](https://github.com/igorms-pro/truegrynd/issues/50) mergé — PR [#51](https://github.com/igorms-pro/truegrynd/pull/51)                                                                                                                                                            |
-| Referral                                      | 🟢 [#52](https://github.com/igorms-pro/truegrynd/issues/52) mergé — PR [#53](https://github.com/igorms-pro/truegrynd/pull/53)                                                                                                                                                            |
-| Confiance / plateforme                        | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55)                                                                                                                                                            |
-| Mouvements / prescription (mix)               | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45)                                                                                                                                                            |
-| **V1.5 — Pages Faction**                      | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57) — PR [#56](https://github.com/igorms-pro/truegrynd/pull/56) + [#58](https://github.com/igorms-pro/truegrynd/pull/58) mergés                                                                                                  |
-| **V1.5 — Profil & Historique**                | 🟢 [#59](https://github.com/igorms-pro/truegrynd/issues/59) PR [#60](https://github.com/igorms-pro/truegrynd/pull/60) + Settings [#61](https://github.com/igorms-pro/truegrynd/issues/61) PR [#62](https://github.com/igorms-pro/truegrynd/pull/62)                                      |
-| **Fix flow submit (POST SCORE → formulaire)** | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)                                                                                                                                                                    |
-| **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                                                                 |
-| **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                                                                    |
-| **V2 — Accessible competition**               | 🟢 V2-00 [#71](https://github.com/igorms-pro/truegrynd/issues/71) PR [#72](https://github.com/igorms-pro/truegrynd/pull/72) · V2-01 [#73](https://github.com/igorms-pro/truegrynd/issues/73) PR [#74](https://github.com/igorms-pro/truegrynd/pull/74) — **prochaine : V2-02** (scaling) |
-| **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                                                             |
+| Bloc                                          | Avancement                                                                                                                                                                                                                                          |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UGC création + cap                            | 🟢 PR #30                                                                                                                                                                                                                                           |
+| Doc backlog V1 (ce fichier)                   | 🟢 [#31](https://github.com/igorms-pro/truegrynd/issues/31) mergé — PR [#32](https://github.com/igorms-pro/truegrynd/pull/32)                                                                                                                       |
+| Doc tri IA + mouvements mix (ce fichier)      | 🟢 [#35](https://github.com/igorms-pro/truegrynd/issues/35) mergé — PR [#36](https://github.com/igorms-pro/truegrynd/pull/36)                                                                                                                       |
+| **`/app/admin`**                              | 🟢 PR #41 mergé (admin + AI triage)                                                                                                                                                                                                                 |
+| Creator Score                                 | 🟢 [#46](https://github.com/igorms-pro/truegrynd/issues/46) mergé — PR [#47](https://github.com/igorms-pro/truegrynd/pull/47)                                                                                                                       |
+| Streaks                                       | 🟢 [#48](https://github.com/igorms-pro/truegrynd/issues/48) mergé — PR [#49](https://github.com/igorms-pro/truegrynd/pull/49)                                                                                                                       |
+| Respect                                       | 🟢 [#50](https://github.com/igorms-pro/truegrynd/issues/50) mergé — PR [#51](https://github.com/igorms-pro/truegrynd/pull/51)                                                                                                                       |
+| Referral                                      | 🟢 [#52](https://github.com/igorms-pro/truegrynd/issues/52) mergé — PR [#53](https://github.com/igorms-pro/truegrynd/pull/53)                                                                                                                       |
+| Confiance / plateforme                        | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55)                                                                                                                       |
+| Mouvements / prescription (mix)               | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45)                                                                                                                       |
+| **V1.5 — Pages Faction**                      | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57) — PR [#56](https://github.com/igorms-pro/truegrynd/pull/56) + [#58](https://github.com/igorms-pro/truegrynd/pull/58) mergés                                                             |
+| **V1.5 — Profil & Historique**                | 🟢 [#59](https://github.com/igorms-pro/truegrynd/issues/59) PR [#60](https://github.com/igorms-pro/truegrynd/pull/60) + Settings [#61](https://github.com/igorms-pro/truegrynd/issues/61) PR [#62](https://github.com/igorms-pro/truegrynd/pull/62) |
+| **Fix flow submit (POST SCORE → formulaire)** | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)                                                                                                                               |
+| **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                            |
+| **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                               |
+| **V2 — Accessible competition**               | 🟡 V2-02 [#75](https://github.com/igorms-pro/truegrynd/issues/75) branche `feature/issue-75-v2-02-scaling` · V2-00 🟢 [#71](https://github.com/igorms-pro/truegrynd/issues/71) · V2-01 🟢 [#73](https://github.com/igorms-pro/truegrynd/issues/73)  |
+| **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                        |
 
-**Suite produit :** Produit **lancé** sur `main`. **V2-01** 🟢 mergée ([#73](https://github.com/igorms-pro/truegrynd/issues/73) · PR [#74](https://github.com/igorms-pro/truegrynd/pull/74) · migration **`015`**). **Prochaine action = V2-02** (variantes / scaling officiel) — créer Issue GitHub + branche avant code.
+**Suite produit :** Produit **lancé** sur `main`. **V2-02** 🟡 en cours ([#75](https://github.com/igorms-pro/truegrynd/issues/75) · branche `feature/issue-75-v2-02-scaling` · migration **`016`**). **Prochaine action = PR V2-02** puis **V2-03** (weekly challenge).
 
 ---
 

--- a/src/components/ChallengeVariantBadges.tsx
+++ b/src/components/ChallengeVariantBadges.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { ChallengeVariant } from '@/lib/types/database.types';
+
+type Props = {
+  variants: readonly ChallengeVariant[];
+  className?: string;
+};
+
+export function ChallengeVariantBadges({ variants, className = '' }: Props) {
+  const t = useTranslations('variants');
+
+  if (variants.length === 0) return null;
+
+  return (
+    <ul className={`flex flex-wrap gap-2 ${className}`.trim()}>
+      {variants.map((variant) => (
+        <li
+          key={variant}
+          className="rounded-sm border border-border bg-background px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground"
+        >
+          {t(variant)}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/admin/components/AdminPendingChallengeRow.tsx
+++ b/src/features/admin/components/AdminPendingChallengeRow.tsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { arenaDisplayStatus, type ArenaDisplayStatus } from '@/features/admin/lib/arenaLifecycle';
+import { ChallengeVariantBadges } from '@/components/ChallengeVariantBadges';
 import type { AdminPendingChallenge as PendingRow } from '@/features/admin/services/adminChallenges';
 import type { ChallengeAiTier } from '@/lib/types/database.types';
 
@@ -151,6 +152,9 @@ export function AdminPendingChallengeRow({
         </td>
       ) : null}
       <td className="py-3 pr-2 text-xs uppercase text-muted-foreground">{row.score_type}</td>
+      <td className="py-3 pr-2 max-w-[10rem]">
+        <ChallengeVariantBadges variants={row.variants ?? ['standard']} />
+      </td>
       <td className="py-3 pr-2 text-xs text-muted-foreground">{creatorLabel(row)}</td>
       <td className="py-3 pr-2 text-xs text-muted-foreground">{dateLabel}</td>
       <td className="py-3 text-right">

--- a/src/features/admin/components/AdminPendingChallengesTable.tsx
+++ b/src/features/admin/components/AdminPendingChallengesTable.tsx
@@ -70,6 +70,9 @@ export function AdminPendingChallengesTable({
               {t('colType')}
             </th>
             <th className="py-2 pr-2" scope="col">
+              {t('colVariants')}
+            </th>
+            <th className="py-2 pr-2" scope="col">
               {t('colCreator')}
             </th>
             <th className="py-2 pr-2" scope="col">

--- a/src/features/admin/services/adminChallenges.ts
+++ b/src/features/admin/services/adminChallenges.ts
@@ -1,10 +1,24 @@
 import { ADMIN_QUEUE_PAGE_SIZE } from '@/features/admin/lib/adminQueueConstants';
 import { normalizePostgrestCreator } from '@/features/admin/lib/normalizeCreator';
 import { supabase } from '@/lib/supabase';
-import type { Challenge, ChallengeAiTier } from '@/lib/types/database.types';
+import type { Challenge, ChallengeAiTier, ChallengeVariant } from '@/lib/types/database.types';
 
 const PENDING_CHALLENGE_SELECT =
-  'id,title,description,rules,score_type,equipment_tags,is_official,status,creator_id,max_duration_seconds,rejection_reason,reviewed_at,reviewed_by,ai_tier,ai_summary,ai_model,ai_checked_at,ends_at,created_at,creator:profiles!challenges_creator_id_fkey(username)';
+  'id,title,description,rules,score_type,equipment_tags,is_official,status,creator_id,max_duration_seconds,rejection_reason,reviewed_at,reviewed_by,ai_tier,ai_summary,ai_model,ai_checked_at,ends_at,created_at,creator:profiles!challenges_creator_id_fkey(username),challenge_variants(variant)';
+
+type AdminChallengeRow = Challenge & {
+  challenge_variants: { variant: ChallengeVariant }[] | null;
+  creator?: unknown;
+};
+
+function mapAdminChallengeRow(row: AdminChallengeRow): AdminPendingChallenge {
+  const { challenge_variants, creator, ...challenge } = row;
+  return {
+    ...(challenge as Challenge),
+    variants: (challenge_variants ?? []).map((item) => item.variant),
+    creator: normalizePostgrestCreator(creator),
+  };
+}
 
 export type AiTierFilter = 'all' | ChallengeAiTier | 'none';
 
@@ -107,10 +121,7 @@ export async function listChallengesForAdmin(options?: {
   const { data, error, count } = await query.range(from, to);
 
   if (error) throw new Error(error.message);
-  const rows = (data ?? []).map((row) => ({
-    ...(row as Challenge),
-    creator: normalizePostgrestCreator((row as { creator?: unknown }).creator),
-  }));
+  const rows = (data ?? []).map((row) => mapAdminChallengeRow(row as AdminChallengeRow));
   return { rows, totalCount: count ?? 0 };
 }
 

--- a/src/features/challenges/components/ChallengeDetail.tsx
+++ b/src/features/challenges/components/ChallengeDetail.tsx
@@ -94,7 +94,11 @@ export function ChallengeDetail({ challengeId }: Props) {
       ) : null}
       <ChallengeDetailSpecPanels challenge={challenge} parsed={parsedRules} />
       {isApproved ? (
-        <Leaderboard challengeId={challenge.id} scoreType={challenge.score_type} />
+        <Leaderboard
+          challengeId={challenge.id}
+          scoreType={challenge.score_type}
+          availableVariants={challenge.variants ?? ['standard']}
+        />
       ) : null}
     </section>
   );

--- a/src/features/challenges/components/ChallengeDetailSpecPanels.tsx
+++ b/src/features/challenges/components/ChallengeDetailSpecPanels.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Dumbbell, ScrollText } from 'lucide-react';
+import { Dumbbell, Layers, ScrollText } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { ChallengeDetailSection } from '@/features/challenges/components/ChallengeDetailSection';
+import { ChallengeVariantBadges } from '@/components/ChallengeVariantBadges';
 import type { ParsedChallengeRules } from '@/features/challenges/lib/parseChallengeRules';
 import type { Challenge } from '@/lib/types/database.types';
 
@@ -17,9 +18,15 @@ export function ChallengeDetailSpecPanels({ challenge, parsed }: Props) {
   const hasScoring = parsed.scoring.trim().length > 0;
   const hasStandards = parsed.standards.trim().length > 0;
   const hasEquipment = challenge.equipment_tags.length > 0;
+  const variants = challenge.variants ?? ['standard'];
 
   return (
     <div className="space-y-4">
+      <ChallengeDetailSection tone="neutral" icon={Layers} title={t('variantsHeading')} withWash>
+        <p className="mb-3 text-xs text-muted-foreground">{t('variantsBody')}</p>
+        <ChallengeVariantBadges variants={variants} />
+      </ChallengeDetailSection>
+
       <div
         className={
           hasScoring && hasStandards

--- a/src/features/challenges/components/CreateChallengeScreen.tsx
+++ b/src/features/challenges/components/CreateChallengeScreen.tsx
@@ -10,6 +10,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { CreateChallengeCircuitSection } from '@/features/challenges/components/CreateChallengeCircuitSection';
 import { CreateChallengeScoringSection } from '@/features/challenges/components/CreateChallengeScoringSection';
+import { CreateChallengeVariantsSection } from '@/features/challenges/components/CreateChallengeVariantsSection';
 import { useCreateChallenge } from '@/features/challenges/hooks/useCreateChallenge';
 import {
   buildCreateChallengeSchema,
@@ -25,6 +26,7 @@ const DEFAULT_VALUES: CreateChallengeFormValues = {
   amrapCap: '',
   forTimeCap: '',
   equipmentTagsRaw: '',
+  variants: ['standard'],
 };
 
 function FieldError({ message }: { message?: string }) {
@@ -139,6 +141,8 @@ export function CreateChallengeScreen() {
           </div>
 
           <CreateChallengeScoringSection disabled={busy} />
+
+          <CreateChallengeVariantsSection disabled={busy} />
 
           <div>
             <label

--- a/src/features/challenges/components/CreateChallengeVariantsSection.tsx
+++ b/src/features/challenges/components/CreateChallengeVariantsSection.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useFormContext } from 'react-hook-form';
+
+import type { CreateChallengeFormValues } from '@/features/challenges/lib/createChallengeSchema';
+import { CHALLENGE_VARIANTS } from '@/lib/variants';
+import type { ChallengeVariant } from '@/lib/types/database.types';
+
+type Props = {
+  disabled?: boolean;
+};
+
+function chipClass(active: boolean, disabled: boolean): string {
+  return [
+    'rounded-sm border px-2 py-1.5 text-[11px] font-black uppercase tracking-[0.14em] transition-colors',
+    disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+    active
+      ? 'border-primary bg-primary/15 text-primary'
+      : 'border-border bg-background text-muted-foreground hover:text-foreground',
+  ].join(' ');
+}
+
+export function CreateChallengeVariantsSection({ disabled = false }: Props) {
+  const t = useTranslations('arena.create');
+  const {
+    watch,
+    setValue,
+    formState: { errors },
+  } = useFormContext<CreateChallengeFormValues>();
+
+  const selected = watch('variants') ?? [];
+
+  const toggle = (variant: ChallengeVariant): void => {
+    if (disabled) return;
+    const next = selected.includes(variant)
+      ? selected.filter((v) => v !== variant)
+      : [...selected, variant];
+    setValue('variants', next, { shouldValidate: true, shouldDirty: true });
+  };
+
+  return (
+    <fieldset className="space-y-2" disabled={disabled}>
+      <legend className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('fields.variants')}
+      </legend>
+      <p className="text-xs text-muted-foreground">{t('fields.variantsHint')}</p>
+      <div className="flex flex-wrap gap-2">
+        {CHALLENGE_VARIANTS.map((variant) => {
+          const active = selected.includes(variant);
+          return (
+            <button
+              key={variant}
+              type="button"
+              aria-pressed={active}
+              disabled={disabled}
+              onClick={() => toggle(variant)}
+              className={chipClass(active, disabled)}
+            >
+              {t(`variants.${variant}`)}
+            </button>
+          );
+        })}
+      </div>
+      {errors.variants?.message ? (
+        <p className="text-xs font-semibold text-primary" role="alert">
+          {errors.variants.message}
+        </p>
+      ) : null}
+    </fieldset>
+  );
+}

--- a/src/features/challenges/components/Leaderboard.tsx
+++ b/src/features/challenges/components/Leaderboard.tsx
@@ -23,6 +23,7 @@ import type { ScoreType } from '@/lib/types/database.types';
 type Props = {
   challengeId: string;
   scoreType: ScoreType;
+  availableVariants: readonly import('@/lib/types/database.types').ChallengeVariant[];
 };
 
 function LeaderboardRow({
@@ -72,7 +73,7 @@ function LeaderboardRow({
   );
 }
 
-export function Leaderboard({ challengeId, scoreType }: Props) {
+export function Leaderboard({ challengeId, scoreType, availableVariants }: Props) {
   const t = useTranslations('leaderboard');
   const profile = useOptionalAppProfile();
   const { data, loading, error, refetch } = useChallengeLeaderboard({
@@ -81,16 +82,22 @@ export function Leaderboard({ challengeId, scoreType }: Props) {
   });
   const [filters, setFilters] = useState<LeaderboardFilters>(EMPTY_FILTERS);
   const [divisionFilterTouched, setDivisionFilterTouched] = useState(false);
+  const [variantFilterTouched, setVariantFilterTouched] = useState(false);
 
-  const effectiveFilters = resolveLeaderboardFilters(
+  const effectiveFilters = resolveLeaderboardFilters({
     filters,
-    profile?.division,
+    profileDivision: profile?.division,
     divisionFilterTouched,
-  );
+    availableVariants,
+    variantFilterTouched,
+  });
 
   const handleFiltersChange = (next: LeaderboardFilters): void => {
     if (next.division !== filters.division) {
       setDivisionFilterTouched(true);
+    }
+    if (next.variant !== filters.variant) {
+      setVariantFilterTouched(true);
     }
     setFilters(next);
   };
@@ -116,7 +123,11 @@ export function Leaderboard({ challengeId, scoreType }: Props) {
         <h2 className="text-lg font-black uppercase tracking-tight">{t('title')}</h2>
       </header>
 
-      <LeaderboardFiltersBar filters={effectiveFilters} onChange={handleFiltersChange} />
+      <LeaderboardFiltersBar
+        filters={effectiveFilters}
+        availableVariants={availableVariants}
+        onChange={handleFiltersChange}
+      />
 
       {loading ? (
         <p role="status" aria-live="polite" className="text-sm text-muted-foreground">

--- a/src/features/challenges/components/LeaderboardFilters.tsx
+++ b/src/features/challenges/components/LeaderboardFilters.tsx
@@ -5,13 +5,14 @@ import { useTranslations } from 'next-intl';
 import { AGE_BRACKETS, type AgeBracket } from '@/features/challenges/lib/ageBracket';
 import type { LeaderboardFilters } from '@/features/challenges/lib/types';
 import { DIVISIONS } from '@/lib/divisions';
-import type { Faction, Sex } from '@/lib/types/database.types';
+import type { ChallengeVariant, Faction, Sex } from '@/lib/types/database.types';
 
 const SEXES: readonly Sex[] = ['male', 'female', 'other'];
 const FACTIONS: readonly Faction[] = ['nomads', 'horde', 'iron_alliance'];
 
 type Props = {
   filters: LeaderboardFilters;
+  availableVariants: readonly ChallengeVariant[];
   onChange: (next: LeaderboardFilters) => void;
 };
 
@@ -35,14 +36,39 @@ function FilterRow({ legend, children }: { legend: string; children: React.React
   );
 }
 
-export function LeaderboardFiltersBar({ filters, onChange }: Props) {
+export function LeaderboardFiltersBar({ filters, availableVariants, onChange }: Props) {
   const t = useTranslations('leaderboard.filters');
   const tFactions = useTranslations('factions');
   const tDivisions = useTranslations('divisions');
+  const tVariants = useTranslations('variants');
   const tSex = useTranslations('onboarding.identity.sexes');
+
+  const showVariantFilters = availableVariants.length > 1;
 
   return (
     <div className="space-y-2">
+      {showVariantFilters ? (
+        <FilterRow legend={t('variant')}>
+          <button
+            type="button"
+            onClick={() => onChange({ ...filters, variant: null })}
+            className={chipClass(filters.variant === null)}
+          >
+            {t('allVariants')}
+          </button>
+          {availableVariants.map((variant) => (
+            <button
+              key={variant}
+              type="button"
+              onClick={() => onChange({ ...filters, variant })}
+              className={chipClass(filters.variant === variant)}
+            >
+              {tVariants(variant)}
+            </button>
+          ))}
+        </FilterRow>
+      ) : null}
+
       <FilterRow legend={t('division')}>
         <button
           type="button"

--- a/src/features/challenges/hooks/useCreateChallenge.ts
+++ b/src/features/challenges/hooks/useCreateChallenge.ts
@@ -57,6 +57,7 @@ export function useCreateChallenge(): {
         rules,
         scoreType,
         equipmentTags: tags,
+        variants: values.variants,
         maxDurationSeconds,
       });
     } catch (e: unknown) {

--- a/src/features/challenges/lib/applyFilters.test.ts
+++ b/src/features/challenges/lib/applyFilters.test.ts
@@ -6,6 +6,7 @@ import { EMPTY_FILTERS, type LeaderboardEntry } from '@/features/challenges/lib/
 const entry = (
   id: string,
   overrides: Partial<LeaderboardEntry['profile']> = {},
+  variant: LeaderboardEntry['variant'] = 'standard',
 ): LeaderboardEntry => ({
   id,
   challenge_id: 'c1',
@@ -13,6 +14,7 @@ const entry = (
   value: 60,
   video_url: null,
   is_validated: true,
+  variant,
   submitted_at: '2025-01-01T00:00:00Z',
   profile: {
     id: `p-${id}`,
@@ -57,6 +59,17 @@ describe('applyLeaderboardFilters', () => {
     ];
     expect(
       applyLeaderboardFilters(list, { ...EMPTY_FILTERS, division: 'savage' }).map((e) => e.id),
+    ).toEqual(['b']);
+  });
+
+  it('filters by variant', () => {
+    const list = [
+      entry('a', {}, 'standard'),
+      entry('b', {}, 'bodyweight'),
+      entry('c', {}, 'savage'),
+    ];
+    expect(
+      applyLeaderboardFilters(list, { ...EMPTY_FILTERS, variant: 'bodyweight' }).map((e) => e.id),
     ).toEqual(['b']);
   });
 

--- a/src/features/challenges/lib/applyFilters.ts
+++ b/src/features/challenges/lib/applyFilters.ts
@@ -11,6 +11,7 @@ export function applyLeaderboardFilters(
     if (filters.sex && profile.sex !== filters.sex) return false;
     if (filters.faction && profile.faction !== filters.faction) return false;
     if (filters.division && profile.division !== filters.division) return false;
+    if (filters.variant && entry.variant !== filters.variant) return false;
     if (filters.ageBracket && !isInBracket(profile.age, filters.ageBracket)) return false;
     return true;
   });

--- a/src/features/challenges/lib/createChallengeSchema.test.ts
+++ b/src/features/challenges/lib/createChallengeSchema.test.ts
@@ -33,6 +33,7 @@ describe('buildCreateChallengeSchema — circuitMinBlock', () => {
     amrapCap: '',
     forTimeCap: '',
     equipmentTagsRaw: '',
+    variants: ['standard'],
   };
 
   it('rejects zero valid circuit blocks', () => {

--- a/src/features/challenges/lib/createChallengeSchema.ts
+++ b/src/features/challenges/lib/createChallengeSchema.ts
@@ -7,6 +7,7 @@ import {
   type CircuitBlock,
 } from '@/features/challenges/lib/circuitBlocks';
 import { OTHER_MOVEMENT_SLUG } from '@/features/challenges/lib/movementCatalog';
+import type { ChallengeVariant } from '@/lib/types/database.types';
 
 export type CreateChallengeFormValues = {
   title: string;
@@ -17,6 +18,7 @@ export type CreateChallengeFormValues = {
   amrapCap: string;
   forTimeCap: string;
   equipmentTagsRaw: string;
+  variants: ChallengeVariant[];
 };
 
 export function buildCreateChallengeSchema(t: (key: string) => string) {
@@ -43,6 +45,9 @@ export function buildCreateChallengeSchema(t: (key: string) => string) {
       amrapCap: z.string().max(10),
       forTimeCap: z.string().max(10),
       equipmentTagsRaw: z.string().max(500, { message: t('tagsMax') }),
+      variants: z
+        .array(z.enum(['no_equipment', 'bodyweight', 'dumbbell', 'standard', 'savage']))
+        .min(1, { message: t('variantsMin') }),
     })
     .superRefine((data, ctx) => {
       if (data.scoringMode === 'for_time') {

--- a/src/features/challenges/lib/pickBestScorePerUser.test.ts
+++ b/src/features/challenges/lib/pickBestScorePerUser.test.ts
@@ -20,4 +20,17 @@ describe('pickBestScorePerUser', () => {
     ];
     expect(pickBestScorePerUser(entries, 'reps')).toEqual([{ id: 'a2', user_id: 'u1', value: 55 }]);
   });
+
+  it('keeps best score per user per variant', () => {
+    const entries = [
+      { id: 'a1', user_id: 'u1', value: 40, variant: 'standard' },
+      { id: 'a2', user_id: 'u1', value: 55, variant: 'standard' },
+      { id: 'b1', user_id: 'u1', value: 30, variant: 'bodyweight' },
+    ];
+    expect(
+      pickBestScorePerUser(entries, 'reps')
+        .map((e) => e.id)
+        .sort(),
+    ).toEqual(['a2', 'b1']);
+  });
 });

--- a/src/features/challenges/lib/pickBestScorePerUser.ts
+++ b/src/features/challenges/lib/pickBestScorePerUser.ts
@@ -4,27 +4,33 @@ type Entry = {
   id: string;
   user_id: string;
   value: number;
+  variant?: string;
 };
 
-/** Keeps one row per user: best validated attempt for the challenge score type. */
+function dedupeKey(entry: Entry): string {
+  return `${entry.user_id}:${entry.variant ?? 'standard'}`;
+}
+
+/** Keeps one row per user per variant: best validated attempt for the challenge score type. */
 export function pickBestScorePerUser<T extends Entry>(
   entries: readonly T[],
   scoreType: ScoreType,
 ): T[] {
-  const byUser = new Map<string, T>();
+  const byUserVariant = new Map<string, T>();
 
   for (const entry of entries) {
-    const prev = byUser.get(entry.user_id);
+    const key = dedupeKey(entry);
+    const prev = byUserVariant.get(key);
     if (!prev) {
-      byUser.set(entry.user_id, entry);
+      byUserVariant.set(key, entry);
       continue;
     }
     if (scoreType === 'time') {
-      if (entry.value < prev.value) byUser.set(entry.user_id, entry);
+      if (entry.value < prev.value) byUserVariant.set(key, entry);
     } else if (entry.value > prev.value) {
-      byUser.set(entry.user_id, entry);
+      byUserVariant.set(key, entry);
     }
   }
 
-  return [...byUser.values()];
+  return [...byUserVariant.values()];
 }

--- a/src/features/challenges/lib/resolveLeaderboardFilters.test.ts
+++ b/src/features/challenges/lib/resolveLeaderboardFilters.test.ts
@@ -3,20 +3,54 @@ import { describe, expect, it } from 'vitest';
 import { EMPTY_FILTERS } from '@/features/challenges/lib/types';
 import { resolveLeaderboardFilters } from '@/features/challenges/lib/resolveLeaderboardFilters';
 
+const variants = ['bodyweight', 'standard', 'savage'] as const;
+
 describe('resolveLeaderboardFilters', () => {
-  it('defaults to the viewer division until the user changes the filter', () => {
-    expect(resolveLeaderboardFilters(EMPTY_FILTERS, 'regular', false)).toEqual({
+  it('defaults division to viewer profile when untouched', () => {
+    expect(
+      resolveLeaderboardFilters({
+        filters: EMPTY_FILTERS,
+        profileDivision: 'regular',
+        divisionFilterTouched: false,
+        availableVariants: variants,
+        variantFilterTouched: false,
+      }),
+    ).toEqual({
       ...EMPTY_FILTERS,
       division: 'regular',
+      variant: 'standard',
     });
   });
 
-  it('keeps global when the user explicitly selects it', () => {
-    expect(resolveLeaderboardFilters(EMPTY_FILTERS, 'regular', true)).toEqual(EMPTY_FILTERS);
+  it('keeps global division when viewer explicitly chose global', () => {
+    expect(
+      resolveLeaderboardFilters({
+        filters: EMPTY_FILTERS,
+        profileDivision: 'regular',
+        divisionFilterTouched: true,
+        availableVariants: variants,
+        variantFilterTouched: false,
+      }),
+    ).toEqual({
+      ...EMPTY_FILTERS,
+      variant: 'standard',
+    });
   });
 
-  it('preserves an explicit division selection', () => {
-    const filters = { ...EMPTY_FILTERS, division: 'elite' as const };
-    expect(resolveLeaderboardFilters(filters, 'regular', true)).toEqual(filters);
+  it('preserves explicit filters when touched', () => {
+    const filters = {
+      ...EMPTY_FILTERS,
+      division: 'elite' as const,
+      variant: 'bodyweight' as const,
+    };
+    expect(
+      resolveLeaderboardFilters({
+        filters,
+        profileDivision: 'regular',
+        divisionFilterTouched: true,
+        availableVariants: variants,
+        variantFilterTouched: true,
+      }),
+    ).toEqual(filters);
   });
 });

--- a/src/features/challenges/lib/resolveLeaderboardFilters.ts
+++ b/src/features/challenges/lib/resolveLeaderboardFilters.ts
@@ -1,13 +1,31 @@
 import type { LeaderboardFilters } from '@/features/challenges/lib/types';
-import type { Division } from '@/lib/types/database.types';
+import { pickDefaultChallengeVariant } from '@/lib/variants';
+import type { ChallengeVariant, Division } from '@/lib/types/database.types';
 
-export function resolveLeaderboardFilters(
-  filters: LeaderboardFilters,
-  profileDivision: Division | undefined,
-  divisionFilterTouched: boolean,
-): LeaderboardFilters {
-  if (divisionFilterTouched || filters.division !== null || !profileDivision) {
-    return filters;
+type Options = {
+  filters: LeaderboardFilters;
+  profileDivision: Division | undefined;
+  divisionFilterTouched: boolean;
+  availableVariants: readonly ChallengeVariant[];
+  variantFilterTouched: boolean;
+};
+
+export function resolveLeaderboardFilters({
+  filters,
+  profileDivision,
+  divisionFilterTouched,
+  availableVariants,
+  variantFilterTouched,
+}: Options): LeaderboardFilters {
+  let next = filters;
+
+  if (!divisionFilterTouched && next.division === null && profileDivision) {
+    next = { ...next, division: profileDivision };
   }
-  return { ...filters, division: profileDivision };
+
+  if (!variantFilterTouched && next.variant === null && availableVariants.length > 0) {
+    next = { ...next, variant: pickDefaultChallengeVariant(availableVariants) };
+  }
+
+  return next;
 }

--- a/src/features/challenges/lib/types.ts
+++ b/src/features/challenges/lib/types.ts
@@ -1,4 +1,4 @@
-import type { Faction, Sex, Division } from '@/lib/types/database.types';
+import type { Faction, Sex, Division, ChallengeVariant } from '@/lib/types/database.types';
 
 export type LeaderboardProfileSlim = {
   id: string;
@@ -16,6 +16,7 @@ export type LeaderboardEntry = {
   value: number;
   video_url: string | null;
   is_validated: boolean;
+  variant: ChallengeVariant;
   submitted_at: string;
   profile: LeaderboardProfileSlim | null;
 };
@@ -25,6 +26,7 @@ export type LeaderboardFilters = {
   ageBracket: import('@/features/challenges/lib/ageBracket').AgeBracket | null;
   faction: Faction | null;
   division: Division | null;
+  variant: ChallengeVariant | null;
 };
 
 export const EMPTY_FILTERS: LeaderboardFilters = {
@@ -32,4 +34,5 @@ export const EMPTY_FILTERS: LeaderboardFilters = {
   ageBracket: null,
   faction: null,
   division: null,
+  variant: null,
 };

--- a/src/features/challenges/services/challenges.ts
+++ b/src/features/challenges/services/challenges.ts
@@ -39,6 +39,7 @@ export async function createPendingChallenge(input: {
   rules: string;
   scoreType: ScoreType;
   equipmentTags: string[];
+  variants: import('@/lib/types/database.types').ChallengeVariant[];
   maxDurationSeconds: number | null;
 }): Promise<Challenge> {
   const { data, error } = await supabase
@@ -57,5 +58,14 @@ export async function createPendingChallenge(input: {
     .maybeSingle<Challenge>();
   if (error) throw new Error(error.message);
   if (!data) throw new Error('challenge_create_failed');
-  return data;
+
+  const { error: variantError } = await supabase.from('challenge_variants').insert(
+    input.variants.map((variant) => ({
+      challenge_id: data.id,
+      variant,
+    })),
+  );
+  if (variantError) throw new Error(variantError.message);
+
+  return { ...data, variants: input.variants };
 }

--- a/src/features/challenges/services/leaderboard.ts
+++ b/src/features/challenges/services/leaderboard.ts
@@ -4,7 +4,7 @@ import { supabase } from '@/lib/supabase';
 import type { ScoreType } from '@/lib/types/database.types';
 
 const LEADERBOARD_SELECT =
-  'id,challenge_id,user_id,value,video_url,is_validated,submitted_at,profile:profiles!scores_user_id_fkey(id,username,sex,age,faction,division)';
+  'id,challenge_id,user_id,value,video_url,is_validated,variant,submitted_at,profile:profiles!scores_user_id_fkey(id,username,sex,age,faction,division)';
 
 type Options = {
   challengeId: string;

--- a/src/features/submission/components/ScoreSubmissionForm.test.tsx
+++ b/src/features/submission/components/ScoreSubmissionForm.test.tsx
@@ -43,7 +43,12 @@ const profile: CompleteProfile = {
 function renderForm(onSubmitted = vi.fn()) {
   return render(
     <NextIntlClientProvider locale="en" messages={en}>
-      <ScoreSubmissionForm challengeId="challenge-1" scoreType="reps" onSubmitted={onSubmitted} />
+      <ScoreSubmissionForm
+        challengeId="challenge-1"
+        scoreType="reps"
+        availableVariants={['standard']}
+        onSubmitted={onSubmitted}
+      />
     </NextIntlClientProvider>,
   );
 }
@@ -74,6 +79,7 @@ describe('ScoreSubmissionForm', () => {
       challengeId: 'challenge-1',
       userId: 'user-1',
       value: 42,
+      variant: 'standard',
       videoUrl: '',
     });
   });

--- a/src/features/submission/components/ScoreSubmissionForm.tsx
+++ b/src/features/submission/components/ScoreSubmissionForm.tsx
@@ -8,17 +8,20 @@ import { useTranslations } from 'next-intl';
 import { useRequireAppAccess } from '@/features/appshell';
 import { ScoreSubmissionProofFields } from '@/features/submission/components/ScoreSubmissionProofFields';
 import { ScoreSubmissionScoreFields } from '@/features/submission/components/ScoreSubmissionScoreFields';
+import { ScoreSubmissionVariantFields } from '@/features/submission/components/ScoreSubmissionVariantFields';
 import {
   buildScoreSubmissionSchema,
   parseScoreSubmissionValue,
   type ScoreSubmissionFormValues,
 } from '@/features/submission/lib/scoreSubmissionSchema';
 import { submitScore, SUBMISSION_ERRORS } from '@/features/submission/services/submitScore';
-import type { ScoreType } from '@/lib/types/database.types';
+import { pickDefaultChallengeVariant } from '@/lib/variants';
+import type { ChallengeVariant, ScoreType } from '@/lib/types/database.types';
 
 type Props = {
   challengeId: string;
   scoreType: ScoreType;
+  availableVariants: readonly ChallengeVariant[];
   maxDurationSeconds?: number | null;
   onSubmitted: (result: { ranked: boolean; insertedId: string }) => void;
 };
@@ -26,6 +29,7 @@ type Props = {
 export function ScoreSubmissionForm({
   challengeId,
   scoreType,
+  availableVariants,
   maxDurationSeconds = null,
   onSubmitted,
 }: Props) {
@@ -33,6 +37,9 @@ export function ScoreSubmissionForm({
   const access = useRequireAppAccess();
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [variant, setVariant] = useState<ChallengeVariant>(() =>
+    pickDefaultChallengeVariant(availableVariants),
+  );
 
   const schema = useMemo(
     () => buildScoreSubmissionSchema((k) => t(k), scoreType, maxDurationSeconds ?? null),
@@ -79,6 +86,7 @@ export function ScoreSubmissionForm({
           challengeId,
           userId: access.profile.id,
           value,
+          variant,
           videoUrl: values.videoUrl,
         });
         onSubmitted({ ranked: res.ranked, insertedId: res.insertedId });
@@ -97,7 +105,7 @@ export function ScoreSubmissionForm({
         setSubmitting(false);
       }
     },
-    [access, challengeId, onSubmitted, scoreType, setError, setScoreError, t],
+    [access, challengeId, onSubmitted, scoreType, setError, setScoreError, t, variant],
   );
 
   if (access.status !== 'ready') {
@@ -110,6 +118,12 @@ export function ScoreSubmissionForm({
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 pb-4">
+      <ScoreSubmissionVariantFields
+        variants={availableVariants}
+        value={variant}
+        disabled={!canInteract}
+        onChange={setVariant}
+      />
       <ScoreSubmissionScoreFields scoreType={scoreType} register={register} errors={errors} />
       <ScoreSubmissionProofFields register={register} errors={errors} />
 

--- a/src/features/submission/components/ScoreSubmissionScreen.tsx
+++ b/src/features/submission/components/ScoreSubmissionScreen.tsx
@@ -111,6 +111,7 @@ export function ScoreSubmissionScreen({ challengeId }: Props) {
       <ScoreSubmissionForm
         challengeId={challenge.id}
         scoreType={challenge.score_type}
+        availableVariants={challenge.variants ?? ['standard']}
         maxDurationSeconds={challenge.max_duration_seconds ?? null}
         onSubmitted={(r) => {
           clearChallengeCommitment(challenge.id);

--- a/src/features/submission/components/ScoreSubmissionVariantFields.tsx
+++ b/src/features/submission/components/ScoreSubmissionVariantFields.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { ChallengeVariant } from '@/lib/types/database.types';
+
+type Props = {
+  variants: readonly ChallengeVariant[];
+  value: ChallengeVariant;
+  disabled?: boolean;
+  onChange: (next: ChallengeVariant) => void;
+};
+
+function chipClass(active: boolean): string {
+  return [
+    'rounded-sm border px-2 py-1.5 text-[11px] font-black uppercase tracking-[0.14em] transition-colors',
+    active
+      ? 'border-primary bg-primary/15 text-primary'
+      : 'border-border bg-background text-muted-foreground hover:text-foreground',
+  ].join(' ');
+}
+
+export function ScoreSubmissionVariantFields({
+  variants,
+  value,
+  disabled = false,
+  onChange,
+}: Props) {
+  const t = useTranslations('submission');
+  const tVariants = useTranslations('variants');
+
+  if (variants.length <= 1) return null;
+
+  return (
+    <fieldset className="space-y-2 rounded-md border border-border bg-card p-4" disabled={disabled}>
+      <legend className="px-1 text-xs font-black uppercase tracking-[0.18em] text-foreground">
+        {t('variantTitle')}
+      </legend>
+      <p className="text-xs text-muted-foreground">{t('variantBody')}</p>
+      <div className="flex flex-wrap gap-2">
+        {variants.map((variant) => (
+          <button
+            key={variant}
+            type="button"
+            aria-pressed={value === variant}
+            disabled={disabled}
+            onClick={() => onChange(variant)}
+            className={chipClass(value === variant)}
+          >
+            {tVariants(variant)}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/features/submission/services/submitScore.ts
+++ b/src/features/submission/services/submitScore.ts
@@ -2,11 +2,13 @@ import { supabase } from '@/lib/supabase';
 
 import { assertTimeScoreWithinCap, TIME_CAP_ERROR } from '@/features/submission/lib/timeScoreCap';
 import { isAllowedVideoUrl } from '@/lib/scoring';
+import type { ChallengeVariant } from '@/lib/types/database.types';
 
 type Options = {
   challengeId: string;
   userId: string;
   value: number;
+  variant: ChallengeVariant;
   videoUrl?: string | null;
 };
 
@@ -16,6 +18,7 @@ type Result = {
 };
 
 const VIDEO_INVALID_ERROR = 'video_invalid';
+const VARIANT_INVALID_ERROR = 'variant_invalid';
 
 export async function submitScore(options: Options): Promise<Result> {
   const trimmedVideo = options.videoUrl?.trim() ?? '';
@@ -30,6 +33,15 @@ export async function submitScore(options: Options): Promise<Result> {
     .maybeSingle<{ score_type: string; max_duration_seconds: number | null }>();
   if (chErr) throw new Error(chErr.message);
   if (!ch) throw new Error('challenge_not_found');
+
+  const { data: variantRows, error: variantErr } = await supabase
+    .from('challenge_variants')
+    .select('variant')
+    .eq('challenge_id', options.challengeId);
+  if (variantErr) throw new Error(variantErr.message);
+  const allowed = new Set((variantRows ?? []).map((row) => row.variant as ChallengeVariant));
+  if (!allowed.has(options.variant)) throw new Error(VARIANT_INVALID_ERROR);
+
   assertTimeScoreWithinCap({
     scoreType: ch.score_type,
     value: options.value,
@@ -46,6 +58,7 @@ export async function submitScore(options: Options): Promise<Result> {
       challenge_id: options.challengeId,
       user_id: options.userId,
       value: options.value,
+      variant: options.variant,
       video_url,
       is_validated,
     })
@@ -61,4 +74,5 @@ export async function submitScore(options: Options): Promise<Result> {
 export const SUBMISSION_ERRORS = {
   VIDEO_INVALID: VIDEO_INVALID_ERROR,
   EXCEEDS_TIME_CAP: TIME_CAP_ERROR,
+  VARIANT_INVALID: VARIANT_INVALID_ERROR,
 } as const;

--- a/src/lib/challenges/getChallengeById.ts
+++ b/src/lib/challenges/getChallengeById.ts
@@ -1,14 +1,34 @@
 import { CHALLENGE_SELECT } from '@/lib/challenges/constants';
 import { supabase } from '@/lib/supabase';
-import type { Challenge } from '@/lib/types/database.types';
+import type { Challenge, ChallengeVariant } from '@/lib/types/database.types';
+
+type ChallengeRow = Challenge & {
+  challenge_variants: { variant: ChallengeVariant }[] | null;
+};
+
+function mapChallengeRow(row: ChallengeRow): Challenge {
+  const { challenge_variants, ...challenge } = row;
+  const variants = (challenge_variants ?? []).map((v) => v.variant);
+  return { ...challenge, variants };
+}
 
 /** Uses RLS: approved challenges for everyone; pending/rejected visible only to creator. */
 export async function getChallengeById(id: string): Promise<Challenge | null> {
   const { data, error } = await supabase
     .from('challenges')
-    .select(CHALLENGE_SELECT)
+    .select(`${CHALLENGE_SELECT}, challenge_variants(variant)`)
     .eq('id', id)
-    .maybeSingle<Challenge>();
+    .maybeSingle<ChallengeRow>();
   if (error) throw new Error(error.message);
-  return data ?? null;
+  if (!data) return null;
+  return mapChallengeRow(data);
+}
+
+export async function listChallengeVariants(challengeId: string): Promise<ChallengeVariant[]> {
+  const { data, error } = await supabase
+    .from('challenge_variants')
+    .select('variant')
+    .eq('challenge_id', challengeId);
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((row) => row.variant as ChallengeVariant);
 }

--- a/src/lib/challenges/index.ts
+++ b/src/lib/challenges/index.ts
@@ -1,3 +1,3 @@
 export { CHALLENGE_SELECT } from '@/lib/challenges/constants';
-export { getChallengeById } from '@/lib/challenges/getChallengeById';
+export { getChallengeById, listChallengeVariants } from '@/lib/challenges/getChallengeById';
 export { listApprovedChallenges } from '@/lib/challenges/listApprovedChallenges';

--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -1,5 +1,6 @@
 export type Faction = 'nomads' | 'horde' | 'iron_alliance';
 export type Division = 'rookie' | 'regular' | 'savage' | 'elite';
+export type ChallengeVariant = 'no_equipment' | 'bodyweight' | 'dumbbell' | 'standard' | 'savage';
 export type Sex = 'male' | 'female' | 'other';
 export type ScoreType = 'time' | 'reps';
 export type ChallengeStatus = 'pending' | 'approved' | 'rejected';
@@ -72,6 +73,8 @@ export interface Challenge {
   /** When set and in the past, approved challenge is closed in Arena (done). */
   ends_at?: string | null;
   created_at: string;
+  /** Official scaling lanes enabled for this challenge (from challenge_variants). */
+  variants?: ChallengeVariant[];
 }
 
 export interface Score {
@@ -82,6 +85,7 @@ export interface Score {
   value: number;
   video_url: string | null;
   is_validated: boolean;
+  variant: ChallengeVariant;
   is_hidden?: boolean;
   submitted_at: string;
   profile?: Profile;

--- a/src/lib/variants/constants.test.ts
+++ b/src/lib/variants/constants.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { isChallengeVariant, pickDefaultChallengeVariant } from '@/lib/variants/constants';
+
+describe('pickDefaultChallengeVariant', () => {
+  it('prefers standard when available', () => {
+    expect(pickDefaultChallengeVariant(['bodyweight', 'standard', 'savage'])).toBe('standard');
+  });
+
+  it('falls back to first variant when standard is absent', () => {
+    expect(pickDefaultChallengeVariant(['bodyweight', 'savage'])).toBe('bodyweight');
+  });
+});
+
+describe('isChallengeVariant', () => {
+  it('accepts canonical slugs', () => {
+    expect(isChallengeVariant('no_equipment')).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    expect(isChallengeVariant('easy_mode')).toBe(false);
+  });
+});

--- a/src/lib/variants/constants.ts
+++ b/src/lib/variants/constants.ts
@@ -1,0 +1,23 @@
+import type { ChallengeVariant } from '@/lib/types/database.types';
+
+export const CHALLENGE_VARIANTS: readonly ChallengeVariant[] = [
+  'no_equipment',
+  'bodyweight',
+  'dumbbell',
+  'standard',
+  'savage',
+] as const;
+
+export const DEFAULT_CHALLENGE_VARIANT: ChallengeVariant = 'standard';
+
+export function isChallengeVariant(value: string): value is ChallengeVariant {
+  return (CHALLENGE_VARIANTS as readonly string[]).includes(value);
+}
+
+/** Preferred default when a challenge exposes multiple official variants. */
+export function pickDefaultChallengeVariant(
+  variants: readonly ChallengeVariant[],
+): ChallengeVariant {
+  if (variants.includes(DEFAULT_CHALLENGE_VARIANT)) return DEFAULT_CHALLENGE_VARIANT;
+  return variants[0] ?? DEFAULT_CHALLENGE_VARIANT;
+}

--- a/src/lib/variants/index.ts
+++ b/src/lib/variants/index.ts
@@ -1,0 +1,6 @@
+export {
+  CHALLENGE_VARIANTS,
+  DEFAULT_CHALLENGE_VARIANT,
+  isChallengeVariant,
+  pickDefaultChallengeVariant,
+} from '@/lib/variants/constants';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -263,7 +263,16 @@
         "rulesDetail": "Standards & scoring (detail)",
         "rulesDetailPlaceholder": "Standards, range of motion, no-rep rules, tie-breaks…",
         "equipmentTags": "Equipment (optional)",
-        "equipmentPlaceholder": "kettlebell, pull-up bar…"
+        "equipmentPlaceholder": "kettlebell, pull-up bar…",
+        "variants": "Official scaling lanes",
+        "variantsHint": "Pick at least one. These are ranked separately — not a shame mode."
+      },
+      "variants": {
+        "no_equipment": "No equipment",
+        "bodyweight": "Bodyweight",
+        "dumbbell": "Dumbbell",
+        "standard": "Standard",
+        "savage": "Savage"
       },
       "scoring": {
         "legend": "HOW IT SCORES",
@@ -314,7 +323,9 @@
         "amrapCapInvalid": "Use MM:SS for the cap (e.g. 10:00).",
         "amrapCapZero": "Cap must be longer than 0:00.",
         "forTimeCapInvalid": "Use MM:SS for the max time (e.g. 15:00).",
-        "forTimeCapZero": "Max time must be longer than 0:00."
+        "forTimeCapZero": "Max time must be longer than 0:00.",
+        "variantsMin": "Enable at least one official scaling lane.",
+        "variantsInvalid": "Pick valid scaling lanes only."
       }
     }
   },
@@ -336,6 +347,8 @@
     "rulesHeading": "Rules",
     "equipmentHeading": "Equipment",
     "noEquipment": "Bodyweight only",
+    "variantsHeading": "Official scaling",
+    "variantsBody": "Same challenge, different lanes. Rankings are per lane — pick yours and compete fairly.",
     "ctaStart": "POST SCORE",
     "ctaRetry": "RE-TRY / IMPROVE YOUR SCORE",
     "participationSummary": "Submitted {count} times. Best: {score} ({status}).",
@@ -411,6 +424,7 @@
       "colTitle": "Title",
       "colAi": "AI triage",
       "colType": "Type",
+      "colVariants": "Scaling",
       "colCreator": "Creator",
       "colSubmitted": "Submitted",
       "colActions": "Actions",
@@ -476,6 +490,8 @@
       "all": "All",
       "global": "Global",
       "division": "Division",
+      "variant": "Scaling",
+      "allVariants": "All lanes",
       "sex": "Sex",
       "age": "Age",
       "faction": "Faction",
@@ -498,6 +514,13 @@
     "savage": "Savage",
     "elite": "Elite"
   },
+  "variants": {
+    "no_equipment": "No equipment",
+    "bodyweight": "Bodyweight",
+    "dumbbell": "Dumbbell",
+    "standard": "Standard",
+    "savage": "Savage"
+  },
   "submission": {
     "title": "SUBMIT YOUR SCORE",
     "loading": "Loading...",
@@ -510,6 +533,8 @@
     "repsPlaceholder": "0",
     "proofTitle": "PROOF (OPTIONAL)",
     "proofBody": "No video = saved but not ranked. Add a YouTube/TikTok link to get ranked.",
+    "variantTitle": "YOUR SCALING LANE",
+    "variantBody": "Official scaling — ranked separately. Not a shame mode.",
     "videoLabelOptional": "VIDEO URL (OPTIONAL)",
     "videoHelper": "YouTube or TikTok only",
     "submit": "SUBMIT YOUR SCORE",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -263,7 +263,16 @@
         "rulesDetail": "Standards & scoring (détail)",
         "rulesDetailPlaceholder": "Standards, amplitude, no-rep, départage…",
         "equipmentTags": "Équipement (optionnel)",
-        "equipmentPlaceholder": "kettlebell, barre de traction…"
+        "equipmentPlaceholder": "kettlebell, barre de traction…",
+        "variants": "Variantes officielles",
+        "variantsHint": "Choisis au moins une. Classements séparés — ce n'est pas un mode honteux."
+      },
+      "variants": {
+        "no_equipment": "Sans matériel",
+        "bodyweight": "Poids du corps",
+        "dumbbell": "Haltères",
+        "standard": "Standard",
+        "savage": "Savage"
       },
       "scoring": {
         "legend": "COMMENT ÇA SCORE",
@@ -314,7 +323,9 @@
         "amrapCapInvalid": "Utilise MM:SS pour le cap (ex. 10:00).",
         "amrapCapZero": "Le cap doit être plus long que 0:00.",
         "forTimeCapInvalid": "Utilise MM:SS pour le temps max (ex. 15:00).",
-        "forTimeCapZero": "Le temps max doit être plus long que 0:00."
+        "forTimeCapZero": "Le temps max doit être plus long que 0:00.",
+        "variantsMin": "Active au moins une variante officielle.",
+        "variantsInvalid": "Choisis des variantes valides uniquement."
       }
     }
   },
@@ -336,6 +347,8 @@
     "rulesHeading": "Règles",
     "equipmentHeading": "Équipement",
     "noEquipment": "Poids du corps uniquement",
+    "variantsHeading": "Scaling officiel",
+    "variantsBody": "Même défi, voies différentes. Classements par voie — choisis la tienne et affronte des pairs.",
     "ctaStart": "POSTER MON SCORE",
     "ctaRetry": "RE-TENTER / AMÉLIORER TON SCORE",
     "participationSummary": "Défis soumis : {count} fois. Ton meilleur score : {score} ({status}).",
@@ -411,6 +424,7 @@
       "colTitle": "Titre",
       "colAi": "Tri IA",
       "colType": "Type",
+      "colVariants": "Scaling",
       "colCreator": "Créateur",
       "colSubmitted": "Soumis",
       "colActions": "Actions",
@@ -476,6 +490,8 @@
       "all": "Tous",
       "global": "Global",
       "division": "Division",
+      "variant": "Scaling",
+      "allVariants": "Toutes les voies",
       "sex": "Sexe",
       "age": "Âge",
       "faction": "Faction",
@@ -498,6 +514,13 @@
     "savage": "Savage",
     "elite": "Elite"
   },
+  "variants": {
+    "no_equipment": "Sans matériel",
+    "bodyweight": "Poids du corps",
+    "dumbbell": "Haltères",
+    "standard": "Standard",
+    "savage": "Savage"
+  },
   "submission": {
     "title": "SOUMETTRE TON SCORE",
     "loading": "Chargement...",
@@ -510,6 +533,8 @@
     "repsPlaceholder": "0",
     "proofTitle": "PREUVE (OPTIONNELLE)",
     "proofBody": "Sans vidéo = sauvegardé mais non classé. Ajoute un lien YouTube/TikTok pour être classé.",
+    "variantTitle": "TA VOIE DE SCALING",
+    "variantBody": "Scaling officiel — classé à part. Ce n'est pas un mode honteux.",
     "videoLabelOptional": "LIEN VIDÉO (OPTIONNEL)",
     "videoHelper": "YouTube ou TikTok uniquement",
     "submit": "SOUMETTRE MON SCORE",

--- a/supabase/migrations/016_challenge_variants.sql
+++ b/supabase/migrations/016_challenge_variants.sql
@@ -1,0 +1,81 @@
+-- V2-02: official challenge scaling variants (structured, not free text).
+
+CREATE TABLE IF NOT EXISTS public.challenge_variants (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenge_id UUID        NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  variant      TEXT        NOT NULL CHECK (variant IN (
+    'no_equipment', 'bodyweight', 'dumbbell', 'standard', 'savage'
+  )),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (challenge_id, variant)
+);
+
+COMMENT ON TABLE public.challenge_variants IS
+  'Official scaling lanes per challenge. Distinct from equipment_tags (descriptive tags).';
+
+ALTER TABLE public.scores
+  ADD COLUMN IF NOT EXISTS variant TEXT NOT NULL DEFAULT 'standard'
+    CHECK (variant IN ('no_equipment', 'bodyweight', 'dumbbell', 'standard', 'savage'));
+
+COMMENT ON COLUMN public.scores.variant IS
+  'Official scaling lane for this submission. Must match a row in challenge_variants.';
+
+INSERT INTO public.challenge_variants (challenge_id, variant)
+SELECT c.id, 'standard'
+FROM public.challenges c
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.challenge_variants cv
+  WHERE cv.challenge_id = c.id AND cv.variant = 'standard'
+);
+
+UPDATE public.scores SET variant = 'standard' WHERE variant IS NULL;
+
+ALTER TABLE public.scores
+  ADD CONSTRAINT scores_challenge_variant_fkey
+  FOREIGN KEY (challenge_id, variant)
+  REFERENCES public.challenge_variants (challenge_id, variant);
+
+CREATE INDEX IF NOT EXISTS idx_challenge_variants_challenge
+  ON public.challenge_variants (challenge_id);
+
+CREATE INDEX IF NOT EXISTS idx_scores_challenge_variant
+  ON public.scores (challenge_id, variant, is_validated);
+
+ALTER TABLE public.challenge_variants ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read variants for approved challenges"
+  ON public.challenge_variants FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.challenges c
+      WHERE c.id = challenge_id AND c.status = 'approved'
+    )
+  );
+
+CREATE POLICY "Creators can read variants for own challenges"
+  ON public.challenge_variants FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.challenges c
+      WHERE c.id = challenge_id AND c.creator_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Admins can read all challenge variants"
+  ON public.challenge_variants FOR SELECT
+  TO authenticated
+  USING (public.is_app_admin());
+
+CREATE POLICY "Creators can insert variants for own pending challenges"
+  ON public.challenge_variants FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.challenges c
+      WHERE c.id = challenge_id
+        AND c.creator_id = auth.uid()
+        AND c.status = 'pending'
+    )
+  );


### PR DESCRIPTION
## Summary
- Migration `016`: `challenge_variants` table + `scores.variant` with FK and RLS
- Creator Studio: pick official scaling lanes (no equipment / bodyweight / dumbbell / standard / savage)
- Score submission: attach score to a variant; server validates lane exists on challenge
- Leaderboard: filter by scaling lane + division (default standard when available)
- Admin MOD queue: scaling column; challenge detail copy clarifies official scaling ≠ shame mode
- i18n EN/FR + unit tests

Fixes #75

## Test plan
- [x] `pnpm check`
- [ ] Apply migration `016` on Supabase (staging/prod)
- [ ] Create UGC challenge with multiple variants → approve → submit on each lane → LB filters
- [ ] Existing challenges/scores backfilled to `standard`


Made with [Cursor](https://cursor.com)