### PR TITLE
feat(rivals): create & invite UI (V2-07 PR2)

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -80,7 +80,7 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 - [x] **V2-04** — Leaderboards par division, faction, ville, pays — 🟢 [#79](https://github.com/igorms-pro/truegrynd/issues/79) PR [#80](https://github.com/igorms-pro/truegrynd/pull/80) · migration **`018`** prod
 - [x] **V2-05** — Truegrynd Rating (Engine / Power / Strength / Grit / Consistency) — 🟢 [#81](https://github.com/igorms-pro/truegrynd/issues/81) PR [#82](https://github.com/igorms-pro/truegrynd/pull/82) · migration **`019`** prod
 - [x] **V2-06** — Challenge Passport / palmarès amateur — 🟢 [#83](https://github.com/igorms-pro/truegrynd/issues/83) PR [#84](https://github.com/igorms-pro/truegrynd/pull/84) · migration **`020`** prod
-- [ ] **V2-07** — Rival Matches (1v1 / petits groupes) — 🟡 [#85](https://github.com/igorms-pro/truegrynd/issues/85) · branche `feature/issue-85-v2-07-rival-matches`
+- [ ] **V2-07** — Rival Matches (1v1 / petits groupes) — 🟡 [#85](https://github.com/igorms-pro/truegrynd/issues/85) · PR1 [#86](https://github.com/igorms-pro/truegrynd/pull/86) · branche `feature/issue-85-v2-07-rival-invite`
 - [ ] **V2-08** — Team Wars / Faction Wars par division
 - [ ] **V2-09** — Micro-events async (24h / 7j / 30j)
 - [ ] **V2-10** — Proof Levels (Honor / Video / Community / Judge / Event)
@@ -669,13 +669,13 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-07. Rival Matches
 
-**GitHub :** [#85](https://github.com/igorms-pro/truegrynd/issues/85) · **Branche :** `feature/issue-85-v2-07-rival-matches` · **Statut :** 🟡
+**GitHub :** [#85](https://github.com/igorms-pro/truegrynd/issues/85) · **Branche :** `feature/issue-85-v2-07-rival-invite` · **Statut :** 🟡 · PR1 [#86](https://github.com/igorms-pro/truegrynd/pull/86) mergé
 
 - [ ] **Produit** : 1v1 ou petit groupe sur 1 à 3 challenges, durée 24h/7j.
-- [ ] **DB** : `rival_matches`, participants, challenge set, status, winner.
-- [ ] **UX** : créer, accepter, soumettre, résultat.
+- [x] **DB** : `rival_matches`, participants, challenge set, status, winner — PR [#86](https://github.com/igorms-pro/truegrynd/pull/86) · migration **`021`** prod
+- [ ] **UX** : créer, accepter, soumettre, résultat — 🟡 PR2 create/invite en cours
 - [ ] **Notifications** : minimal V2 (email/toast/polling), pas besoin d'un réseau social complet.
-- [ ] **Anti-abus** : refuser spam d'invitations.
+- [x] **Anti-abus** : max 5 pending invites (RPC + migration **`021`**)
 
 ### V2-08. Team Wars / Faction Wars Par Division
 
@@ -756,10 +756,10 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | **Fix flow submit (POST SCORE → formulaire)** | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)                                                                                                                               |
 | **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                            |
 | **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                               |
-| **V2 — Accessible competition**               | 🟢 V2-00–06 · **🟡 V2-07** [#85](https://github.com/igorms-pro/truegrynd/issues/85) `feature/issue-85-v2-07-rival-matches`                                                                                                                          |
+| **V2 — Accessible competition**               | 🟢 V2-00–06 · **🟡 V2-07** [#85](https://github.com/igorms-pro/truegrynd/issues/85) PR1 [#86](https://github.com/igorms-pro/truegrynd/pull/86) · `feature/issue-85-v2-07-rival-invite`                                                              |
 | **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                        |
 
-**Suite produit :** **V2-07** 🟡 en cours ([#85](https://github.com/igorms-pro/truegrynd/issues/85) · `feature/issue-85-v2-07-rival-matches`). QA V2 globale en fin de lot V2, pas issue par issue.
+**Suite produit :** **V2-07** 🟡 ([#85](https://github.com/igorms-pro/truegrynd/issues/85) · PR1 [#86](https://github.com/igorms-pro/truegrynd/pull/86) mergé · PR2 create/invite). QA V2 globale en fin de lot V2, pas issue par issue.
 
 ---
 

--- a/src/app/[locale]/app/profile/page.tsx
+++ b/src/app/[locale]/app/profile/page.tsx
@@ -11,6 +11,7 @@ import {
   useProfile,
 } from '@/features/profile';
 import { useProfileRating } from '@/features/profile/hooks/useProfileRating';
+import { RivalHubLink } from '@/features/rivals';
 
 export default function ProfilePage() {
   const tabs = useTranslations('app.tabs');
@@ -65,6 +66,8 @@ export default function ProfilePage() {
       <ProfileHeader profile={state.profile} onAvatarUpdated={refetch} />
 
       <PassportLink />
+
+      <RivalHubLink />
 
       <ProfileRatingCard
         rating={ratingState.state.status === 'ready' ? ratingState.state.rating : null}

--- a/src/app/[locale]/app/rivals/new/page.tsx
+++ b/src/app/[locale]/app/rivals/new/page.tsx
@@ -1,0 +1,5 @@
+import { CreateRivalMatchScreen } from '@/features/rivals/components/CreateRivalMatchScreen';
+
+export default function CreateRivalMatchPage() {
+  return <CreateRivalMatchScreen />;
+}

--- a/src/app/[locale]/app/rivals/page.tsx
+++ b/src/app/[locale]/app/rivals/page.tsx
@@ -1,0 +1,5 @@
+import { RivalMatchesScreen } from '@/features/rivals/components/RivalMatchesScreen';
+
+export default function RivalMatchesPage() {
+  return <RivalMatchesScreen />;
+}

--- a/src/features/rivals/components/CreateRivalMatchScreen.tsx
+++ b/src/features/rivals/components/CreateRivalMatchScreen.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import Link from 'next/link';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowLeft } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useMemo } from 'react';
+import { Controller, useForm, useWatch } from 'react-hook-form';
+
+import { RivalChallengePicker } from '@/features/rivals/components/RivalChallengePicker';
+import { useCreateRivalMatch } from '@/features/rivals/hooks/useCreateRivalMatch';
+import { useProfile } from '@/features/profile/hooks/useProfile';
+import {
+  buildCreateRivalMatchSchema,
+  type CreateRivalMatchFormValues,
+} from '@/features/rivals/lib/createRivalMatchSchema';
+
+const DEFAULT_VALUES: CreateRivalMatchFormValues = {
+  challengeIds: [],
+  durationHours: 24,
+  inviteeUsername: '',
+};
+
+export function CreateRivalMatchScreen() {
+  const t = useTranslations('rivals.create');
+  const tVal = useTranslations('rivals.create.validation');
+  const tDivisions = useTranslations('divisions');
+  const tErrors = useTranslations('rivals.errors');
+  const locale = useLocale();
+  const router = useRouter();
+  const profileState = useProfile();
+  const {
+    challenges,
+    loadingChallenges,
+    challengesError,
+    busy,
+    errorKey,
+    submit,
+    clearError,
+    reloadChallenges,
+  } = useCreateRivalMatch();
+
+  const schema = useMemo(() => buildCreateRivalMatchSchema(tVal), [tVal]);
+  const form = useForm<CreateRivalMatchFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  const selectedIds = useWatch({ control: form.control, name: 'challengeIds' }) ?? [];
+  const profile = profileState.state.status === 'ready' ? profileState.state.profile : null;
+
+  const toggleChallenge = (challengeId: string) => {
+    const current = form.getValues('challengeIds');
+    if (current.includes(challengeId)) {
+      form.setValue(
+        'challengeIds',
+        current.filter((id) => id !== challengeId),
+        { shouldValidate: true },
+      );
+      return;
+    }
+    if (current.length >= 3) return;
+    form.setValue('challengeIds', [...current, challengeId], { shouldValidate: true });
+  };
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    clearError();
+    try {
+      await submit(values);
+      router.push(`/${locale}/app/rivals`);
+    } catch {
+      /* hook sets errorKey */
+    }
+  });
+
+  return (
+    <section className="space-y-6">
+      <Link
+        href={`/${locale}/app/rivals`}
+        className="inline-flex min-h-11 items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        {t('back')}
+      </Link>
+
+      <header className="space-y-1">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+        {profile ? (
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            {t('divisionHint', { division: tDivisions(profile.division) })}
+          </p>
+        ) : null}
+      </header>
+
+      {errorKey ? (
+        <p
+          className="rounded-md border border-primary/40 bg-card p-3 text-sm text-primary"
+          role="alert"
+        >
+          {tErrors(errorKey)}
+        </p>
+      ) : null}
+
+      <form className="space-y-6" onSubmit={onSubmit}>
+        <Controller
+          name="challengeIds"
+          control={form.control}
+          render={({ fieldState }) => (
+            <div>
+              <RivalChallengePicker
+                challenges={challenges}
+                selectedIds={selectedIds}
+                loading={loadingChallenges}
+                error={challengesError}
+                disabled={busy}
+                onToggle={toggleChallenge}
+                onRetry={reloadChallenges}
+                selectedLabel={t('picker.selected', { count: selectedIds.length })}
+                labels={{
+                  title: t('picker.title'),
+                  hint: t('picker.hint'),
+                  loading: t('picker.loading'),
+                  error: t('picker.error'),
+                  retry: t('picker.retry'),
+                  empty: t('picker.empty'),
+                }}
+              />
+              {fieldState.error ? (
+                <p className="mt-2 text-xs font-semibold text-primary" role="alert">
+                  {fieldState.error.message}
+                </p>
+              ) : null}
+            </div>
+          )}
+        />
+
+        <fieldset className="space-y-3" disabled={busy}>
+          <legend className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+            {t('duration.title')}
+          </legend>
+          <Controller
+            name="durationHours"
+            control={form.control}
+            render={({ field }) => (
+              <div className="flex flex-wrap gap-2">
+                {[24, 168].map((hours) => (
+                  <label
+                    key={hours}
+                    className="inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-md border border-border px-4 text-xs font-black uppercase tracking-[0.18em]"
+                  >
+                    <input
+                      type="radio"
+                      value={hours}
+                      checked={field.value === hours}
+                      onChange={() => field.onChange(hours as 24 | 168)}
+                      className="accent-primary"
+                    />
+                    {hours === 24 ? t('duration.h24') : t('duration.d7')}
+                  </label>
+                ))}
+              </div>
+            )}
+          />
+        </fieldset>
+
+        <div>
+          <label
+            htmlFor="rival-invitee"
+            className="text-xs font-black uppercase tracking-[0.18em] text-primary"
+          >
+            {t('invitee.label')}
+          </label>
+          <input
+            id="rival-invitee"
+            type="text"
+            autoComplete="off"
+            disabled={busy}
+            className="mt-2 w-full rounded-md border border-border bg-card px-3 py-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            placeholder={t('invitee.placeholder')}
+            {...form.register('inviteeUsername')}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">{t('invitee.hint')}</p>
+          {form.formState.errors.inviteeUsername ? (
+            <p className="mt-2 text-xs font-semibold text-primary" role="alert">
+              {form.formState.errors.inviteeUsername.message}
+            </p>
+          ) : null}
+        </div>
+
+        <button
+          type="submit"
+          disabled={busy}
+          className="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? t('submitting') : t('submit')}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/features/rivals/components/RivalChallengePicker.tsx
+++ b/src/features/rivals/components/RivalChallengePicker.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import type { Challenge } from '@/lib/types/database.types';
+
+type Props = {
+  challenges: Challenge[];
+  selectedIds: string[];
+  loading: boolean;
+  error: string | null;
+  disabled: boolean;
+  onToggle: (challengeId: string) => void;
+  onRetry: () => void;
+  selectedLabel: string;
+  labels: {
+    title: string;
+    hint: string;
+    loading: string;
+    error: string;
+    retry: string;
+    empty: string;
+  };
+};
+
+export function RivalChallengePicker({
+  challenges,
+  selectedIds,
+  loading,
+  error,
+  disabled,
+  onToggle,
+  onRetry,
+  selectedLabel,
+  labels,
+}: Props) {
+  if (loading) {
+    return (
+      <p className="text-sm text-muted-foreground" role="status">
+        {labels.loading}
+      </p>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">{labels.error}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 inline-flex min-h-11 items-center rounded-md border border-border px-3 text-xs font-black uppercase tracking-[0.18em]"
+        >
+          {labels.retry}
+        </button>
+      </div>
+    );
+  }
+
+  if (challenges.length === 0) {
+    return <p className="text-sm text-muted-foreground">{labels.empty}</p>;
+  }
+
+  return (
+    <fieldset className="space-y-3" disabled={disabled}>
+      <legend className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+        {labels.title}
+      </legend>
+      <p className="text-sm text-muted-foreground">{labels.hint}</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {selectedLabel}
+      </p>
+      <ul className="max-h-64 space-y-2 overflow-y-auto rounded-sm border border-border p-2">
+        {challenges.map((challenge) => {
+          const checked = selectedIds.includes(challenge.id);
+          const inputId = `rival-challenge-${challenge.id}`;
+          return (
+            <li key={challenge.id}>
+              <label
+                htmlFor={inputId}
+                className="flex min-h-11 cursor-pointer items-start gap-3 rounded-sm px-2 py-2 hover:bg-muted/60"
+              >
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => onToggle(challenge.id)}
+                  className="mt-1 h-4 w-4 accent-primary"
+                />
+                <span>
+                  <span className="block text-sm font-black uppercase tracking-tight">
+                    {challenge.title}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    {challenge.score_type.toUpperCase()}
+                  </span>
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </fieldset>
+  );
+}

--- a/src/features/rivals/components/RivalHubLink.tsx
+++ b/src/features/rivals/components/RivalHubLink.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+
+export function RivalHubLink() {
+  const t = useTranslations('rivals.hubLink');
+  const locale = useLocale();
+  const href = `/${locale}/app/rivals`;
+
+  return (
+    <Link
+      href={href}
+      className="flex min-h-11 items-center justify-between gap-3 rounded-sm border border-border bg-card px-4 py-3 hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label={t('openAria')}
+    >
+      <div>
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{t('kicker')}</p>
+        <p className="text-sm font-black uppercase tracking-tight">{t('cta')}</p>
+      </div>
+      <ArrowRight className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+    </Link>
+  );
+}

--- a/src/features/rivals/components/RivalMatchSummaryRow.tsx
+++ b/src/features/rivals/components/RivalMatchSummaryRow.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { RivalMatchView } from '@/features/rivals/services/rivalMatches';
+
+type Props = {
+  match: RivalMatchView;
+};
+
+export function RivalMatchSummaryRow({ match }: Props) {
+  const t = useTranslations('rivals.list');
+  const tStatus = useTranslations('rivals.status');
+  const tDivisions = useTranslations('divisions');
+  const challengeTitles = match.challenges.map((c) => c.title).join(' · ');
+
+  return (
+    <article className="rounded-sm border border-border bg-card px-4 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+            {tStatus(match.status)}
+          </p>
+          <p className="mt-1 text-sm font-black uppercase tracking-tight">{challengeTitles}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t('divisionLine', { division: tDivisions(match.division) })}
+          </p>
+        </div>
+        <span className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+          {match.durationHours === 24 ? t('duration24') : t('duration7d')}
+        </span>
+      </div>
+    </article>
+  );
+}

--- a/src/features/rivals/components/RivalMatchesScreen.tsx
+++ b/src/features/rivals/components/RivalMatchesScreen.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { RivalMatchSummaryRow } from '@/features/rivals/components/RivalMatchSummaryRow';
+import { RivalPendingInviteCard } from '@/features/rivals/components/RivalPendingInviteCard';
+import { useMyRivalMatches } from '@/features/rivals/hooks/useMyRivalMatches';
+import { useProfile } from '@/features/profile/hooks/useProfile';
+
+export function RivalMatchesScreen() {
+  const t = useTranslations('rivals.hub');
+  const locale = useLocale();
+  const profileState = useProfile();
+  const userId = profileState.state.status === 'ready' ? profileState.state.profile.id : null;
+  const { state, pendingInvites, refetch, respond, respondingId } = useMyRivalMatches(userId);
+
+  if (profileState.state.status === 'loading' || state.status === 'loading') {
+    return (
+      <section className="space-y-4">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground" role="status">
+          {t('loading')}
+        </p>
+      </section>
+    );
+  }
+
+  if (profileState.state.status === 'error' || state.status === 'error') {
+    return (
+      <section className="space-y-4">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+            {t('errorTitle')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">{t('errorBody')}</p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="mt-4 inline-flex min-h-11 items-center rounded-md bg-primary px-4 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground"
+          >
+            {t('retry')}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const matches = state.matches ?? [];
+  const otherMatches = matches.filter(
+    (match) => !pendingInvites.some((pending) => pending.id === match.id),
+  );
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+        </div>
+        <Link
+          href={`/${locale}/app/rivals/new`}
+          className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90"
+        >
+          {t('newCta')}
+        </Link>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+          {t('invitesTitle')}
+        </h2>
+        {pendingInvites.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('invitesEmpty')}</p>
+        ) : (
+          <ul className="space-y-3">
+            {pendingInvites.map((match) => (
+              <li key={match.id}>
+                <RivalPendingInviteCard
+                  match={match}
+                  disabled={respondingId === match.id}
+                  onAccept={() => void respond(match.id, true)}
+                  onDecline={() => void respond(match.id, false)}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+          {t('matchesTitle')}
+        </h2>
+        {otherMatches.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('matchesEmpty')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {otherMatches.map((match) => (
+              <li key={match.id}>
+                <RivalMatchSummaryRow match={match} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/src/features/rivals/components/RivalPendingInviteCard.tsx
+++ b/src/features/rivals/components/RivalPendingInviteCard.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { RivalMatchView } from '@/features/rivals/services/rivalMatches';
+
+type Props = {
+  match: RivalMatchView;
+  disabled: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+};
+
+export function RivalPendingInviteCard({ match, disabled, onAccept, onDecline }: Props) {
+  const t = useTranslations('rivals.invite');
+  const tDivisions = useTranslations('divisions');
+  const creator = match.participants.find((p) => p.userId === match.creatorId);
+  const challengeTitles = match.challenges.map((c) => c.title).join(' · ');
+
+  return (
+    <article className="rounded-sm border border-border bg-card p-4">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{t('kicker')}</p>
+      <h2 className="mt-1 text-sm font-black uppercase tracking-tight">
+        {t('from', { username: creator?.username ?? t('unknown') })}
+      </h2>
+      <p className="mt-2 text-xs text-muted-foreground">{challengeTitles}</p>
+      <p className="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {t('meta', {
+          division: tDivisions(match.division),
+          duration: match.durationHours === 24 ? t('duration24') : t('duration7d'),
+        })}
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onAccept}
+          className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {disabled ? t('accepting') : t('accept')}
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onDecline}
+          className="inline-flex min-h-11 items-center justify-center rounded-md border border-border bg-muted px-4 text-xs font-black uppercase tracking-[0.18em] hover:border-primary/40 disabled:opacity-50"
+        >
+          {t('decline')}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/features/rivals/hooks/useCreateRivalMatch.ts
+++ b/src/features/rivals/hooks/useCreateRivalMatch.ts
@@ -1,0 +1,106 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { listApprovedChallenges } from '@/features/challenges/services/challenges';
+import { type CreateRivalMatchFormValues } from '@/features/rivals/lib/createRivalMatchSchema';
+import { mapRivalErrorKey } from '@/features/rivals/lib/mapRivalErrorKey';
+import { createRivalMatch } from '@/features/rivals/services/rivalMatches';
+import type { Challenge } from '@/lib/types/database.types';
+
+type State = {
+  challenges: Challenge[];
+  loadingChallenges: boolean;
+  challengesError: string | null;
+  busy: boolean;
+  errorKey: string | null;
+};
+
+const initial: State = {
+  challenges: [],
+  loadingChallenges: true,
+  challengesError: null,
+  busy: false,
+  errorKey: null,
+};
+
+export function useCreateRivalMatch(): {
+  challenges: Challenge[];
+  loadingChallenges: boolean;
+  challengesError: string | null;
+  busy: boolean;
+  errorKey: string | null;
+  submit: (values: CreateRivalMatchFormValues) => Promise<string>;
+  clearError: () => void;
+  reloadChallenges: () => void;
+} {
+  const [state, setState] = useState<State>(initial);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const challenges = await listApprovedChallenges();
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            challenges,
+            loadingChallenges: false,
+            challengesError: null,
+          }));
+        }
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            loadingChallenges: false,
+            challengesError: message,
+          }));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const clearError = useCallback(() => {
+    setState((prev) => ({ ...prev, errorKey: null }));
+  }, []);
+
+  const reloadChallenges = useCallback(() => {
+    setState((prev) => ({ ...prev, loadingChallenges: true, challengesError: null }));
+    setReloadKey((key) => key + 1);
+  }, []);
+
+  const submit = useCallback(async (values: CreateRivalMatchFormValues): Promise<string> => {
+    setState((prev) => ({ ...prev, busy: true, errorKey: null }));
+    try {
+      const matchId = await createRivalMatch({
+        challengeIds: values.challengeIds,
+        durationHours: values.durationHours,
+        inviteeUsername: values.inviteeUsername.trim(),
+      });
+      return matchId;
+    } catch (e: unknown) {
+      setState((prev) => ({ ...prev, errorKey: mapRivalErrorKey(e) }));
+      throw e;
+    } finally {
+      setState((prev) => ({ ...prev, busy: false }));
+    }
+  }, []);
+
+  return {
+    challenges: state.challenges,
+    loadingChallenges: state.loadingChallenges,
+    challengesError: state.challengesError,
+    busy: state.busy,
+    errorKey: state.errorKey,
+    submit,
+    clearError,
+    reloadChallenges,
+  };
+}

--- a/src/features/rivals/hooks/useMyRivalMatches.ts
+++ b/src/features/rivals/hooks/useMyRivalMatches.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  listMyRivalMatches,
+  respondRivalMatchInvite,
+  type RivalMatchView,
+} from '@/features/rivals/services/rivalMatches';
+
+type State =
+  | { status: 'loading'; matches: null; error: null }
+  | { status: 'error'; matches: null; error: string }
+  | { status: 'ready'; matches: RivalMatchView[]; error: null };
+
+const initial: State = { status: 'loading', matches: null, error: null };
+
+export function useMyRivalMatches(userId: string | null): {
+  state: State;
+  pendingInvites: RivalMatchView[];
+  refetch: () => void;
+  respond: (matchId: string, accept: boolean) => Promise<void>;
+  respondingId: string | null;
+} {
+  const [state, setState] = useState<State>(initial);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [respondingId, setRespondingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userId) return undefined;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const matches = await listMyRivalMatches(userId);
+        if (!cancelled) setState({ status: 'ready', matches, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', matches: null, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey, userId]);
+
+  const refetch = useCallback(() => {
+    setState(initial);
+    setReloadKey((key) => key + 1);
+  }, []);
+
+  const respond = useCallback(
+    async (matchId: string, accept: boolean) => {
+      setRespondingId(matchId);
+      try {
+        await respondRivalMatchInvite(matchId, accept);
+        refetch();
+      } finally {
+        setRespondingId(null);
+      }
+    },
+    [refetch],
+  );
+
+  const pendingInvites = useMemo(() => {
+    if (state.status !== 'ready' || !userId) return [];
+    return state.matches.filter(
+      (match) =>
+        match.status === 'pending' &&
+        match.participants.some((p) => p.userId === userId && p.status === 'invited'),
+    );
+  }, [state, userId]);
+
+  return { state, pendingInvites, refetch, respond, respondingId };
+}

--- a/src/features/rivals/index.ts
+++ b/src/features/rivals/index.ts
@@ -1,3 +1,8 @@
+export { CreateRivalMatchScreen } from '@/features/rivals/components/CreateRivalMatchScreen';
+export { RivalHubLink } from '@/features/rivals/components/RivalHubLink';
+export { RivalMatchesScreen } from '@/features/rivals/components/RivalMatchesScreen';
+export { useCreateRivalMatch } from '@/features/rivals/hooks/useCreateRivalMatch';
+export { useMyRivalMatches } from '@/features/rivals/hooks/useMyRivalMatches';
 export { useRivalMatch } from '@/features/rivals/hooks/useRivalMatch';
 export {
   MAX_PENDING_RIVAL_INVITES,

--- a/src/features/rivals/lib/createRivalMatchSchema.test.ts
+++ b/src/features/rivals/lib/createRivalMatchSchema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCreateRivalMatchSchema } from '@/features/rivals/lib/createRivalMatchSchema';
+
+const t = (key: string) => key;
+
+describe('buildCreateRivalMatchSchema', () => {
+  const schema = buildCreateRivalMatchSchema(t);
+
+  it('accepts a valid 1v1 payload', () => {
+    const result = schema.safeParse({
+      challengeIds: ['11111111-1111-4111-8111-111111111111'],
+      durationHours: 24,
+      inviteeUsername: 'rival_one',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty challenge selection', () => {
+    const result = schema.safeParse({
+      challengeIds: [],
+      durationHours: 168,
+      inviteeUsername: 'rival_one',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects more than three challenges', () => {
+    const result = schema.safeParse({
+      challengeIds: [
+        '11111111-1111-4111-8111-111111111111',
+        '22222222-2222-4222-8222-222222222222',
+        '33333333-3333-4333-8333-333333333333',
+        '44444444-4444-4444-8444-444444444444',
+      ],
+      durationHours: 24,
+      inviteeUsername: 'rival_one',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/rivals/lib/createRivalMatchSchema.ts
+++ b/src/features/rivals/lib/createRivalMatchSchema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export type CreateRivalMatchFormValues = {
+  challengeIds: string[];
+  durationHours: 24 | 168;
+  inviteeUsername: string;
+};
+
+export function buildCreateRivalMatchSchema(t: (key: string) => string) {
+  return z.object({
+    challengeIds: z.array(z.string().uuid()).min(1, t('challengesMin')).max(3, t('challengesMax')),
+    durationHours: z.union([z.literal(24), z.literal(168)]),
+    inviteeUsername: z.string().trim().min(2, t('usernameMin')).max(30, t('usernameMax')),
+  });
+}

--- a/src/features/rivals/lib/mapRivalErrorKey.ts
+++ b/src/features/rivals/lib/mapRivalErrorKey.ts
@@ -1,0 +1,7 @@
+import { parseRivalRpcError } from '@/features/rivals/lib/rivalInviteLimits';
+
+export function mapRivalErrorKey(error: unknown): string {
+  const message = error instanceof Error ? error.message : '';
+  const code = parseRivalRpcError(message);
+  return code === 'unknown' ? 'generic' : code;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -599,6 +599,95 @@
     "endsIn": "Ends in {days}d {hours}h",
     "ended": "This week is over"
   },
+  "rivals": {
+    "hubLink": {
+      "kicker": "RIVALS",
+      "cta": "DUELS & INVITES",
+      "openAria": "Open rival matches"
+    },
+    "hub": {
+      "title": "RIVAL MATCHES",
+      "subtitle": "Async 1v1 duels on 1–3 challenges. Same division only.",
+      "loading": "Loading rival matches...",
+      "errorTitle": "Could not load rivals",
+      "errorBody": "Try again.",
+      "retry": "Retry",
+      "newCta": "START DUEL",
+      "invitesTitle": "PENDING INVITES",
+      "invitesEmpty": "No invites waiting. Start a duel or wait for a rival.",
+      "matchesTitle": "YOUR MATCHES",
+      "matchesEmpty": "No matches yet."
+    },
+    "create": {
+      "back": "RIVALS",
+      "title": "START A DUEL",
+      "subtitle": "Pick up to 3 Arena challenges and invite a rival by username.",
+      "divisionHint": "Matching locked to your division: {division}",
+      "picker": {
+        "title": "CHALLENGES",
+        "hint": "Select 1 to 3 approved challenges.",
+        "selected": "{count} / 3 selected",
+        "loading": "Loading Arena challenges...",
+        "error": "Could not load challenges.",
+        "retry": "Retry",
+        "empty": "No open Arena challenges right now."
+      },
+      "duration": {
+        "title": "DURATION",
+        "h24": "24 HOURS",
+        "d7": "7 DAYS"
+      },
+      "invitee": {
+        "label": "RIVAL USERNAME",
+        "placeholder": "their_username",
+        "hint": "They must be in your division to accept."
+      },
+      "submit": "SEND INVITE",
+      "submitting": "SENDING...",
+      "validation": {
+        "challengesMin": "Pick at least one challenge.",
+        "challengesMax": "Pick at most three challenges.",
+        "usernameMin": "Username is too short.",
+        "usernameMax": "Username is too long."
+      }
+    },
+    "invite": {
+      "kicker": "DUEL INVITE",
+      "from": "From @{username}",
+      "unknown": "rival",
+      "meta": "{division} · {duration}",
+      "duration24": "24h window",
+      "duration7d": "7d window",
+      "accept": "ACCEPT",
+      "accepting": "ACCEPTING...",
+      "decline": "DECLINE"
+    },
+    "list": {
+      "divisionLine": "{division} division",
+      "duration24": "24h",
+      "duration7d": "7d"
+    },
+    "status": {
+      "pending": "Pending",
+      "active": "Active",
+      "completed": "Completed",
+      "cancelled": "Cancelled",
+      "expired": "Expired"
+    },
+    "errors": {
+      "generic": "Could not complete this rival action. Try again.",
+      "too_many_pending_invites_sent": "You have too many pending invites. Wait for responses.",
+      "invitee_too_many_pending": "This rival has too many pending invites.",
+      "division_mismatch": "That user is not in your division.",
+      "invitee_not_found": "Username not found.",
+      "cannot_invite_self": "You cannot duel yourself.",
+      "invalid_challenge_count": "Pick 1 to 3 challenges.",
+      "invalid_duration": "Invalid duration.",
+      "not_invited": "You are not invited to this match.",
+      "match_not_pending": "This invite is no longer pending.",
+      "cannot_cancel": "Could not cancel this match."
+    }
+  },
   "finisher": {
     "title": "FINISHER CARD",
     "loading": "Loading...",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -599,6 +599,95 @@
     "endsIn": "Fin dans {days}j {hours}h",
     "ended": "Cette semaine est terminée"
   },
+  "rivals": {
+    "hubLink": {
+      "kicker": "RIVALS",
+      "cta": "DUELS & INVITATIONS",
+      "openAria": "Ouvrir les rival matches"
+    },
+    "hub": {
+      "title": "RIVAL MATCHES",
+      "subtitle": "Duels async 1v1 sur 1 à 3 défis. Même division uniquement.",
+      "loading": "Chargement des duels...",
+      "errorTitle": "Impossible de charger les rivals",
+      "errorBody": "Réessaie.",
+      "retry": "Réessayer",
+      "newCta": "LANCER UN DUEL",
+      "invitesTitle": "INVITATIONS EN ATTENTE",
+      "invitesEmpty": "Aucune invitation. Lance un duel ou attends un rival.",
+      "matchesTitle": "TES MATCHS",
+      "matchesEmpty": "Aucun match pour l'instant."
+    },
+    "create": {
+      "back": "RIVALS",
+      "title": "LANCER UN DUEL",
+      "subtitle": "Choisis jusqu'à 3 défis Arena et invite un rival par username.",
+      "divisionHint": "Matchmaking limité à ta division : {division}",
+      "picker": {
+        "title": "DÉFIS",
+        "hint": "Sélectionne 1 à 3 défis approuvés.",
+        "selected": "{count} / 3 sélectionnés",
+        "loading": "Chargement des défis Arena...",
+        "error": "Impossible de charger les défis.",
+        "retry": "Réessayer",
+        "empty": "Aucun défi Arena ouvert pour l'instant."
+      },
+      "duration": {
+        "title": "DURÉE",
+        "h24": "24 HEURES",
+        "d7": "7 JOURS"
+      },
+      "invitee": {
+        "label": "USERNAME DU RIVAL",
+        "placeholder": "son_username",
+        "hint": "Il doit être dans ta division pour accepter."
+      },
+      "submit": "ENVOYER L'INVIT",
+      "submitting": "ENVOI...",
+      "validation": {
+        "challengesMin": "Choisis au moins un défi.",
+        "challengesMax": "Choisis au maximum trois défis.",
+        "usernameMin": "Username trop court.",
+        "usernameMax": "Username trop long."
+      }
+    },
+    "invite": {
+      "kicker": "INVIT DUEL",
+      "from": "De @{username}",
+      "unknown": "rival",
+      "meta": "{division} · {duration}",
+      "duration24": "fenêtre 24h",
+      "duration7d": "fenêtre 7j",
+      "accept": "ACCEPTER",
+      "accepting": "ACCEPTATION...",
+      "decline": "REFUSER"
+    },
+    "list": {
+      "divisionLine": "Division {division}",
+      "duration24": "24h",
+      "duration7d": "7j"
+    },
+    "status": {
+      "pending": "En attente",
+      "active": "Actif",
+      "completed": "Terminé",
+      "cancelled": "Annulé",
+      "expired": "Expiré"
+    },
+    "errors": {
+      "generic": "Action rival impossible. Réessaie.",
+      "too_many_pending_invites_sent": "Trop d'invitations en attente. Attends des réponses.",
+      "invitee_too_many_pending": "Ce rival a trop d'invitations en attente.",
+      "division_mismatch": "Cet utilisateur n'est pas dans ta division.",
+      "invitee_not_found": "Username introuvable.",
+      "cannot_invite_self": "Tu ne peux pas te défier toi-même.",
+      "invalid_challenge_count": "Choisis 1 à 3 défis.",
+      "invalid_duration": "Durée invalide.",
+      "not_invited": "Tu n'es pas invité sur ce match.",
+      "match_not_pending": "Cette invitation n'est plus en attente.",
+      "cannot_cancel": "Impossible d'annuler ce match."
+    }
+  },
   "finisher": {
     "title": "FINISHER CARD",
     "loading": "Chargement...",


### PR DESCRIPTION
## Summary
- `/app/rivals` hub: pending invites (accept/decline) + match list
- `/app/rivals/new`: 1–3 challenges, 24h/7d, invite by username (same division via RPC)
- Profile link + i18n EN/FR + form validation tests

Part of #85 — PR2 of 4

## Test plan
- [x] `pnpm test:run` (192 tests)
- [ ] Manual: create duel → invitee accepts → match becomes active
- [ ] Manual: decline invite → match cancelled


Made with [Cursor](https://cursor.com)