### PR TITLE
feat(rivals): DB + services for Rival Matches (V2-07 PR1)

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -3,7 +3,7 @@
 > **MVP core livré.** **V1 sérieuse (sections A–G)** : **livré sur `main`** (PR [#30](https://github.com/igorms-pro/truegrynd/pull/30) → [#55](https://github.com/igorms-pro/truegrynd/pull/55)).  
 > **V2** : stratégie dans [docs/V2_STRATEGY.md](../V2_STRATEGY.md). Angle : compétition fitness accessible, divisions de niveau, weekly challenges, équipes/factions, progression amateur.
 
-**Dernière mise à jour :** 1 juin 2026 (post-PR #82 / V2-05)
+**Dernière mise à jour :** 1 juin 2026 (post-PR #84 / V2-06)
 
 ---
 
@@ -39,7 +39,7 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 | **V1.5 — Profil épuré & page Historique** | Section **K** — carrousel CARDS + `/app/profile/history`                                                        |
 | **Fix & polish pré-V2 (QA V1)**           | Section **J** — flow soumission score / copy CTA                                                                |
 | **Production hardening (10k users)**      | Section **L** — clean archi, DRY, limites feature                                                               |
-| **V2 — Accessible competition**           | Section **H** — V2-00 🟢 · … · V2-05 🟢 · **V2-06 🟡** [#83](https://github.com/igorms-pro/truegrynd/issues/83) |
+| **V2 — Accessible competition**           | Section **H** — V2-00 🟢 · … · V2-06 🟢 · **V2-07 🟡** [#85](https://github.com/igorms-pro/truegrynd/issues/85) |
 
 **Macro-checklist**
 
@@ -79,8 +79,8 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 - [x] **V2-03** — Weekly Global Challenge — 🟢 [#77](https://github.com/igorms-pro/truegrynd/issues/77) PR [#78](https://github.com/igorms-pro/truegrynd/pull/78)
 - [x] **V2-04** — Leaderboards par division, faction, ville, pays — 🟢 [#79](https://github.com/igorms-pro/truegrynd/issues/79) PR [#80](https://github.com/igorms-pro/truegrynd/pull/80) · migration **`018`** prod
 - [x] **V2-05** — Truegrynd Rating (Engine / Power / Strength / Grit / Consistency) — 🟢 [#81](https://github.com/igorms-pro/truegrynd/issues/81) PR [#82](https://github.com/igorms-pro/truegrynd/pull/82) · migration **`019`** prod
-- [ ] **V2-06** — Challenge Passport / palmarès amateur — 🟡 [#83](https://github.com/igorms-pro/truegrynd/issues/83) · branche `feature/issue-83-v2-06-passport`
-- [ ] **V2-07** — Rival Matches (1v1 / petits groupes)
+- [x] **V2-06** — Challenge Passport / palmarès amateur — 🟢 [#83](https://github.com/igorms-pro/truegrynd/issues/83) PR [#84](https://github.com/igorms-pro/truegrynd/pull/84) · migration **`020`** prod
+- [ ] **V2-07** — Rival Matches (1v1 / petits groupes) — 🟡 [#85](https://github.com/igorms-pro/truegrynd/issues/85) · branche `feature/issue-85-v2-07-rival-matches`
 - [ ] **V2-08** — Team Wars / Faction Wars par division
 - [ ] **V2-09** — Micro-events async (24h / 7j / 30j)
 - [ ] **V2-10** — Proof Levels (Honor / Video / Community / Judge / Event)
@@ -659,7 +659,7 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-06. Challenge Passport / Palmarès Amateur
 
-**GitHub :** [#83](https://github.com/igorms-pro/truegrynd/issues/83) · **Branche :** `feature/issue-83-v2-06-passport` · **Statut :** 🟡
+**GitHub :** [#83](https://github.com/igorms-pro/truegrynd/issues/83) · **PR :** [#84](https://github.com/igorms-pro/truegrynd/pull/84) · **Statut :** 🟢
 
 - [x] **Produit** : transformer le profil en CV compétitif amateur.
 - [x] **Contenu** : divisions atteintes, meilleurs scores, badges, weekly complétés, finisher cards (rival matches → V2-07).
@@ -669,8 +669,9 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-07. Rival Matches
 
+**GitHub :** [#85](https://github.com/igorms-pro/truegrynd/issues/85) · **Branche :** `feature/issue-85-v2-07-rival-matches` · **Statut :** 🟡
+
 - [ ] **Produit** : 1v1 ou petit groupe sur 1 à 3 challenges, durée 24h/7j.
-- [ ] **Matching** : même division par défaut ; option faction adverse / ami / ville.
 - [ ] **DB** : `rival_matches`, participants, challenge set, status, winner.
 - [ ] **UX** : créer, accepter, soumettre, résultat.
 - [ ] **Notifications** : minimal V2 (email/toast/polling), pas besoin d'un réseau social complet.
@@ -755,10 +756,10 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | **Fix flow submit (POST SCORE → formulaire)** | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)                                                                                                                               |
 | **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                            |
 | **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                               |
-| **V2 — Accessible competition**               | 🟢 V2-00–05 · **🟡 V2-06** [#83](https://github.com/igorms-pro/truegrynd/issues/83) `feature/issue-83-v2-06-passport`                                                                                                                               |
+| **V2 — Accessible competition**               | 🟢 V2-00–06 · **🟡 V2-07** [#85](https://github.com/igorms-pro/truegrynd/issues/85) `feature/issue-85-v2-07-rival-matches`                                                                                                                          |
 | **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                        |
 
-**Suite produit :** **V2-06** 🟡 en cours ([#83](https://github.com/igorms-pro/truegrynd/issues/83) · `feature/issue-83-v2-06-passport`). QA V2 globale en fin de lot V2, pas issue par issue.
+**Suite produit :** **V2-07** 🟡 en cours ([#85](https://github.com/igorms-pro/truegrynd/issues/85) · `feature/issue-85-v2-07-rival-matches`). QA V2 globale en fin de lot V2, pas issue par issue.
 
 ---
 

--- a/src/features/rivals/hooks/useRivalMatch.ts
+++ b/src/features/rivals/hooks/useRivalMatch.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { fetchRivalMatch, type RivalMatchView } from '@/features/rivals/services/rivalMatches';
+
+type State =
+  | { status: 'loading'; match: null; error: null }
+  | { status: 'error'; match: null; error: string }
+  | { status: 'ready'; match: RivalMatchView | null; error: null };
+
+const initial: State = { status: 'loading', match: null, error: null };
+
+export function useRivalMatch(matchId: string | null): {
+  state: State;
+  refetch: () => void;
+} {
+  const [state, setState] = useState<State>(initial);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!matchId) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const match = await fetchRivalMatch(matchId);
+        if (!cancelled) setState({ status: 'ready', match, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', match: null, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [matchId, reloadKey]);
+
+  const refetch = useCallback(() => {
+    setState(initial);
+    setReloadKey((key) => key + 1);
+  }, []);
+
+  return { state, refetch };
+}

--- a/src/features/rivals/index.ts
+++ b/src/features/rivals/index.ts
@@ -1,0 +1,19 @@
+export { useRivalMatch } from '@/features/rivals/hooks/useRivalMatch';
+export {
+  MAX_PENDING_RIVAL_INVITES,
+  parseRivalRpcError,
+} from '@/features/rivals/lib/rivalInviteLimits';
+export { resolveRivalWinner } from '@/features/rivals/lib/resolveRivalWinner';
+export {
+  cancelRivalMatch,
+  computeRivalWinnerFromScores,
+  createRivalMatch,
+  fetchRivalMatch,
+  listMyRivalMatches,
+  respondRivalMatchInvite,
+} from '@/features/rivals/services/rivalMatches';
+export type {
+  RivalMatchChallengeView,
+  RivalMatchParticipantView,
+  RivalMatchView,
+} from '@/features/rivals/services/rivalMatches';

--- a/src/features/rivals/lib/resolveRivalWinner.test.ts
+++ b/src/features/rivals/lib/resolveRivalWinner.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveRivalWinner,
+  type RivalChallengeInput,
+} from '@/features/rivals/lib/resolveRivalWinner';
+
+describe('resolveRivalWinner', () => {
+  const participants = ['user-a', 'user-b'];
+
+  it('picks higher reps on a single reps challenge', () => {
+    const challenges: RivalChallengeInput[] = [
+      {
+        challengeId: 'ch-1',
+        scoreType: 'reps',
+        scores: [
+          { userId: 'user-a', value: 40 },
+          { userId: 'user-b', value: 55 },
+        ],
+      },
+    ];
+
+    const result = resolveRivalWinner(challenges, participants);
+    expect(result.reason).toBe('decided');
+    expect(result.winnerId).toBe('user-b');
+  });
+
+  it('picks faster time on a single time challenge', () => {
+    const challenges: RivalChallengeInput[] = [
+      {
+        challengeId: 'ch-1',
+        scoreType: 'time',
+        scores: [
+          { userId: 'user-a', value: 120 },
+          { userId: 'user-b', value: 95 },
+        ],
+      },
+    ];
+
+    expect(resolveRivalWinner(challenges, participants).winnerId).toBe('user-b');
+  });
+
+  it('returns incomplete when a participant has no score', () => {
+    const challenges: RivalChallengeInput[] = [
+      {
+        challengeId: 'ch-1',
+        scoreType: 'reps',
+        scores: [{ userId: 'user-a', value: 10 }],
+      },
+    ];
+
+    expect(resolveRivalWinner(challenges, participants).reason).toBe('incomplete');
+  });
+
+  it('uses best-of across multiple challenges', () => {
+    const challenges: RivalChallengeInput[] = [
+      {
+        challengeId: 'ch-1',
+        scoreType: 'reps',
+        scores: [
+          { userId: 'user-a', value: 50 },
+          { userId: 'user-b', value: 40 },
+        ],
+      },
+      {
+        challengeId: 'ch-2',
+        scoreType: 'reps',
+        scores: [
+          { userId: 'user-a', value: 30 },
+          { userId: 'user-b', value: 20 },
+        ],
+      },
+    ];
+
+    expect(resolveRivalWinner(challenges, participants).winnerId).toBe('user-a');
+  });
+
+  it('returns tie when challenge wins are split evenly', () => {
+    const challenges: RivalChallengeInput[] = [
+      {
+        challengeId: 'ch-1',
+        scoreType: 'reps',
+        scores: [
+          { userId: 'user-a', value: 50 },
+          { userId: 'user-b', value: 40 },
+        ],
+      },
+      {
+        challengeId: 'ch-2',
+        scoreType: 'reps',
+        scores: [
+          { userId: 'user-a', value: 20 },
+          { userId: 'user-b', value: 30 },
+        ],
+      },
+    ];
+
+    expect(resolveRivalWinner(challenges, participants).reason).toBe('tie');
+  });
+});

--- a/src/features/rivals/lib/resolveRivalWinner.ts
+++ b/src/features/rivals/lib/resolveRivalWinner.ts
@@ -1,0 +1,74 @@
+import type { ScoreType } from '@/lib/types/database.types';
+
+export type RivalParticipantScore = {
+  userId: string;
+  value: number;
+};
+
+export type RivalChallengeInput = {
+  challengeId: string;
+  scoreType: ScoreType;
+  scores: readonly RivalParticipantScore[];
+};
+
+export type RivalWinnerResult = {
+  winnerId: string | null;
+  challengeWinners: ReadonlyMap<string, string | null>;
+  reason: 'decided' | 'tie' | 'incomplete';
+};
+
+function pickChallengeWinner(
+  scores: readonly RivalParticipantScore[],
+  scoreType: ScoreType,
+): string | null {
+  if (scores.length === 0) return null;
+
+  let best = scores[0];
+  for (let i = 1; i < scores.length; i += 1) {
+    const candidate = scores[i];
+    if (scoreType === 'time') {
+      if (candidate.value < best.value) best = candidate;
+    } else if (candidate.value > best.value) {
+      best = candidate;
+    }
+  }
+
+  const tied = scores.filter((s) => s.value === best.value);
+  if (tied.length !== 1) return null;
+  return best.userId;
+}
+
+export function resolveRivalWinner(
+  challenges: readonly RivalChallengeInput[],
+  participantIds: readonly string[],
+): RivalWinnerResult {
+  const challengeWinners = new Map<string, string | null>();
+  const wins = new Map<string, number>();
+
+  for (const id of participantIds) {
+    wins.set(id, 0);
+  }
+
+  for (const challenge of challenges) {
+    const expected = participantIds.length;
+    const submitted = challenge.scores.filter((s) => participantIds.includes(s.userId));
+    if (submitted.length < expected) {
+      return { winnerId: null, challengeWinners, reason: 'incomplete' };
+    }
+
+    const roundWinner = pickChallengeWinner(submitted, challenge.scoreType);
+    challengeWinners.set(challenge.challengeId, roundWinner);
+    if (roundWinner) {
+      wins.set(roundWinner, (wins.get(roundWinner) ?? 0) + 1);
+    }
+  }
+
+  const maxWins = Math.max(...participantIds.map((id) => wins.get(id) ?? 0));
+  const leaders = participantIds.filter((id) => (wins.get(id) ?? 0) === maxWins);
+
+  if (leaders.length !== 1 || maxWins === 0) {
+    return { winnerId: null, challengeWinners, reason: 'tie' };
+  }
+
+  return { winnerId: leaders[0] ?? null, challengeWinners, reason: 'decided' };
+}

--- a/src/features/rivals/lib/rivalInviteLimits.test.ts
+++ b/src/features/rivals/lib/rivalInviteLimits.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isPendingInviteLimitReached,
+  MAX_PENDING_RIVAL_INVITES,
+  parseRivalRpcError,
+} from '@/features/rivals/lib/rivalInviteLimits';
+
+describe('rivalInviteLimits', () => {
+  it('blocks at max pending invites', () => {
+    expect(isPendingInviteLimitReached(MAX_PENDING_RIVAL_INVITES - 1)).toBe(false);
+    expect(isPendingInviteLimitReached(MAX_PENDING_RIVAL_INVITES)).toBe(true);
+  });
+
+  it('parses known RPC errors from Supabase messages', () => {
+    expect(parseRivalRpcError('division_mismatch')).toBe('division_mismatch');
+    expect(parseRivalRpcError('ERROR: too_many_pending_invites_sent')).toBe(
+      'too_many_pending_invites_sent',
+    );
+    expect(parseRivalRpcError('something else')).toBe('unknown');
+  });
+});

--- a/src/features/rivals/lib/rivalInviteLimits.ts
+++ b/src/features/rivals/lib/rivalInviteLimits.ts
@@ -1,0 +1,38 @@
+export const MAX_PENDING_RIVAL_INVITES = 5;
+
+export function isPendingInviteLimitReached(pendingCount: number): boolean {
+  return pendingCount >= MAX_PENDING_RIVAL_INVITES;
+}
+
+export type RivalRpcErrorCode =
+  | 'too_many_pending_invites_sent'
+  | 'invitee_too_many_pending'
+  | 'division_mismatch'
+  | 'invitee_not_found'
+  | 'cannot_invite_self'
+  | 'invalid_challenge_count'
+  | 'invalid_duration'
+  | 'not_invited'
+  | 'match_not_pending'
+  | 'cannot_cancel';
+
+export function parseRivalRpcError(message: string): RivalRpcErrorCode | 'unknown' {
+  const codes: RivalRpcErrorCode[] = [
+    'too_many_pending_invites_sent',
+    'invitee_too_many_pending',
+    'division_mismatch',
+    'invitee_not_found',
+    'cannot_invite_self',
+    'invalid_challenge_count',
+    'invalid_duration',
+    'not_invited',
+    'match_not_pending',
+    'cannot_cancel',
+  ];
+
+  for (const code of codes) {
+    if (message.includes(code)) return code;
+  }
+
+  return 'unknown';
+}

--- a/src/features/rivals/services/rivalMatches.ts
+++ b/src/features/rivals/services/rivalMatches.ts
@@ -1,0 +1,224 @@
+import { pickBestScorePerUser } from '@/features/challenges/lib/pickBestScorePerUser';
+import {
+  resolveRivalWinner,
+  type RivalChallengeInput,
+} from '@/features/rivals/lib/resolveRivalWinner';
+import { supabase } from '@/lib/supabase';
+import type {
+  Division,
+  RivalMatch,
+  RivalMatchChallenge,
+  RivalMatchParticipant,
+  RivalMatchStatus,
+  RivalParticipantStatus,
+  ScoreType,
+} from '@/lib/types/database.types';
+
+export type RivalMatchChallengeView = {
+  challengeId: string;
+  sortOrder: number;
+  title: string;
+  scoreType: ScoreType;
+};
+
+export type RivalMatchParticipantView = {
+  userId: string;
+  username: string | null;
+  status: RivalParticipantStatus;
+  invitedAt: string;
+  respondedAt: string | null;
+};
+
+export type RivalMatchView = {
+  id: string;
+  creatorId: string;
+  status: RivalMatchStatus;
+  durationHours: 24 | 168;
+  division: Division;
+  maxParticipants: number;
+  createdAt: string;
+  startsAt: string | null;
+  endsAt: string | null;
+  winnerId: string | null;
+  challenges: RivalMatchChallengeView[];
+  participants: RivalMatchParticipantView[];
+};
+
+const MATCH_COLUMNS =
+  'id,creator_id,status,duration_hours,division,max_participants,created_at,starts_at,ends_at,winner_id';
+
+type MatchRow = RivalMatch;
+
+type ChallengeJoinRow = RivalMatchChallenge & {
+  challenge: { title: string; score_type: ScoreType } | null;
+};
+
+type ParticipantJoinRow = RivalMatchParticipant & {
+  profile: { username: string | null } | null;
+};
+
+function mapMatchRow(
+  row: MatchRow,
+  challenges: ChallengeJoinRow[],
+  participants: ParticipantJoinRow[],
+): RivalMatchView {
+  return {
+    id: row.id,
+    creatorId: row.creator_id,
+    status: row.status,
+    durationHours: row.duration_hours as 24 | 168,
+    division: row.division,
+    maxParticipants: row.max_participants,
+    createdAt: row.created_at,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    winnerId: row.winner_id,
+    challenges: challenges
+      .slice()
+      .sort((a, b) => a.sort_order - b.sort_order)
+      .map((c) => ({
+        challengeId: c.challenge_id,
+        sortOrder: c.sort_order,
+        title: c.challenge?.title ?? '',
+        scoreType: c.challenge?.score_type ?? 'reps',
+      })),
+    participants: participants.map((p) => ({
+      userId: p.user_id,
+      username: p.profile?.username ?? null,
+      status: p.status,
+      invitedAt: p.invited_at,
+      respondedAt: p.responded_at,
+    })),
+  };
+}
+
+export async function createRivalMatch(options: {
+  challengeIds: string[];
+  durationHours: 24 | 168;
+  inviteeUsername: string;
+  maxParticipants?: number;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc('create_rival_match', {
+    p_challenge_ids: options.challengeIds,
+    p_duration_hours: options.durationHours,
+    p_invitee_username: options.inviteeUsername,
+    p_max_participants: options.maxParticipants ?? 2,
+  });
+
+  if (error) throw new Error(error.message);
+  return data as string;
+}
+
+export async function respondRivalMatchInvite(matchId: string, accept: boolean): Promise<void> {
+  const { error } = await supabase.rpc('respond_rival_match_invite', {
+    p_match_id: matchId,
+    p_accept: accept,
+  });
+
+  if (error) throw new Error(error.message);
+}
+
+export async function cancelRivalMatch(matchId: string): Promise<void> {
+  const { error } = await supabase.rpc('cancel_rival_match', {
+    p_match_id: matchId,
+  });
+
+  if (error) throw new Error(error.message);
+}
+
+export async function fetchRivalMatch(matchId: string): Promise<RivalMatchView | null> {
+  const { data: match, error: matchError } = await supabase
+    .from('rival_matches')
+    .select(MATCH_COLUMNS)
+    .eq('id', matchId)
+    .maybeSingle();
+
+  if (matchError) throw new Error(matchError.message);
+  if (!match) return null;
+
+  const [{ data: challenges, error: chError }, { data: participants, error: pError }] =
+    await Promise.all([
+      supabase
+        .from('rival_match_challenges')
+        .select(
+          'match_id,challenge_id,sort_order,challenge:challenges!rival_match_challenges_challenge_id_fkey(title,score_type)',
+        )
+        .eq('match_id', matchId),
+      supabase
+        .from('rival_match_participants')
+        .select(
+          'match_id,user_id,status,invited_at,responded_at,profile:profiles!rival_match_participants_user_id_fkey(username)',
+        )
+        .eq('match_id', matchId),
+    ]);
+
+  if (chError) throw new Error(chError.message);
+  if (pError) throw new Error(pError.message);
+
+  return mapMatchRow(
+    match as MatchRow,
+    (challenges ?? []) as unknown as ChallengeJoinRow[],
+    (participants ?? []) as unknown as ParticipantJoinRow[],
+  );
+}
+
+export async function listMyRivalMatches(userId: string): Promise<RivalMatchView[]> {
+  const { data: participantRows, error: participantError } = await supabase
+    .from('rival_match_participants')
+    .select('match_id')
+    .eq('user_id', userId)
+    .order('invited_at', { ascending: false })
+    .limit(30);
+
+  if (participantError) throw new Error(participantError.message);
+
+  const matchIds = [...new Set((participantRows ?? []).map((r) => r.match_id as string))];
+  if (matchIds.length === 0) return [];
+
+  const results = await Promise.all(matchIds.map((id) => fetchRivalMatch(id)));
+  return results.filter((m): m is RivalMatchView => m !== null);
+}
+
+export async function computeRivalWinnerFromScores(
+  match: RivalMatchView,
+): Promise<ReturnType<typeof resolveRivalWinner>> {
+  if (!match.startsAt || !match.endsAt || match.status !== 'active') {
+    return { winnerId: null, challengeWinners: new Map(), reason: 'incomplete' };
+  }
+
+  const acceptedIds = match.participants
+    .filter((p) => p.status === 'accepted')
+    .map((p) => p.userId);
+
+  const challengeInputs: RivalChallengeInput[] = [];
+
+  for (const challenge of match.challenges) {
+    const { data, error } = await supabase
+      .from('scores')
+      .select('id,user_id,value,is_validated,submitted_at')
+      .eq('challenge_id', challenge.challengeId)
+      .eq('is_validated', true)
+      .in('user_id', acceptedIds)
+      .gte('submitted_at', match.startsAt)
+      .lte('submitted_at', match.endsAt);
+
+    if (error) throw new Error(error.message);
+
+    const best = pickBestScorePerUser(
+      ((data ?? []) as { id: string; user_id: string; value: number }[]).map((row) => ({
+        id: row.id,
+        user_id: row.user_id,
+        value: Number(row.value),
+      })),
+      challenge.scoreType,
+    );
+
+    challengeInputs.push({
+      challengeId: challenge.challengeId,
+      scoreType: challenge.scoreType,
+      scores: best.map((row) => ({ userId: row.user_id, value: row.value })),
+    });
+  }
+
+  return resolveRivalWinner(challengeInputs, acceptedIds);
+}

--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -7,6 +7,8 @@ export type ScoreType = 'time' | 'reps';
 export type ChallengeStatus = 'pending' | 'approved' | 'rejected';
 export type ChallengeAiTier = 'green' | 'orange' | 'red';
 export type WeeklyChallengeStatus = 'scheduled' | 'active' | 'completed' | 'cancelled';
+export type RivalMatchStatus = 'pending' | 'active' | 'completed' | 'cancelled' | 'expired';
+export type RivalParticipantStatus = 'invited' | 'accepted' | 'declined' | 'left';
 
 export interface WeeklyChallenge {
   id: string;
@@ -17,6 +19,34 @@ export interface WeeklyChallenge {
   week_label: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface RivalMatch {
+  id: string;
+  creator_id: string;
+  status: RivalMatchStatus;
+  duration_hours: 24 | 168;
+  division: Division;
+  max_participants: number;
+  created_at: string;
+  starts_at: string | null;
+  ends_at: string | null;
+  winner_id: string | null;
+  cancelled_at: string | null;
+}
+
+export interface RivalMatchChallenge {
+  match_id: string;
+  challenge_id: string;
+  sort_order: number;
+}
+
+export interface RivalMatchParticipant {
+  match_id: string;
+  user_id: string;
+  status: RivalParticipantStatus;
+  invited_at: string;
+  responded_at: string | null;
 }
 
 /**

--- a/supabase/migrations/021_rival_matches.sql
+++ b/supabase/migrations/021_rival_matches.sql
@@ -1,0 +1,328 @@
+-- V2-07 PR1: async rival matches (1v1 / small group, 1–3 challenges, 24h or 7d).
+
+CREATE TABLE IF NOT EXISTS public.rival_matches (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id       UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status           TEXT        NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'active', 'completed', 'cancelled', 'expired')),
+  duration_hours   INT         NOT NULL CHECK (duration_hours IN (24, 168)),
+  division         TEXT        NOT NULL CHECK (division IN ('rookie', 'regular', 'savage', 'elite')),
+  max_participants INT         NOT NULL DEFAULT 2 CHECK (max_participants BETWEEN 2 AND 4),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  starts_at        TIMESTAMPTZ NULL,
+  ends_at          TIMESTAMPTZ NULL,
+  winner_id        UUID        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  cancelled_at     TIMESTAMPTZ NULL,
+  CONSTRAINT rival_matches_window_check CHECK (
+    starts_at IS NULL OR ends_at IS NULL OR ends_at > starts_at
+  )
+);
+
+COMMENT ON TABLE public.rival_matches IS
+  'V2-07: async rival duel window. Division snapshot at create; scores reuse public.scores in match window.';
+
+CREATE INDEX IF NOT EXISTS idx_rival_matches_creator
+  ON public.rival_matches (creator_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rival_matches_status
+  ON public.rival_matches (status, ends_at)
+  WHERE status IN ('pending', 'active');
+
+CREATE TABLE IF NOT EXISTS public.rival_match_challenges (
+  match_id     UUID NOT NULL REFERENCES public.rival_matches(id) ON DELETE CASCADE,
+  challenge_id UUID NOT NULL REFERENCES public.challenges(id) ON DELETE RESTRICT,
+  sort_order   INT  NOT NULL CHECK (sort_order BETWEEN 1 AND 3),
+  PRIMARY KEY (match_id, challenge_id),
+  UNIQUE (match_id, sort_order)
+);
+
+CREATE TABLE IF NOT EXISTS public.rival_match_participants (
+  match_id     UUID NOT NULL REFERENCES public.rival_matches(id) ON DELETE CASCADE,
+  user_id      UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status       TEXT NOT NULL DEFAULT 'invited'
+    CHECK (status IN ('invited', 'accepted', 'declined', 'left')),
+  invited_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  responded_at TIMESTAMPTZ NULL,
+  PRIMARY KEY (match_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rival_match_participants_user
+  ON public.rival_match_participants (user_id, status);
+
+ALTER TABLE public.rival_matches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rival_match_challenges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rival_match_participants ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.rival_match_is_member(
+  p_match_id UUID,
+  p_user_id UUID DEFAULT auth.uid()
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.rival_match_participants p
+    WHERE p.match_id = p_match_id AND p.user_id = p_user_id
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM public.rival_matches m
+    WHERE m.id = p_match_id AND m.creator_id = p_user_id
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.count_pending_rival_invites_sent(p_user_id UUID DEFAULT auth.uid())
+RETURNS INT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COUNT(*)::INT
+  FROM public.rival_matches m
+  JOIN public.rival_match_participants p ON p.match_id = m.id
+  WHERE m.creator_id = p_user_id
+    AND m.status = 'pending'
+    AND p.status = 'invited'
+    AND p.user_id <> p_user_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.count_pending_rival_invites_received(p_user_id UUID DEFAULT auth.uid())
+RETURNS INT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COUNT(*)::INT
+  FROM public.rival_match_participants p
+  JOIN public.rival_matches m ON m.id = p.match_id
+  WHERE p.user_id = p_user_id
+    AND p.status = 'invited'
+    AND m.status = 'pending';
+$$;
+
+CREATE OR REPLACE FUNCTION public.try_activate_rival_match(p_match_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_match public.rival_matches%ROWTYPE;
+  v_accepted INT;
+BEGIN
+  SELECT * INTO v_match FROM public.rival_matches WHERE id = p_match_id FOR UPDATE;
+  IF NOT FOUND OR v_match.status <> 'pending' THEN
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*)::INT INTO v_accepted
+  FROM public.rival_match_participants
+  WHERE match_id = p_match_id AND status = 'accepted';
+
+  IF v_accepted < v_match.max_participants THEN
+    RETURN;
+  END IF;
+
+  UPDATE public.rival_matches
+  SET status = 'active',
+      starts_at = NOW(),
+      ends_at = NOW() + (v_match.duration_hours || ' hours')::INTERVAL
+  WHERE id = p_match_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_rival_match(
+  p_challenge_ids UUID[],
+  p_duration_hours INT,
+  p_invitee_username TEXT,
+  p_max_participants INT DEFAULT 2
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_creator_id UUID := auth.uid();
+  v_creator_division TEXT;
+  v_invitee_id UUID;
+  v_invitee_division TEXT;
+  v_match_id UUID;
+  v_challenge_id UUID;
+  v_sort INT := 0;
+  v_len INT;
+BEGIN
+  IF v_creator_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF public.count_pending_rival_invites_sent(v_creator_id) >= 5 THEN
+    RAISE EXCEPTION 'too_many_pending_invites_sent';
+  END IF;
+
+  v_len := COALESCE(array_length(p_challenge_ids, 1), 0);
+  IF v_len < 1 OR v_len > 3 THEN
+    RAISE EXCEPTION 'invalid_challenge_count';
+  END IF;
+
+  IF p_duration_hours NOT IN (24, 168) THEN
+    RAISE EXCEPTION 'invalid_duration';
+  END IF;
+
+  IF p_max_participants NOT BETWEEN 2 AND 4 THEN
+    RAISE EXCEPTION 'invalid_max_participants';
+  END IF;
+
+  SELECT division INTO v_creator_division
+  FROM public.profiles WHERE id = v_creator_id;
+
+  SELECT id, division INTO v_invitee_id, v_invitee_division
+  FROM public.profiles
+  WHERE lower(username) = lower(trim(p_invitee_username));
+
+  IF v_invitee_id IS NULL THEN
+    RAISE EXCEPTION 'invitee_not_found';
+  END IF;
+
+  IF v_invitee_id = v_creator_id THEN
+    RAISE EXCEPTION 'cannot_invite_self';
+  END IF;
+
+  IF v_invitee_division IS DISTINCT FROM v_creator_division THEN
+    RAISE EXCEPTION 'division_mismatch';
+  END IF;
+
+  IF public.count_pending_rival_invites_received(v_invitee_id) >= 5 THEN
+    RAISE EXCEPTION 'invitee_too_many_pending';
+  END IF;
+
+  FOREACH v_challenge_id IN ARRAY p_challenge_ids LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM public.challenges c
+      WHERE c.id = v_challenge_id AND c.status = 'approved'
+    ) THEN
+      RAISE EXCEPTION 'challenge_not_approved';
+    END IF;
+  END LOOP;
+
+  INSERT INTO public.rival_matches (
+    creator_id, duration_hours, division, max_participants
+  )
+  VALUES (
+    v_creator_id, p_duration_hours, v_creator_division, p_max_participants
+  )
+  RETURNING id INTO v_match_id;
+
+  FOREACH v_challenge_id IN ARRAY p_challenge_ids LOOP
+    v_sort := v_sort + 1;
+    INSERT INTO public.rival_match_challenges (match_id, challenge_id, sort_order)
+    VALUES (v_match_id, v_challenge_id, v_sort);
+  END LOOP;
+
+  INSERT INTO public.rival_match_participants (match_id, user_id, status, responded_at)
+  VALUES (v_match_id, v_creator_id, 'accepted', NOW());
+
+  INSERT INTO public.rival_match_participants (match_id, user_id, status)
+  VALUES (v_match_id, v_invitee_id, 'invited');
+
+  RETURN v_match_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.respond_rival_match_invite(
+  p_match_id UUID,
+  p_accept BOOLEAN
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_status TEXT;
+  v_match_status TEXT;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  SELECT m.status INTO v_match_status
+  FROM public.rival_matches m WHERE m.id = p_match_id FOR UPDATE;
+
+  IF v_match_status IS DISTINCT FROM 'pending' THEN
+    RAISE EXCEPTION 'match_not_pending';
+  END IF;
+
+  SELECT p.status INTO v_status
+  FROM public.rival_match_participants p
+  WHERE p.match_id = p_match_id AND p.user_id = v_user_id
+  FOR UPDATE;
+
+  IF v_status IS DISTINCT FROM 'invited' THEN
+    RAISE EXCEPTION 'not_invited';
+  END IF;
+
+  IF p_accept THEN
+    UPDATE public.rival_match_participants
+    SET status = 'accepted', responded_at = NOW()
+    WHERE match_id = p_match_id AND user_id = v_user_id;
+
+    PERFORM public.try_activate_rival_match(p_match_id);
+  ELSE
+    UPDATE public.rival_match_participants
+    SET status = 'declined', responded_at = NOW()
+    WHERE match_id = p_match_id AND user_id = v_user_id;
+
+    UPDATE public.rival_matches
+    SET status = 'cancelled', cancelled_at = NOW()
+    WHERE id = p_match_id;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.cancel_rival_match(p_match_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_creator_id UUID := auth.uid();
+BEGIN
+  IF v_creator_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  UPDATE public.rival_matches
+  SET status = 'cancelled', cancelled_at = NOW()
+  WHERE id = p_match_id
+    AND creator_id = v_creator_id
+    AND status = 'pending';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'cannot_cancel';
+  END IF;
+END;
+$$;
+
+CREATE POLICY "Rival match members can read matches"
+  ON public.rival_matches FOR SELECT
+  TO authenticated
+  USING (public.rival_match_is_member(id));
+
+CREATE POLICY "Rival match members can read challenges"
+  ON public.rival_match_challenges FOR SELECT
+  TO authenticated
+  USING (public.rival_match_is_member(match_id));
+
+CREATE POLICY "Rival match members can read participants"
+  ON public.rival_match_participants FOR SELECT
+  TO authenticated
+  USING (public.rival_match_is_member(match_id));


### PR DESCRIPTION
## Summary
- Migration `021`: `rival_matches`, challenges, participants, RLS, RPCs (`create_rival_match`, `respond_rival_match_invite`, `cancel_rival_match`)
- Anti-spam: max 5 pending invites sent/received per user
- New `features/rivals/` module: services, `useRivalMatch`, `resolveRivalWinner` + tests
- `docs/issues/issues.md`: V2-06 🟢 (PR #84), V2-07 🟡 #85

Part of #85 — PR1 of 4 (create/invite UI → PR2)

## Test plan
- [x] `pnpm test:run` (189 tests)
- [ ] Apply migration `021` on staging/prod before RPC smoke test
- [ ] Manual RPC: create → accept → active window


Made with [Cursor](https://cursor.com)