### PR TITLE
feat(events): async micro-events admin + leaderboards (V2-09)

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -26,20 +26,20 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 
 ## Sommaire backlog
 
-| Bloc                                      | Détail dans ce fichier                                                                                          |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **`/app/admin` (UGC)**                    | Section **A** — tâches détaillées (+ **A9–A10** IA tri)                                                         |
-| **Mouvements & prescription**             | Section **G** — catalogue mix + règles création                                                                 |
-| **Creator Score**                         | Section **B**                                                                                                   |
-| **Streaks**                               | Section **C**                                                                                                   |
-| **Respect (leaderboard)**                 | Section **D**                                                                                                   |
-| **Referral**                              | Section **E**                                                                                                   |
-| **Confiance & plateforme**                | Section **F**                                                                                                   |
-| **V1.5 — Pages Faction & symétrie UI**    | Section **I** — arbitrages dock / Clan / Overview                                                               |
-| **V1.5 — Profil épuré & page Historique** | Section **K** — carrousel CARDS + `/app/profile/history`                                                        |
-| **Fix & polish pré-V2 (QA V1)**           | Section **J** — flow soumission score / copy CTA                                                                |
-| **Production hardening (10k users)**      | Section **L** — clean archi, DRY, limites feature                                                               |
-| **V2 — Accessible competition**           | Section **H** — V2-00 🟢 · … · V2-06 🟢 · **V2-07 🟡** [#85](https://github.com/igorms-pro/truegrynd/issues/85) |
+| Bloc                                      | Détail dans ce fichier                                                                                                                                                                                                                                                                                                     |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`/app/admin` (UGC)**                    | Section **A** — tâches détaillées (+ **A9–A10** IA tri)                                                                                                                                                                                                                                                                    |
+| **Mouvements & prescription**             | Section **G** — catalogue mix + règles création                                                                                                                                                                                                                                                                            |
+| **Creator Score**                         | Section **B**                                                                                                                                                                                                                                                                                                              |
+| **Streaks**                               | Section **C**                                                                                                                                                                                                                                                                                                              |
+| **Respect (leaderboard)**                 | Section **D**                                                                                                                                                                                                                                                                                                              |
+| **Referral**                              | Section **E**                                                                                                                                                                                                                                                                                                              |
+| **Confiance & plateforme**                | Section **F**                                                                                                                                                                                                                                                                                                              |
+| **V1.5 — Pages Faction & symétrie UI**    | Section **I** — arbitrages dock / Clan / Overview                                                                                                                                                                                                                                                                          |
+| **V1.5 — Profil épuré & page Historique** | Section **K** — carrousel CARDS + `/app/profile/history`                                                                                                                                                                                                                                                                   |
+| **Fix & polish pré-V2 (QA V1)**           | Section **J** — flow soumission score / copy CTA                                                                                                                                                                                                                                                                           |
+| **Production hardening (10k users)**      | Section **L** — clean archi, DRY, limites feature                                                                                                                                                                                                                                                                          |
+| **V2 — Accessible competition**           | Section **H** — V2-00 🟢 · … · V2-06 🟢 · **V2-07 🟢** [#85](https://github.com/igorms-pro/truegrynd/issues/85) PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) · **V2-08 🟢** [#90](https://github.com/igorms-pro/truegrynd/issues/90) · **V2-09 🟡** [#92](https://github.com/igorms-pro/truegrynd/issues/92) |
 
 **Macro-checklist**
 
@@ -80,9 +80,9 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 - [x] **V2-04** — Leaderboards par division, faction, ville, pays — 🟢 [#79](https://github.com/igorms-pro/truegrynd/issues/79) PR [#80](https://github.com/igorms-pro/truegrynd/pull/80) · migration **`018`** prod
 - [x] **V2-05** — Truegrynd Rating (Engine / Power / Strength / Grit / Consistency) — 🟢 [#81](https://github.com/igorms-pro/truegrynd/issues/81) PR [#82](https://github.com/igorms-pro/truegrynd/pull/82) · migration **`019`** prod
 - [x] **V2-06** — Challenge Passport / palmarès amateur — 🟢 [#83](https://github.com/igorms-pro/truegrynd/issues/83) PR [#84](https://github.com/igorms-pro/truegrynd/pull/84) · migration **`020`** prod
-- [ ] **V2-07** — Rival Matches (1v1 / petits groupes) — 🟡 [#85](https://github.com/igorms-pro/truegrynd/issues/85) · PR1–3 [#86](https://github.com/igorms-pro/truegrynd/pull/86) [#87](https://github.com/igorms-pro/truegrynd/pull/87) [#88](https://github.com/igorms-pro/truegrynd/pull/88) · **PR4** [#89](https://github.com/igorms-pro/truegrynd/pull/89) · migration **`022`** prod
+- [x] **V2-07** — Rival Matches (1v1 / petits groupes) — 🟢 [#85](https://github.com/igorms-pro/truegrynd/issues/85) · PR1–3 [#86](https://github.com/igorms-pro/truegrynd/pull/86) [#87](https://github.com/igorms-pro/truegrynd/pull/87) [#88](https://github.com/igorms-pro/truegrynd/pull/88) · PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) · migrations **`021`** **`022`** prod
 - [x] **V2-08** — Team Wars / Faction Wars par division — 🟢 [#90](https://github.com/igorms-pro/truegrynd/issues/90) PR [#91](https://github.com/igorms-pro/truegrynd/pull/91) · migration **`023`** prod
-- [ ] **V2-09** — Micro-events async (24h / 7j / 30j)
+- [ ] **V2-09** — Micro-events async (24h / 7j / 30j) — 🟡 [#92](https://github.com/igorms-pro/truegrynd/issues/92) · branche `feature/issue-92-micro-events` · migration **`024`**
 - [ ] **V2-10** — Proof Levels (Honor / Video / Community / Judge / Event)
 - [ ] **V2-11** — Growth loops (cards, invitations, comeback weeks)
 - [ ] **V2-12** — Monétisation exploratoire (après signal d'usage)
@@ -669,12 +669,12 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-07. Rival Matches
 
-**GitHub :** [#85](https://github.com/igorms-pro/truegrynd/issues/85) · **Branche :** `feature/issue-85-rival-matches-pr4` · **Statut :** 🟡 · PR1–3 mergés · **PR4** [#89](https://github.com/igorms-pro/truegrynd/pull/89) (finalize + résultat UI + passport rival wins) · migration **`022`** prod
+**GitHub :** [#85](https://github.com/igorms-pro/truegrynd/issues/85) · **Statut :** 🟢 **LIVRÉ** · PR1–3 [#86](https://github.com/igorms-pro/truegrynd/pull/86) [#87](https://github.com/igorms-pro/truegrynd/pull/87) [#88](https://github.com/igorms-pro/truegrynd/pull/88) · PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) mergée · migrations **`021`** **`022`** prod
 
-- [ ] **Produit** : 1v1 ou petit groupe sur 1 à 3 challenges, durée 24h/7j.
-- [x] **DB** : `rival_matches`, participants, challenge set, status, winner — PR [#86](https://github.com/igorms-pro/truegrynd/pull/86) · migration **`021`** prod · finalize PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) · **`022`** prod
-- [ ] **UX** : créer, accepter, soumettre, résultat — PR2 [#87](https://github.com/igorms-pro/truegrynd/pull/87) · PR3 [#88](https://github.com/igorms-pro/truegrynd/pull/88) · PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) (résultat + passport)
-- [ ] **Notifications** : minimal V2 (email/toast/polling) — polling PR3 [#88](https://github.com/igorms-pro/truegrynd/pull/88) ✅ · toast/email post-PR4
+- [x] **Produit** : 1v1 ou petit groupe sur 1 à 3 challenges, durée 24h/7j.
+- [x] **DB** : `rival_matches`, participants, challenge set, status, winner — PR [#86](https://github.com/igorms-pro/truegrynd/pull/86) · finalize PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) · **`021`** **`022`** prod
+- [x] **UX** : créer, accepter, soumettre, résultat — PR2–4 [#87](https://github.com/igorms-pro/truegrynd/pull/87) [#88](https://github.com/igorms-pro/truegrynd/pull/88) [#89](https://github.com/igorms-pro/truegrynd/pull/89) (résultat + passport rival wins)
+- [ ] **Notifications** : toast/email post-lot (hors scope MVP V2-07)
 - [x] **Anti-abus** : max 5 pending invites (RPC + migration **`021`**)
 
 ### V2-08. Team Wars / Faction Wars Par Division
@@ -691,12 +691,15 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-09. Micro-Events Async
 
-- [ ] **Produit** : events 24h / 7j / 30j sans lieu physique : Rookie Week, No Equipment Cup, Faction War Weekend.
-- [ ] **DB** : `events`, `event_challenges`, `event_scores`, status.
-- [ ] **Admin** : créer/programmer un event depuis l'admin.
-- [ ] **Classements** : event leaderboard + divisions.
-- [ ] **Fin** : recap, badges, cards, classement final.
-- [ ] **Ops** : pas de paiement au départ ; prouver l'engagement avant monétisation.
+**GitHub :** [#92](https://github.com/igorms-pro/truegrynd/issues/92) · **Branche :** `feature/issue-92-micro-events` · **Statut :** 🟡
+
+- [x] **Produit** : events 24h / 7j / 30j sans lieu physique : Rookie Week, No Equipment Cup, Faction War Weekend.
+- [x] **DB** : `events`, `event_challenges`, `event_scores`, status — migration **`024`**
+- [x] **Admin** : créer/programmer un event depuis `/app/admin/events`.
+- [x] **Classements** : event leaderboard + divisions (RPC `get_event_standings`).
+- [x] **Fin** : recap top-N par division (RPC `get_event_recap`).
+- [ ] **Badges / cards** : reporté V2-11 growth loops.
+- [ ] **Ops** : appliquer migration **`024`** prod.
 
 ### V2-10. Proof Levels
 
@@ -743,27 +746,27 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 
 ## Suivi synthétique
 
-| Bloc                                          | Avancement                                                                                                                                                                                                                                                                                                             |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| UGC création + cap                            | 🟢 PR #30                                                                                                                                                                                                                                                                                                              |
-| Doc backlog V1 (ce fichier)                   | 🟢 [#31](https://github.com/igorms-pro/truegrynd/issues/31) mergé — PR [#32](https://github.com/igorms-pro/truegrynd/pull/32)                                                                                                                                                                                          |
-| Doc tri IA + mouvements mix (ce fichier)      | 🟢 [#35](https://github.com/igorms-pro/truegrynd/issues/35) mergé — PR [#36](https://github.com/igorms-pro/truegrynd/pull/36)                                                                                                                                                                                          |
-| **`/app/admin`**                              | 🟢 PR #41 mergé (admin + AI triage)                                                                                                                                                                                                                                                                                    |
-| Creator Score                                 | 🟢 [#46](https://github.com/igorms-pro/truegrynd/issues/46) mergé — PR [#47](https://github.com/igorms-pro/truegrynd/pull/47)                                                                                                                                                                                          |
-| Streaks                                       | 🟢 [#48](https://github.com/igorms-pro/truegrynd/issues/48) mergé — PR [#49](https://github.com/igorms-pro/truegrynd/pull/49)                                                                                                                                                                                          |
-| Respect                                       | 🟢 [#50](https://github.com/igorms-pro/truegrynd/issues/50) mergé — PR [#51](https://github.com/igorms-pro/truegrynd/pull/51)                                                                                                                                                                                          |
-| Referral                                      | 🟢 [#52](https://github.com/igorms-pro/truegrynd/issues/52) mergé — PR [#53](https://github.com/igorms-pro/truegrynd/pull/53)                                                                                                                                                                                          |
-| Confiance / plateforme                        | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55)                                                                                                                                                                                          |
-| Mouvements / prescription (mix)               | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45)                                                                                                                                                                                          |
-| **V1.5 — Pages Faction**                      | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57) — PR [#56](https://github.com/igorms-pro/truegrynd/pull/56) + [#58](https://github.com/igorms-pro/truegrynd/pull/58) mergés                                                                                                                                |
-| **V1.5 — Profil & Historique**                | 🟢 [#59](https://github.com/igorms-pro/truegrynd/issues/59) PR [#60](https://github.com/igorms-pro/truegrynd/pull/60) + Settings [#61](https://github.com/igorms-pro/truegrynd/issues/61) PR [#62](https://github.com/igorms-pro/truegrynd/pull/62)                                                                    |
-| **Fix flow submit (POST SCORE → formulaire)** | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)                                                                                                                                                                                                  |
-| **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                                                                                               |
-| **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                                                                                                  |
-| **V2 — Accessible competition**               | 🟢 V2-00–06 · **🟡 V2-07** [#85](https://github.com/igorms-pro/truegrynd/issues/85) PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) · 🟢 **V2-08** [#90](https://github.com/igorms-pro/truegrynd/issues/90) PR [#91](https://github.com/igorms-pro/truegrynd/pull/91) · migrations **`022`** **`023`** prod |
-| **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                                                                                           |
+| Bloc                                          | Avancement                                                                                                                                                                                                                                          |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UGC création + cap                            | 🟢 PR #30                                                                                                                                                                                                                                           |
+| Doc backlog V1 (ce fichier)                   | 🟢 [#31](https://github.com/igorms-pro/truegrynd/issues/31) mergé — PR [#32](https://github.com/igorms-pro/truegrynd/pull/32)                                                                                                                       |
+| Doc tri IA + mouvements mix (ce fichier)      | 🟢 [#35](https://github.com/igorms-pro/truegrynd/issues/35) mergé — PR [#36](https://github.com/igorms-pro/truegrynd/pull/36)                                                                                                                       |
+| **`/app/admin`**                              | 🟢 PR #41 mergé (admin + AI triage)                                                                                                                                                                                                                 |
+| Creator Score                                 | 🟢 [#46](https://github.com/igorms-pro/truegrynd/issues/46) mergé — PR [#47](https://github.com/igorms-pro/truegrynd/pull/47)                                                                                                                       |
+| Streaks                                       | 🟢 [#48](https://github.com/igorms-pro/truegrynd/issues/48) mergé — PR [#49](https://github.com/igorms-pro/truegrynd/pull/49)                                                                                                                       |
+| Respect                                       | 🟢 [#50](https://github.com/igorms-pro/truegrynd/issues/50) mergé — PR [#51](https://github.com/igorms-pro/truegrynd/pull/51)                                                                                                                       |
+| Referral                                      | 🟢 [#52](https://github.com/igorms-pro/truegrynd/issues/52) mergé — PR [#53](https://github.com/igorms-pro/truegrynd/pull/53)                                                                                                                       |
+| Confiance / plateforme                        | 🟢 [#54](https://github.com/igorms-pro/truegrynd/issues/54) mergé — PR [#55](https://github.com/igorms-pro/truegrynd/pull/55)                                                                                                                       |
+| Mouvements / prescription (mix)               | 🟢 [#44](https://github.com/igorms-pro/truegrynd/issues/44) mergé — PR [#45](https://github.com/igorms-pro/truegrynd/pull/45)                                                                                                                       |
+| **V1.5 — Pages Faction**                      | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57) — PR [#56](https://github.com/igorms-pro/truegrynd/pull/56) + [#58](https://github.com/igorms-pro/truegrynd/pull/58) mergés                                                             |
+| **V1.5 — Profil & Historique**                | 🟢 [#59](https://github.com/igorms-pro/truegrynd/issues/59) PR [#60](https://github.com/igorms-pro/truegrynd/pull/60) + Settings [#61](https://github.com/igorms-pro/truegrynd/issues/61) PR [#62](https://github.com/igorms-pro/truegrynd/pull/62) |
+| **Fix flow submit (POST SCORE → formulaire)** | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63) PR [#64](https://github.com/igorms-pro/truegrynd/pull/64)                                                                                                                               |
+| **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                            |
+| **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                               |
+| **V2 — Accessible competition**               | 🟢 V2-00–08 · **🟡 V2-09** [#92](https://github.com/igorms-pro/truegrynd/issues/92) branche `feature/issue-92-micro-events` · migrations **`022`** **`023`** **`024`** prod                                                                         |
+| **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                        |
 
-**Suite produit :** merger **PR4** [#89](https://github.com/igorms-pro/truegrynd/pull/89) → clôturer **V2-07** [#85](https://github.com/igorms-pro/truegrynd/issues/85) · **V2-09** Micro-events async · appliquer migrations **`022`** **`023`** prod. QA V2 globale en fin de lot V2.
+**Suite produit :** ouvrir PR **V2-09** [#92](https://github.com/igorms-pro/truegrynd/issues/92) → appliquer migrations **`022`** **`023`** **`024`** prod · QA V2 globale en fin de lot V2.
 
 ---
 

--- a/src/app/[locale]/app/admin/challenges/page.tsx
+++ b/src/app/[locale]/app/admin/challenges/page.tsx
@@ -16,9 +16,15 @@ export default function AdminChallengesPage() {
         <p className="mt-1 text-sm text-muted-foreground">{t('subtitle')}</p>
         <Link
           href={`/${locale}/app/admin/weekly`}
-          className="mt-2 inline-block text-xs font-black uppercase tracking-[0.18em] text-accent hover:opacity-90"
+          className="mt-2 mr-4 inline-block text-xs font-black uppercase tracking-[0.18em] text-accent hover:opacity-90"
         >
           {t('weeklyLink')}
+        </Link>
+        <Link
+          href={`/${locale}/app/admin/events`}
+          className="mt-2 inline-block text-xs font-black uppercase tracking-[0.18em] text-accent hover:opacity-90"
+        >
+          {t('eventsLink')}
         </Link>
       </header>
       <AdminChallengeQueue />

--- a/src/app/[locale]/app/admin/events/page.tsx
+++ b/src/app/[locale]/app/admin/events/page.tsx
@@ -3,10 +3,10 @@
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
-import { AdminWeeklyScheduler } from '@/features/admin/components/AdminWeeklyScheduler';
+import { AdminEventsScheduler } from '@/features/admin/components/AdminEventsScheduler';
 
-export default function AdminWeeklyPage() {
-  const t = useTranslations('admin.weekly');
+export default function AdminEventsPage() {
+  const t = useTranslations('admin.events');
   const tAdmin = useTranslations('admin');
   const locale = useLocale();
 
@@ -21,16 +21,16 @@ export default function AdminWeeklyPage() {
             ← {tAdmin('nav.link')}
           </Link>
           <Link
-            href={`/${locale}/app/admin/events`}
+            href={`/${locale}/app/admin/weekly`}
             className="text-xs font-black uppercase tracking-[0.18em] text-accent hover:opacity-90"
           >
-            {tAdmin('eventsLink')}
+            {tAdmin('weeklyLink')}
           </Link>
         </div>
         <h1 className="text-2xl font-black uppercase tracking-tight">{t('title')}</h1>
         <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
       </header>
-      <AdminWeeklyScheduler />
+      <AdminEventsScheduler />
     </section>
   );
 }

--- a/src/app/[locale]/app/events/[slug]/page.tsx
+++ b/src/app/[locale]/app/events/[slug]/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+import { use } from 'react';
+
+import { EventDetailScreen } from '@/features/events';
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export default function EventDetailPage({ params }: Props) {
+  const { slug } = use(params);
+  const locale = useLocale();
+  const t = useTranslations('events');
+
+  return (
+    <section className="space-y-4">
+      <Link
+        href={`/${locale}/app/events`}
+        className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+      >
+        ← {t('backEvents')}
+      </Link>
+      <EventDetailScreen slug={slug} />
+    </section>
+  );
+}

--- a/src/app/[locale]/app/events/page.tsx
+++ b/src/app/[locale]/app/events/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { EventsListScreen } from '@/features/events';
+
+export default function EventsPage() {
+  const locale = useLocale();
+  const t = useTranslations('events');
+
+  return (
+    <section className="space-y-4">
+      <header className="space-y-2">
+        <Link
+          href={`/${locale}/app/overview`}
+          className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+        >
+          ← {t('backOverview')}
+        </Link>
+        <h1 className="text-2xl font-black uppercase tracking-tight">{t('listTitle')}</h1>
+        <p className="text-sm text-muted-foreground">{t('listSubtitle')}</p>
+      </header>
+      <EventsListScreen />
+    </section>
+  );
+}

--- a/src/features/admin/components/AdminEventsScheduler.tsx
+++ b/src/features/admin/components/AdminEventsScheduler.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { useAdminEventsScheduler } from '@/features/admin/hooks/useAdminEventsScheduler';
+import { EVENT_TYPES } from '@/features/events/services/events';
+import { fromDatetimeLocalValue, toDatetimeLocalValue } from '@/lib/weekly';
+import type { EventStatus, EventType } from '@/lib/types/database.types';
+
+const STATUSES: EventStatus[] = ['scheduled', 'active', 'completed', 'cancelled'];
+
+function defaultEventWindow(): { startsAt: string; endsAt: string } {
+  const starts = new Date();
+  starts.setHours(0, 0, 0, 0);
+  const ends = new Date(starts);
+  ends.setDate(ends.getDate() + 7);
+  ends.setHours(23, 59, 0, 0);
+  return { startsAt: starts.toISOString(), endsAt: ends.toISOString() };
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function AdminEventsScheduler() {
+  const t = useTranslations('admin.events');
+  const { state, refetch, save, saving, saveError } = useAdminEventsScheduler();
+  const defaults = useMemo(() => defaultEventWindow(), []);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [slug, setSlug] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [eventType, setEventType] = useState<EventType>('custom');
+  const [startsAt, setStartsAt] = useState(toDatetimeLocalValue(defaults.startsAt));
+  const [endsAt, setEndsAt] = useState(toDatetimeLocalValue(defaults.endsAt));
+  const [status, setStatus] = useState<EventStatus>('scheduled');
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const challenges = state.status === 'ready' ? state.challenges : [];
+
+  const toggleChallenge = (id: string) => {
+    setSelectedIds((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id);
+      if (prev.length >= 5) return prev;
+      return [...prev, id];
+    });
+  };
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!title.trim() || selectedIds.length === 0) return;
+    const finalSlug = slug.trim() || slugify(title);
+    await save({
+      id: editId,
+      slug: finalSlug,
+      title: title.trim(),
+      description: description.trim(),
+      eventType,
+      startsAt: fromDatetimeLocalValue(startsAt),
+      endsAt: fromDatetimeLocalValue(endsAt),
+      status,
+      challengeIds: selectedIds,
+    });
+    setEditId(null);
+    setSlug('');
+    setTitle('');
+    setDescription('');
+    setSelectedIds([]);
+  };
+
+  const loadRow = (row: (typeof state.rows)[number]) => {
+    setEditId(row.id);
+    setSlug(row.slug);
+    setTitle(row.title);
+    setDescription(row.description);
+    setEventType(row.event_type);
+    setStartsAt(toDatetimeLocalValue(row.starts_at));
+    setEndsAt(toDatetimeLocalValue(row.ends_at));
+    setStatus(row.status);
+    setSelectedIds(
+      row.event_challenges
+        .map((ec) => ec.challenge_id)
+        .sort(
+          (a, b) =>
+            (row.event_challenges.find((x) => x.challenge_id === a)?.sort_order ?? 0) -
+            (row.event_challenges.find((x) => x.challenge_id === b)?.sort_order ?? 0),
+        ),
+    );
+  };
+
+  if (state.status === 'loading') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">{t('error')}</p>
+        <button
+          type="button"
+          onClick={refetch}
+          className="rounded-md border border-border bg-muted px-3 py-2 text-xs font-black uppercase tracking-[0.18em]"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={onSubmit} className="space-y-4 rounded-md border border-border bg-card p-4">
+        <h2 className="text-sm font-black uppercase tracking-[0.18em]">
+          {editId ? t('formEditTitle') : t('formCreateTitle')}
+        </h2>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="block space-y-1">
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+              {t('nameLabel')}
+            </span>
+            <input
+              required
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+              {t('slug')}
+            </span>
+            <input
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder={t('slugPlaceholder')}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+
+        <label className="block space-y-1">
+          <span className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('description')}
+          </span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </label>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="block space-y-1">
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+              {t('eventType')}
+            </span>
+            <select
+              value={eventType}
+              onChange={(e) => setEventType(e.target.value as EventType)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            >
+              {EVENT_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {t(`types.${type}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block space-y-1">
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+              {t('status')}
+            </span>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as EventStatus)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            >
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {t(`statuses.${s}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="block space-y-1">
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+              {t('startsAt')}
+            </span>
+            <input
+              type="datetime-local"
+              required
+              value={startsAt}
+              onChange={(e) => setStartsAt(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+              {t('endsAt')}
+            </span>
+            <input
+              type="datetime-local"
+              required
+              value={endsAt}
+              onChange={(e) => setEndsAt(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+
+        <fieldset className="space-y-2">
+          <legend className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('challenges')} ({selectedIds.length}/5)
+          </legend>
+          <ul className="max-h-48 space-y-1 overflow-y-auto rounded-md border border-border p-2">
+            {challenges.map((c) => (
+              <li key={c.id}>
+                <label className="flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(c.id)}
+                    onChange={() => toggleChallenge(c.id)}
+                  />
+                  {c.is_official ? '★ ' : ''}
+                  {c.title}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+
+        {saveError ? <p className="text-xs text-primary">{saveError}</p> : null}
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="submit"
+            disabled={saving || !title.trim() || selectedIds.length === 0}
+            className="rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground disabled:opacity-50"
+          >
+            {saving ? t('saving') : editId ? t('update') : t('create')}
+          </button>
+          {editId ? (
+            <button
+              type="button"
+              onClick={() => {
+                setEditId(null);
+                setSelectedIds([]);
+              }}
+              className="rounded-md border border-border bg-background px-4 py-2 text-xs font-black uppercase tracking-[0.18em]"
+            >
+              {t('cancelEdit')}
+            </button>
+          ) : null}
+        </div>
+      </form>
+
+      <div className="space-y-2">
+        <h2 className="text-sm font-black uppercase tracking-[0.18em]">{t('listTitle')}</h2>
+        {state.rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('empty')}</p>
+        ) : (
+          <ul className="divide-y divide-border rounded-md border border-border">
+            {state.rows.map((row) => (
+              <li key={row.id} className="flex flex-wrap items-center justify-between gap-3 p-3">
+                <div>
+                  <p className="text-sm font-black uppercase tracking-tight">{row.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    /{row.slug} · {t(`statuses.${row.status}`)} · {row.event_challenges.length}{' '}
+                    {t('challengeShort')}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => loadRow(row)}
+                  className="rounded-md border border-border px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em]"
+                >
+                  {t('edit')}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/hooks/useAdminEventsScheduler.ts
+++ b/src/features/admin/hooks/useAdminEventsScheduler.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  adminUpsertEvent,
+  listApprovedChallengesForEventPicker,
+  listEventsForAdmin,
+  type AdminEventRow,
+} from '@/features/admin/services/adminEvents';
+import type { EventStatus, EventType } from '@/lib/types/database.types';
+
+type State =
+  | {
+      status: 'loading';
+      rows: AdminEventRow[];
+      challenges: { id: string; title: string; is_official: boolean }[];
+      error: null;
+    }
+  | {
+      status: 'ready';
+      rows: AdminEventRow[];
+      challenges: { id: string; title: string; is_official: boolean }[];
+      error: null;
+    }
+  | {
+      status: 'error';
+      rows: AdminEventRow[];
+      challenges: { id: string; title: string; is_official: boolean }[];
+      error: string;
+    };
+
+const emptyLists = {
+  rows: [] as AdminEventRow[],
+  challenges: [] as { id: string; title: string; is_official: boolean }[],
+};
+
+export function useAdminEventsScheduler(): {
+  state: State;
+  refetch: () => void;
+  save: (input: {
+    id?: string | null;
+    slug: string;
+    title: string;
+    description?: string;
+    eventType: EventType;
+    startsAt: string;
+    endsAt: string;
+    status: EventStatus;
+    challengeIds: string[];
+  }) => Promise<void>;
+  saving: boolean;
+  saveError: string | null;
+} {
+  const [state, setState] = useState<State>({ status: 'loading', ...emptyLists, error: null });
+  const [reloadKey, setReloadKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const [rows, challenges] = await Promise.all([
+          listEventsForAdmin(),
+          listApprovedChallengesForEventPicker(),
+        ]);
+        if (!cancelled) setState({ status: 'ready', rows, challenges, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', ...emptyLists, error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const refetch = () => {
+    setState({ status: 'loading', ...emptyLists, error: null });
+    setReloadKey((k) => k + 1);
+  };
+
+  const save = async (input: {
+    id?: string | null;
+    slug: string;
+    title: string;
+    description?: string;
+    eventType: EventType;
+    startsAt: string;
+    endsAt: string;
+    status: EventStatus;
+    challengeIds: string[];
+  }) => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await adminUpsertEvent(input);
+      refetch();
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : 'unknown');
+      throw e;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return { state, refetch, save, saving, saveError };
+}

--- a/src/features/admin/services/adminEvents.ts
+++ b/src/features/admin/services/adminEvents.ts
@@ -1,0 +1,63 @@
+import { supabase } from '@/lib/supabase';
+import type { EventStatus, EventType, MicroEvent } from '@/lib/types/database.types';
+
+const EVENT_SELECT =
+  'id,slug,title,description,event_type,starts_at,ends_at,status,created_at,updated_at';
+
+export type AdminEventRow = MicroEvent & {
+  event_challenges: { challenge_id: string; sort_order: number }[];
+};
+
+export async function listEventsForAdmin(): Promise<AdminEventRow[]> {
+  const { data, error } = await supabase
+    .from('events')
+    .select(`${EVENT_SELECT}, event_challenges(challenge_id,sort_order)`)
+    .order('starts_at', { ascending: false })
+    .limit(24);
+  if (error) throw new Error(error.message);
+  return (data ?? []) as unknown as AdminEventRow[];
+}
+
+export async function listApprovedChallengesForEventPicker(): Promise<
+  { id: string; title: string; is_official: boolean }[]
+> {
+  const nowIso = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('challenges')
+    .select('id,title,is_official')
+    .eq('status', 'approved')
+    .or(`ends_at.is.null,ends_at.gt.${nowIso}`)
+    .order('is_official', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(100);
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+type UpsertInput = {
+  id?: string | null;
+  slug: string;
+  title: string;
+  description?: string;
+  eventType: EventType;
+  startsAt: string;
+  endsAt: string;
+  status: EventStatus;
+  challengeIds: string[];
+};
+
+export async function adminUpsertEvent(input: UpsertInput): Promise<string> {
+  const { data, error } = await supabase.rpc('admin_upsert_event', {
+    p_id: input.id ?? null,
+    p_slug: input.slug,
+    p_title: input.title,
+    p_description: input.description ?? '',
+    p_event_type: input.eventType,
+    p_starts_at: input.startsAt,
+    p_ends_at: input.endsAt,
+    p_status: input.status,
+    p_challenge_ids: input.challengeIds,
+  });
+  if (error) throw new Error(error.message);
+  return data as string;
+}

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import type { ActiveEventSummary } from '@/lib/events/getActiveEvents';
+import { getEventTimeRemaining } from '@/lib/events/getActiveEvents';
+
+type Props = {
+  event: ActiveEventSummary;
+};
+
+export function EventCard({ event }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('events');
+  const remaining = getEventTimeRemaining(new Date(event.ends_at));
+  const isActive = event.status === 'active' && !remaining.ended;
+
+  return (
+    <article className="rounded-md border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-[10px] font-black uppercase tracking-[0.2em] text-accent">
+          {t(`types.${event.event_type}`)}
+        </p>
+        <span
+          className={[
+            'rounded-sm border px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.14em]',
+            isActive ? 'border-primary/50 text-primary' : 'border-border text-muted-foreground',
+          ].join(' ')}
+        >
+          {t(`status.${event.status}`)}
+        </span>
+      </div>
+      <h2 className="mt-2 text-lg font-black uppercase tracking-tight">{event.title}</h2>
+      {event.description ? (
+        <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{event.description}</p>
+      ) : null}
+      <p className="mt-2 text-xs text-muted-foreground">
+        {t('challengeCount', { count: event.challengeCount })}
+      </p>
+      {isActive && !remaining.ended ? (
+        <p className="mt-1 text-xs font-black uppercase tracking-[0.14em] text-accent">
+          {t('endsIn', { days: remaining.days, hours: remaining.hours })}
+        </p>
+      ) : null}
+      <Link
+        href={`/${locale}/app/events/${event.slug}`}
+        className="mt-4 inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2.5 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t('viewEvent')}
+      </Link>
+    </article>
+  );
+}

--- a/src/features/events/components/EventDetailScreen.tsx
+++ b/src/features/events/components/EventDetailScreen.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+import { EventLeaderboardSection } from '@/features/events/components/EventLeaderboardSection';
+import { EventRecapSection } from '@/features/events/components/EventRecapSection';
+import { useEventDetail } from '@/features/events/hooks/useEventDetail';
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { getEventTimeRemaining } from '@/lib/events/getActiveEvents';
+import type { Division } from '@/lib/types/database.types';
+
+type Props = {
+  slug: string;
+};
+
+export function EventDetailScreen({ slug }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('events');
+  const profile = useOptionalAppProfile();
+  const [division, setDivision] = useState<Division>(profile?.division ?? 'rookie');
+  const { state, refetch } = useEventDetail(slug, division);
+
+  if (state.status === 'loading') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+
+  if (state.status === 'not_found') {
+    return <p className="text-sm text-muted-foreground">{t('notFound')}</p>;
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">{t('error')}</p>
+        <button
+          type="button"
+          onClick={refetch}
+          className="rounded-md border border-border bg-muted px-3 py-2 text-xs font-black uppercase tracking-[0.18em]"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    );
+  }
+
+  const { event, standings, recap } = state;
+  const remaining = getEventTimeRemaining(new Date(event.ends_at));
+  const isActive = event.status === 'active' && !remaining.ended;
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <p className="text-[10px] font-black uppercase tracking-[0.2em] text-accent">
+          {t(`types.${event.event_type}`)}
+        </p>
+        <h1 className="text-2xl font-black uppercase tracking-tight">{event.title}</h1>
+        {event.description ? (
+          <p className="text-sm text-muted-foreground">{event.description}</p>
+        ) : null}
+        <p className="text-xs font-black uppercase tracking-[0.14em] text-muted-foreground">
+          {t(`status.${event.status}`)}
+          {isActive ? ` · ${t('endsIn', { days: remaining.days, hours: remaining.hours })}` : null}
+        </p>
+      </header>
+
+      <section className="space-y-3 rounded-md border border-border bg-card p-4">
+        <h2 className="text-sm font-black uppercase tracking-[0.18em]">{t('challengesTitle')}</h2>
+        <ol className="space-y-2">
+          {event.challenges.map((ch) => (
+            <li key={ch.challengeId}>
+              <Link
+                href={`/${locale}/app/arena/${ch.challengeId}`}
+                className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/20 px-3 py-2.5 hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <span className="text-sm font-bold uppercase tracking-tight">{ch.title}</span>
+                <span className="text-[10px] font-black uppercase tracking-[0.14em] text-primary">
+                  {t('submitScore')}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <EventLeaderboardSection
+        division={division}
+        onDivisionChange={setDivision}
+        standings={standings}
+      />
+
+      {event.status === 'completed' ? <EventRecapSection recap={recap} /> : null}
+    </div>
+  );
+}

--- a/src/features/events/components/EventLeaderboardSection.tsx
+++ b/src/features/events/components/EventLeaderboardSection.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { EventStanding } from '@/features/events/services/events';
+import type { Division } from '@/lib/types/database.types';
+
+const DIVISIONS: Division[] = ['rookie', 'regular', 'savage', 'elite'];
+
+type Props = {
+  division: Division;
+  onDivisionChange: (division: Division) => void;
+  standings: readonly EventStanding[];
+  loading?: boolean;
+};
+
+export function EventLeaderboardSection({
+  division,
+  onDivisionChange,
+  standings,
+  loading = false,
+}: Props) {
+  const t = useTranslations('events.leaderboard');
+  const tDiv = useTranslations('divisions');
+
+  return (
+    <section className="space-y-4 rounded-md border border-border bg-card p-4">
+      <header className="space-y-3">
+        <h2 className="text-sm font-black uppercase tracking-[0.18em]">{t('title')}</h2>
+        <div className="flex flex-wrap gap-2" role="group" aria-label={t('divisionFilter')}>
+          {DIVISIONS.map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => onDivisionChange(d)}
+              aria-pressed={division === d}
+              className={[
+                'rounded-sm border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em]',
+                division === d
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border text-muted-foreground hover:text-foreground',
+              ].join(' ')}
+            >
+              {tDiv(d)}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {loading ? <p className="text-sm text-muted-foreground">{t('loading')}</p> : null}
+
+      {!loading && standings.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('empty')}</p>
+      ) : null}
+
+      {!loading && standings.length > 0 ? (
+        <ol className="divide-y divide-border">
+          {standings.map((row, index) => (
+            <li
+              key={row.userId}
+              className="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0"
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="w-6 shrink-0 text-sm font-black tabular-nums text-muted-foreground">
+                  {index + 1}
+                </span>
+                <span className="truncate text-sm font-bold uppercase tracking-tight">
+                  {row.username}
+                </span>
+              </div>
+              <div className="shrink-0 text-right">
+                <span className="text-sm font-black tabular-nums">{row.totalPoints}</span>
+                <p className="text-[10px] text-muted-foreground">
+                  {t('challengesScored', { count: row.challengesScored })}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/events/components/EventRecapSection.tsx
+++ b/src/features/events/components/EventRecapSection.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { EventRecapRow } from '@/features/events/services/events';
+import type { Division } from '@/lib/types/database.types';
+
+const DIVISIONS: Division[] = ['rookie', 'regular', 'savage', 'elite'];
+
+type Props = {
+  recap: readonly EventRecapRow[];
+};
+
+export function EventRecapSection({ recap }: Props) {
+  const t = useTranslations('events.recap');
+  const tDiv = useTranslations('divisions');
+
+  if (recap.length === 0) return null;
+
+  return (
+    <section className="space-y-4 rounded-md border border-accent/30 bg-card p-4">
+      <header>
+        <h2 className="text-sm font-black uppercase tracking-[0.18em] text-accent">{t('title')}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {DIVISIONS.map((division) => {
+          const rows = recap.filter((r) => r.division === division);
+          if (rows.length === 0) return null;
+
+          return (
+            <article key={division} className="rounded-md border border-border bg-muted/30 p-3">
+              <h3 className="text-xs font-black uppercase tracking-[0.18em]">{tDiv(division)}</h3>
+              <ol className="mt-2 space-y-1.5">
+                {rows.map((row) => (
+                  <li key={row.userId} className="flex items-center justify-between gap-2 text-sm">
+                    <span className="font-black tabular-nums text-muted-foreground">
+                      #{row.rank}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-bold uppercase">
+                      {row.username}
+                    </span>
+                    <span className="font-black tabular-nums">{row.totalPoints}</span>
+                  </li>
+                ))}
+              </ol>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/features/events/components/EventsListScreen.tsx
+++ b/src/features/events/components/EventsListScreen.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { EventCard } from '@/features/events/components/EventCard';
+import { useEventsList } from '@/features/events/hooks/useEventsList';
+
+export function EventsListScreen() {
+  const t = useTranslations('events');
+  const { state, refetch } = useEventsList();
+
+  if (state.status === 'loading') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">{t('error')}</p>
+        <button
+          type="button"
+          onClick={refetch}
+          className="rounded-md border border-border bg-muted px-3 py-2 text-xs font-black uppercase tracking-[0.18em]"
+        >
+          {t('retry')}
+        </button>
+      </div>
+    );
+  }
+
+  if (state.events.length === 0) {
+    return <p className="text-sm text-muted-foreground">{t('empty')}</p>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {state.events.map((event) => (
+        <EventCard key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/events/hooks/useActiveEvents.ts
+++ b/src/features/events/hooks/useActiveEvents.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { getActiveEvents, type ActiveEventSummary } from '@/lib/events/getActiveEvents';
+
+type State =
+  | { status: 'loading'; events: ActiveEventSummary[]; error: null }
+  | { status: 'ready'; events: ActiveEventSummary[]; error: null }
+  | { status: 'error'; events: ActiveEventSummary[]; error: string };
+
+export function useActiveEvents(): { state: State; refetch: () => void } {
+  const [state, setState] = useState<State>({ status: 'loading', events: [], error: null });
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const events = await getActiveEvents();
+        if (!cancelled) setState({ status: 'ready', events, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', events: [], error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  return {
+    state,
+    refetch: () => {
+      setState({ status: 'loading', events: [], error: null });
+      setReloadKey((k) => k + 1);
+    },
+  };
+}

--- a/src/features/events/hooks/useEventDetail.ts
+++ b/src/features/events/hooks/useEventDetail.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  fetchEventBySlug,
+  fetchEventRecap,
+  fetchEventStandings,
+  type EventDetail,
+  type EventRecapRow,
+  type EventStanding,
+} from '@/features/events/services/events';
+import type { Division } from '@/lib/types/database.types';
+
+type State =
+  | {
+      status: 'loading';
+      event: EventDetail | null;
+      standings: EventStanding[];
+      recap: EventRecapRow[];
+      error: null;
+    }
+  | {
+      status: 'ready';
+      event: EventDetail;
+      standings: EventStanding[];
+      recap: EventRecapRow[];
+      error: null;
+    }
+  | {
+      status: 'not_found';
+      event: null;
+      standings: EventStanding[];
+      recap: EventRecapRow[];
+      error: null;
+    }
+  | {
+      status: 'error';
+      event: EventDetail | null;
+      standings: EventStanding[];
+      recap: EventRecapRow[];
+      error: string;
+    };
+
+const empty = { standings: [] as EventStanding[], recap: [] as EventRecapRow[] };
+
+export function useEventDetail(
+  slug: string,
+  division: Division,
+): { state: State; refetch: () => void } {
+  const [state, setState] = useState<State>({
+    status: 'loading',
+    event: null,
+    ...empty,
+    error: null,
+  });
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const event = await fetchEventBySlug(slug);
+        if (!event) {
+          if (!cancelled) setState({ status: 'not_found', event: null, ...empty, error: null });
+          return;
+        }
+
+        const [standings, recap] = await Promise.all([
+          fetchEventStandings(event.id, division),
+          event.status === 'completed' ? fetchEventRecap(event.id) : Promise.resolve([]),
+        ]);
+
+        if (!cancelled) {
+          setState({ status: 'ready', event, standings, recap, error: null });
+        }
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) {
+          setState({ status: 'error', event: null, ...empty, error: message });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, division, reloadKey]);
+
+  return {
+    state,
+    refetch: () => {
+      setState({ status: 'loading', event: null, ...empty, error: null });
+      setReloadKey((k) => k + 1);
+    },
+  };
+}

--- a/src/features/events/hooks/useEventsList.ts
+++ b/src/features/events/hooks/useEventsList.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { listPublicEvents, type ActiveEventSummary } from '@/lib/events/getActiveEvents';
+
+type State =
+  | { status: 'loading'; events: ActiveEventSummary[]; error: null }
+  | { status: 'ready'; events: ActiveEventSummary[]; error: null }
+  | { status: 'error'; events: ActiveEventSummary[]; error: string };
+
+export function useEventsList(): { state: State; refetch: () => void } {
+  const [state, setState] = useState<State>({ status: 'loading', events: [], error: null });
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const events = await listPublicEvents();
+        if (!cancelled) setState({ status: 'ready', events, error: null });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'unknown';
+        if (!cancelled) setState({ status: 'error', events: [], error: message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  return {
+    state,
+    refetch: () => {
+      setState({ status: 'loading', events: [], error: null });
+      setReloadKey((k) => k + 1);
+    },
+  };
+}

--- a/src/features/events/index.ts
+++ b/src/features/events/index.ts
@@ -1,0 +1,8 @@
+export { EventCard } from '@/features/events/components/EventCard';
+export { EventDetailScreen } from '@/features/events/components/EventDetailScreen';
+export { EventLeaderboardSection } from '@/features/events/components/EventLeaderboardSection';
+export { EventRecapSection } from '@/features/events/components/EventRecapSection';
+export { EventsListScreen } from '@/features/events/components/EventsListScreen';
+export { useActiveEvents } from '@/features/events/hooks/useActiveEvents';
+export { useEventDetail } from '@/features/events/hooks/useEventDetail';
+export { useEventsList } from '@/features/events/hooks/useEventsList';

--- a/src/features/events/services/events.ts
+++ b/src/features/events/services/events.ts
@@ -1,0 +1,138 @@
+import { supabase } from '@/lib/supabase';
+import type { Division, EventType, MicroEvent } from '@/lib/types/database.types';
+
+const EVENT_SELECT =
+  'id,slug,title,description,event_type,starts_at,ends_at,status,created_at,updated_at';
+
+export type EventChallengeDetail = {
+  challengeId: string;
+  sortOrder: number;
+  title: string;
+  scoreType: string;
+};
+
+export type EventDetail = MicroEvent & {
+  challenges: EventChallengeDetail[];
+};
+
+export type EventStanding = {
+  userId: string;
+  username: string;
+  totalPoints: number;
+  challengesScored: number;
+};
+
+export type EventRecapRow = {
+  division: Division;
+  userId: string;
+  username: string;
+  totalPoints: number;
+  rank: number;
+};
+
+export async function fetchEventBySlug(slug: string): Promise<EventDetail | null> {
+  const { data, error } = await supabase
+    .from('events')
+    .select(
+      `${EVENT_SELECT}, event_challenges(sort_order, challenge:challenges(id,title,score_type))`,
+    )
+    .eq('slug', slug)
+    .neq('status', 'cancelled')
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+
+  type Row = MicroEvent & {
+    event_challenges: {
+      sort_order: number;
+      challenge: { id: string; title: string; score_type: string } | null;
+    }[];
+  };
+
+  const row = data as unknown as Row;
+  const challenges = (row.event_challenges ?? [])
+    .filter((ec) => ec.challenge)
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((ec) => ({
+      challengeId: ec.challenge!.id,
+      sortOrder: ec.sort_order,
+      title: ec.challenge!.title,
+      scoreType: ec.challenge!.score_type,
+    }));
+
+  return {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    event_type: row.event_type,
+    starts_at: row.starts_at,
+    ends_at: row.ends_at,
+    status: row.status,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    challenges,
+  };
+}
+
+export async function fetchEventStandings(
+  eventId: string,
+  division: Division,
+  limit = 50,
+): Promise<EventStanding[]> {
+  const { data, error } = await supabase.rpc('get_event_standings', {
+    p_event_id: eventId,
+    p_division: division,
+    p_limit: limit,
+  });
+  if (error) throw new Error(error.message);
+
+  return (data ?? []).map(
+    (row: {
+      user_id: string;
+      username: string;
+      total_points: number;
+      challenges_scored: number;
+    }) => ({
+      userId: row.user_id,
+      username: row.username,
+      totalPoints: Number(row.total_points),
+      challengesScored: row.challenges_scored,
+    }),
+  );
+}
+
+export async function fetchEventRecap(eventId: string, topN = 3): Promise<EventRecapRow[]> {
+  const { data, error } = await supabase.rpc('get_event_recap', {
+    p_event_id: eventId,
+    p_top_n: topN,
+  });
+  if (error) throw new Error(error.message);
+
+  return (data ?? []).map(
+    (row: {
+      division: Division;
+      user_id: string;
+      username: string;
+      total_points: number;
+      rank: number;
+    }) => ({
+      division: row.division,
+      userId: row.user_id,
+      username: row.username,
+      totalPoints: Number(row.total_points),
+      rank: row.rank,
+    }),
+  );
+}
+
+export const EVENT_TYPES: EventType[] = [
+  'rookie_week',
+  'no_equipment_cup',
+  'faction_war_weekend',
+  'city_clash',
+  'grit_open',
+  'comeback_week',
+  'custom',
+];

--- a/src/features/overview/components/OverviewScreen.tsx
+++ b/src/features/overview/components/OverviewScreen.tsx
@@ -9,6 +9,8 @@ import {
   resolveWeeklyDisplayLabel,
   useWeeklyChallenge,
 } from '@/features/overview/hooks/useWeeklyChallenge';
+import { EventCard } from '@/features/events/components/EventCard';
+import { useActiveEvents } from '@/features/events/hooks/useActiveEvents';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { getFactionBadgeClasses } from '@/lib/factionStyles';
 import { getWeeklyTimeRemaining } from '@/lib/weekly';
@@ -32,6 +34,7 @@ export function OverviewScreen() {
   const tFactions = useTranslations('factions');
 
   const { state: weeklyState, refetch: refetchWeekly } = useWeeklyChallenge();
+  const { state: eventsState } = useActiveEvents();
   const appProfile = useOptionalAppProfile();
 
   const clanHref = `/${locale}/app/clan`;
@@ -178,6 +181,28 @@ export function OverviewScreen() {
           ) : null}
         </article>
       </div>
+
+      <article className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-accent">
+          {t('eventsTitle')}
+        </p>
+        {eventsState.status === 'loading' ? (
+          <p className="mt-2 text-sm text-muted-foreground">{t('loading')}</p>
+        ) : null}
+        {eventsState.status === 'ready' && eventsState.events.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">{t('eventsEmpty')}</p>
+        ) : null}
+        {eventsState.status === 'ready' && eventsState.events.length > 0 ? (
+          <div className="mt-3 grid gap-4 md:grid-cols-2">
+            {eventsState.events.slice(0, 2).map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </div>
+        ) : null}
+        <div className="mt-4">
+          <PrimaryButtonLink href={`/${locale}/app/events`} label={t('eventsCta')} />
+        </div>
+      </article>
     </section>
   );
 }

--- a/src/lib/events/eventPoints.test.ts
+++ b/src/lib/events/eventPoints.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateEventStandings, eventScorePoints } from '@/lib/events/eventPoints';
+
+describe('eventScorePoints', () => {
+  it('caps reps scores at 10000', () => {
+    expect(eventScorePoints(50, 'reps')).toBe(50);
+    expect(eventScorePoints(99999, 'reps')).toBe(10000);
+  });
+
+  it('inverts time scores (faster = more points)', () => {
+    expect(eventScorePoints(120, 'time')).toBe(9880);
+    expect(eventScorePoints(60, 'time')).toBe(9940);
+  });
+});
+
+describe('aggregateEventStandings', () => {
+  it('sums points across challenges per user', () => {
+    const result = aggregateEventStandings([
+      { userId: 'a', username: 'alpha', points: 100, challengeId: 'c1' },
+      { userId: 'a', username: 'alpha', points: 50, challengeId: 'c2' },
+      { userId: 'b', username: 'beta', points: 120, challengeId: 'c1' },
+    ]);
+
+    expect(result[0]?.userId).toBe('a');
+    expect(result[0]?.totalPoints).toBe(150);
+    expect(result[0]?.challengesScored).toBe(2);
+    expect(result[1]?.totalPoints).toBe(120);
+    expect(result[1]?.challengesScored).toBe(1);
+  });
+});

--- a/src/lib/events/eventPoints.ts
+++ b/src/lib/events/eventPoints.ts
@@ -1,0 +1,49 @@
+import type { ScoreType } from '@/lib/types/database.types';
+
+const EVENT_POINTS_CAP = 10_000;
+const TIME_VALUE_CAP = 9_999;
+
+/** Maps score value to event points (mirrors SQL `faction_war_contribution_points`). */
+export function eventScorePoints(value: number, scoreType: ScoreType): number {
+  const safe = Number.isFinite(value) ? value : 0;
+  if (scoreType === 'time') {
+    return Math.max(0, EVENT_POINTS_CAP - Math.min(Math.max(safe, 0), TIME_VALUE_CAP));
+  }
+  return Math.min(Math.max(safe, 0), EVENT_POINTS_CAP);
+}
+
+export type EventStandingRow = {
+  userId: string;
+  username: string;
+  totalPoints: number;
+  challengesScored: number;
+};
+
+/** Aggregate event_scores rows into overall standings (sum points per user). */
+export function aggregateEventStandings(
+  rows: readonly { userId: string; username: string; points: number; challengeId: string }[],
+): EventStandingRow[] {
+  const byUser = new Map<string, EventStandingRow>();
+
+  for (const row of rows) {
+    const existing = byUser.get(row.userId);
+    if (!existing) {
+      byUser.set(row.userId, {
+        userId: row.userId,
+        username: row.username,
+        totalPoints: row.points,
+        challengesScored: 1,
+      });
+      continue;
+    }
+    existing.totalPoints += row.points;
+    existing.challengesScored += 1;
+  }
+
+  return [...byUser.values()].sort(
+    (a, b) =>
+      b.totalPoints - a.totalPoints ||
+      b.challengesScored - a.challengesScored ||
+      a.username.localeCompare(b.username),
+  );
+}

--- a/src/lib/events/getActiveEvents.ts
+++ b/src/lib/events/getActiveEvents.ts
@@ -1,0 +1,64 @@
+import { supabase } from '@/lib/supabase';
+import type { EventStatus, MicroEvent } from '@/lib/types/database.types';
+
+const EVENT_SELECT =
+  'id,slug,title,description,event_type,starts_at,ends_at,status,created_at,updated_at';
+
+export type ActiveEventSummary = MicroEvent & {
+  challengeCount: number;
+};
+
+type EventRow = MicroEvent & {
+  event_challenges: { challenge_id: string }[];
+};
+
+export type EventTimeRemaining = {
+  days: number;
+  hours: number;
+  ended: boolean;
+};
+
+export function getEventTimeRemaining(endsAt: Date, now: Date = new Date()): EventTimeRemaining {
+  const ms = endsAt.getTime() - now.getTime();
+  if (ms <= 0) {
+    return { days: 0, hours: 0, ended: true };
+  }
+  const totalHours = Math.ceil(ms / (1000 * 60 * 60));
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return { days, hours, ended: false };
+}
+
+export async function getActiveEvents(limit = 6): Promise<ActiveEventSummary[]> {
+  const nowIso = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('events')
+    .select(`${EVENT_SELECT}, event_challenges(challenge_id)`)
+    .eq('status', 'active')
+    .lte('starts_at', nowIso)
+    .gt('ends_at', nowIso)
+    .order('ends_at', { ascending: true })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+  return mapEventRows(data as EventRow[] | null);
+}
+
+export async function listPublicEvents(): Promise<ActiveEventSummary[]> {
+  const { data, error } = await supabase
+    .from('events')
+    .select(`${EVENT_SELECT}, event_challenges(challenge_id)`)
+    .in('status', ['scheduled', 'active', 'completed'] satisfies EventStatus[])
+    .order('starts_at', { ascending: false })
+    .limit(24);
+
+  if (error) throw new Error(error.message);
+  return mapEventRows(data as EventRow[] | null);
+}
+
+function mapEventRows(rows: EventRow[] | null): ActiveEventSummary[] {
+  return (rows ?? []).map(({ event_challenges, ...event }) => ({
+    ...event,
+    challengeCount: event_challenges?.length ?? 0,
+  }));
+}

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -1,0 +1,4 @@
+export { eventScorePoints, aggregateEventStandings } from '@/lib/events/eventPoints';
+export type { EventStandingRow } from '@/lib/events/eventPoints';
+export { getActiveEvents, getEventTimeRemaining } from '@/lib/events/getActiveEvents';
+export type { ActiveEventSummary } from '@/lib/events/getActiveEvents';

--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -7,6 +7,15 @@ export type ScoreType = 'time' | 'reps';
 export type ChallengeStatus = 'pending' | 'approved' | 'rejected';
 export type ChallengeAiTier = 'green' | 'orange' | 'red';
 export type WeeklyChallengeStatus = 'scheduled' | 'active' | 'completed' | 'cancelled';
+export type EventType =
+  | 'rookie_week'
+  | 'no_equipment_cup'
+  | 'faction_war_weekend'
+  | 'city_clash'
+  | 'grit_open'
+  | 'comeback_week'
+  | 'custom';
+export type EventStatus = 'scheduled' | 'active' | 'completed' | 'cancelled';
 export type RivalMatchStatus = 'pending' | 'active' | 'completed' | 'cancelled' | 'expired';
 export type RivalParticipantStatus = 'invited' | 'accepted' | 'declined' | 'left';
 
@@ -17,6 +26,37 @@ export interface WeeklyChallenge {
   ends_at: string;
   status: WeeklyChallengeStatus;
   week_label: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MicroEvent {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  event_type: EventType;
+  starts_at: string;
+  ends_at: string;
+  status: EventStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EventChallenge {
+  event_id: string;
+  challenge_id: string;
+  sort_order: number;
+}
+
+export interface EventScore {
+  id: string;
+  event_id: string;
+  user_id: string;
+  challenge_id: string;
+  division: Division;
+  score_id: string | null;
+  points: number;
   created_at: string;
   updated_at: string;
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -161,7 +161,10 @@
     "factionYourTeam": "YOUR TEAM",
     "factionNudgeBody": "{faction} needs points today. Post a ranked score.",
     "noFactionBody": "No faction on file. Complete onboarding.",
-    "noFactionCta": "GO TO ONBOARDING"
+    "noFactionCta": "GO TO ONBOARDING",
+    "eventsTitle": "MICRO-EVENTS",
+    "eventsEmpty": "No active events right now. Check back soon.",
+    "eventsCta": "VIEW ALL EVENTS"
   },
   "clan": {
     "subtitle": "Your faction is a weapon. Use it.",
@@ -373,6 +376,7 @@
     "title": "UGC MOD QUEUE",
     "subtitle": "Moderation vs Arena. In review → approve. Live = open in Arena. Done = closed. Rejected = blocked.",
     "weeklyLink": "SCHEDULE WEEKLY CHALLENGE →",
+    "eventsLink": "SCHEDULE MICRO-EVENT →",
     "nav": {
       "link": "MOD",
       "dock": "MOD",
@@ -476,6 +480,47 @@
       "listTitle": "Recent windows",
       "empty": "No weekly windows yet.",
       "edit": "Edit",
+      "statuses": {
+        "scheduled": "Scheduled",
+        "active": "Active",
+        "completed": "Completed",
+        "cancelled": "Cancelled"
+      }
+    },
+    "events": {
+      "title": "MICRO-EVENTS",
+      "subtitle": "Time-boxed async events (24h–30d) with 1–5 challenges. No deploy needed.",
+      "loading": "Loading events…",
+      "error": "Could not load events.",
+      "retry": "Retry",
+      "formCreateTitle": "Create event",
+      "formEditTitle": "Edit event",
+      "nameLabel": "Title",
+      "slug": "URL slug",
+      "slugPlaceholder": "rookie-week-june (auto from title if empty)",
+      "description": "Description",
+      "eventType": "Event type",
+      "startsAt": "Starts",
+      "endsAt": "Ends",
+      "status": "Status",
+      "challenges": "Challenges",
+      "challengeShort": "ch.",
+      "create": "Create",
+      "update": "Save",
+      "saving": "Saving…",
+      "cancelEdit": "Cancel edit",
+      "listTitle": "Recent events",
+      "empty": "No events yet.",
+      "edit": "Edit",
+      "types": {
+        "rookie_week": "Rookie Week",
+        "no_equipment_cup": "No Equipment Cup",
+        "faction_war_weekend": "Faction War Weekend",
+        "city_clash": "City Clash",
+        "grit_open": "Grit Open",
+        "comeback_week": "Comeback Week",
+        "custom": "Custom"
+      },
       "statuses": {
         "scheduled": "Scheduled",
         "active": "Active",
@@ -603,6 +648,48 @@
     "bannerAria": "Weekly challenge {label}",
     "endsIn": "Ends in {days}d {hours}h",
     "ended": "This week is over"
+  },
+  "events": {
+    "listTitle": "MICRO-EVENTS",
+    "listSubtitle": "Async time-boxed competitions — 24h to 30 days.",
+    "backOverview": "OVERVIEW",
+    "backEvents": "ALL EVENTS",
+    "loading": "Loading events…",
+    "error": "Could not load events.",
+    "retry": "Retry",
+    "empty": "No events scheduled yet.",
+    "notFound": "Event not found.",
+    "viewEvent": "ENTER EVENT",
+    "challengeCount": "{count, plural, one {# challenge} other {# challenges}}",
+    "endsIn": "Ends in {days}d {hours}h",
+    "challengesTitle": "EVENT CHALLENGES",
+    "submitScore": "SCORE →",
+    "types": {
+      "rookie_week": "Rookie Week",
+      "no_equipment_cup": "No Equipment Cup",
+      "faction_war_weekend": "Faction War Weekend",
+      "city_clash": "City Clash",
+      "grit_open": "Grit Open",
+      "comeback_week": "Comeback Week",
+      "custom": "Custom"
+    },
+    "status": {
+      "scheduled": "Scheduled",
+      "active": "Live",
+      "completed": "Completed",
+      "cancelled": "Cancelled"
+    },
+    "leaderboard": {
+      "title": "EVENT LEADERBOARD",
+      "divisionFilter": "Filter by division",
+      "loading": "Loading standings…",
+      "empty": "No ranked scores in this division yet.",
+      "challengesScored": "{count, plural, one {# ch.} other {# ch.}}"
+    },
+    "recap": {
+      "title": "FINAL STANDINGS",
+      "subtitle": "Top performers per division when the event closed."
+    }
   },
   "rivals": {
     "hubLink": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -161,7 +161,10 @@
     "factionYourTeam": "TON ÉQUIPE",
     "factionNudgeBody": "{faction} a besoin de points aujourd’hui. Poste un score classé.",
     "noFactionBody": "Aucune faction enregistrée. Termine l’onboarding.",
-    "noFactionCta": "ALLER À L’ONBOARDING"
+    "noFactionCta": "ALLER À L’ONBOARDING",
+    "eventsTitle": "MICRO-ÉVÉNEMENTS",
+    "eventsEmpty": "Aucun événement actif pour l’instant.",
+    "eventsCta": "VOIR TOUS LES ÉVÉNEMENTS"
   },
   "clan": {
     "subtitle": "Ta faction est une arme. Utilise-la.",
@@ -373,6 +376,7 @@
     "title": "FILE MODÉRATION UGC",
     "subtitle": "Modération vs Arène. En revue → approuver. Live = ouvert dans l’Arène. Terminé = fermé. Refusé = bloqué.",
     "weeklyLink": "PROGRAMMER LE DÉFI HEBDO →",
+    "eventsLink": "PROGRAMMER UN MICRO-ÉVÉNEMENT →",
     "nav": {
       "link": "MOD",
       "dock": "MOD",
@@ -476,6 +480,47 @@
       "listTitle": "Fenêtres récentes",
       "empty": "Aucune fenêtre hebdo.",
       "edit": "Modifier",
+      "statuses": {
+        "scheduled": "Programmé",
+        "active": "Actif",
+        "completed": "Terminé",
+        "cancelled": "Annulé"
+      }
+    },
+    "events": {
+      "title": "MICRO-ÉVÉNEMENTS",
+      "subtitle": "Événements async (24h–30j) avec 1 à 5 défis. Sans déploiement.",
+      "loading": "Chargement des événements…",
+      "error": "Impossible de charger les événements.",
+      "retry": "Réessayer",
+      "formCreateTitle": "Créer un événement",
+      "formEditTitle": "Modifier l’événement",
+      "nameLabel": "Titre",
+      "slug": "Slug URL",
+      "slugPlaceholder": "rookie-week-juin (auto depuis le titre si vide)",
+      "description": "Description",
+      "eventType": "Type d’événement",
+      "startsAt": "Début",
+      "endsAt": "Fin",
+      "status": "Statut",
+      "challenges": "Défis",
+      "challengeShort": "déf.",
+      "create": "Créer",
+      "update": "Enregistrer",
+      "saving": "Enregistrement…",
+      "cancelEdit": "Annuler",
+      "listTitle": "Événements récents",
+      "empty": "Aucun événement.",
+      "edit": "Modifier",
+      "types": {
+        "rookie_week": "Semaine Rookie",
+        "no_equipment_cup": "Coupe sans matériel",
+        "faction_war_weekend": "Week-end guerre des factions",
+        "city_clash": "City Clash",
+        "grit_open": "Grit Open",
+        "comeback_week": "Semaine comeback",
+        "custom": "Personnalisé"
+      },
       "statuses": {
         "scheduled": "Programmé",
         "active": "Actif",
@@ -603,6 +648,48 @@
     "bannerAria": "Défi hebdo {label}",
     "endsIn": "Fin dans {days}j {hours}h",
     "ended": "Cette semaine est terminée"
+  },
+  "events": {
+    "listTitle": "MICRO-ÉVÉNEMENTS",
+    "listSubtitle": "Compétitions async — de 24h à 30 jours.",
+    "backOverview": "APERÇU",
+    "backEvents": "TOUS LES ÉVÉNEMENTS",
+    "loading": "Chargement des événements…",
+    "error": "Impossible de charger les événements.",
+    "retry": "Réessayer",
+    "empty": "Aucun événement programmé.",
+    "notFound": "Événement introuvable.",
+    "viewEvent": "ENTRER",
+    "challengeCount": "{count, plural, one {# défi} other {# défis}}",
+    "endsIn": "Fin dans {days}j {hours}h",
+    "challengesTitle": "DÉFIS DE L’ÉVÉNEMENT",
+    "submitScore": "SCORE →",
+    "types": {
+      "rookie_week": "Semaine Rookie",
+      "no_equipment_cup": "Coupe sans matériel",
+      "faction_war_weekend": "Week-end guerre des factions",
+      "city_clash": "City Clash",
+      "grit_open": "Grit Open",
+      "comeback_week": "Semaine comeback",
+      "custom": "Personnalisé"
+    },
+    "status": {
+      "scheduled": "Programmé",
+      "active": "En cours",
+      "completed": "Terminé",
+      "cancelled": "Annulé"
+    },
+    "leaderboard": {
+      "title": "CLASSEMENT ÉVÉNEMENT",
+      "divisionFilter": "Filtrer par division",
+      "loading": "Chargement du classement…",
+      "empty": "Aucun score classé dans cette division.",
+      "challengesScored": "{count, plural, one {# défi} other {# défis}}"
+    },
+    "recap": {
+      "title": "CLASSEMENT FINAL",
+      "subtitle": "Top par division à la clôture de l’événement."
+    }
   },
   "rivals": {
     "hubLink": {

--- a/supabase/migrations/024_micro_events.sql
+++ b/supabase/migrations/024_micro_events.sql
@@ -1,0 +1,411 @@
+-- V2-09: async micro-events (24h / 7d / 30d) with multi-challenge sets and division leaderboards.
+
+CREATE TABLE IF NOT EXISTS public.events (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug         TEXT        NOT NULL UNIQUE,
+  title        TEXT        NOT NULL,
+  description  TEXT        NOT NULL DEFAULT '',
+  event_type   TEXT        NOT NULL DEFAULT 'custom'
+    CHECK (event_type IN (
+      'rookie_week', 'no_equipment_cup', 'faction_war_weekend',
+      'city_clash', 'grit_open', 'comeback_week', 'custom'
+    )),
+  starts_at    TIMESTAMPTZ NOT NULL,
+  ends_at      TIMESTAMPTZ NOT NULL,
+  status       TEXT        NOT NULL DEFAULT 'scheduled'
+    CHECK (status IN ('scheduled', 'active', 'completed', 'cancelled')),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT events_window_check CHECK (ends_at > starts_at)
+);
+
+COMMENT ON TABLE public.events IS
+  'V2-09: time-boxed micro-events (Rookie Week, No Equipment Cup, etc.). Admin-managed.';
+
+CREATE INDEX IF NOT EXISTS idx_events_window
+  ON public.events (starts_at DESC, ends_at DESC)
+  WHERE status <> 'cancelled';
+
+CREATE INDEX IF NOT EXISTS idx_events_slug
+  ON public.events (slug);
+
+CREATE TABLE IF NOT EXISTS public.event_challenges (
+  event_id     UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  challenge_id UUID NOT NULL REFERENCES public.challenges(id) ON DELETE RESTRICT,
+  sort_order   INT  NOT NULL CHECK (sort_order BETWEEN 1 AND 5),
+  PRIMARY KEY (event_id, challenge_id),
+  UNIQUE (event_id, sort_order)
+);
+
+COMMENT ON TABLE public.event_challenges IS
+  'V2-09: ordered challenge set for a micro-event (1–5 challenges).';
+
+CREATE TABLE IF NOT EXISTS public.event_scores (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id     UUID        NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  user_id      UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  challenge_id UUID        NOT NULL REFERENCES public.challenges(id) ON DELETE RESTRICT,
+  division     TEXT        NOT NULL CHECK (division IN ('rookie', 'regular', 'savage', 'elite')),
+  score_id     UUID        NULL REFERENCES public.scores(id) ON DELETE SET NULL,
+  points       NUMERIC     NOT NULL CHECK (points >= 0),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT event_scores_event_user_challenge_unique UNIQUE (event_id, user_id, challenge_id)
+);
+
+COMMENT ON TABLE public.event_scores IS
+  'V2-09: best validated score per user per challenge within an event window.';
+
+CREATE INDEX IF NOT EXISTS idx_event_scores_event_division
+  ON public.event_scores (event_id, division, points DESC);
+
+CREATE INDEX IF NOT EXISTS idx_event_scores_event_challenge
+  ON public.event_scores (event_id, challenge_id, division, points DESC);
+
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_challenges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.event_scores ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can read events"
+  ON public.events FOR SELECT
+  TO authenticated
+  USING (status <> 'cancelled');
+
+CREATE POLICY "Authenticated users can read event challenges"
+  ON public.event_challenges FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Authenticated users can read event scores"
+  ON public.event_scores FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Admins can insert events"
+  ON public.events FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_app_admin());
+
+CREATE POLICY "Admins can update events"
+  ON public.events FOR UPDATE
+  TO authenticated
+  USING (public.is_app_admin())
+  WITH CHECK (public.is_app_admin());
+
+CREATE POLICY "Admins can insert event challenges"
+  ON public.event_challenges FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_app_admin());
+
+CREATE POLICY "Admins can delete event challenges"
+  ON public.event_challenges FOR DELETE
+  TO authenticated
+  USING (public.is_app_admin());
+
+CREATE OR REPLACE FUNCTION public.upsert_event_score_on_score()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_id    UUID;
+  v_division    TEXT;
+  v_score_type  TEXT;
+  v_points      NUMERIC;
+BEGIN
+  IF NOT NEW.is_validated THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.is_validated THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT e.id
+  INTO v_event_id
+  FROM public.events e
+  INNER JOIN public.event_challenges ec ON ec.event_id = e.id
+  WHERE ec.challenge_id = NEW.challenge_id
+    AND e.status NOT IN ('cancelled', 'completed')
+    AND NEW.submitted_at >= e.starts_at
+    AND NEW.submitted_at < e.ends_at
+  ORDER BY e.starts_at DESC
+  LIMIT 1;
+
+  IF v_event_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT p.division
+  INTO v_division
+  FROM public.profiles p
+  WHERE p.id = NEW.user_id;
+
+  IF v_division IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT c.score_type
+  INTO v_score_type
+  FROM public.challenges c
+  WHERE c.id = NEW.challenge_id;
+
+  v_points := public.faction_war_contribution_points(NEW.value, COALESCE(v_score_type, 'reps'));
+
+  INSERT INTO public.event_scores (
+    event_id, user_id, challenge_id, division, score_id, points
+  )
+  VALUES (
+    v_event_id, NEW.user_id, NEW.challenge_id, v_division, NEW.id, v_points
+  )
+  ON CONFLICT (event_id, user_id, challenge_id) DO UPDATE
+  SET
+    points = GREATEST(public.event_scores.points, EXCLUDED.points),
+    score_id = CASE
+      WHEN EXCLUDED.points > public.event_scores.points THEN EXCLUDED.score_id
+      ELSE public.event_scores.score_id
+    END,
+    division = EXCLUDED.division,
+    updated_at = NOW();
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_score_event_score ON public.scores;
+CREATE TRIGGER on_score_event_score
+  AFTER INSERT OR UPDATE ON public.scores
+  FOR EACH ROW
+  EXECUTE FUNCTION public.upsert_event_score_on_score();
+
+CREATE OR REPLACE FUNCTION public.admin_upsert_event(
+  p_id uuid,
+  p_slug text,
+  p_title text,
+  p_description text,
+  p_event_type text,
+  p_starts_at timestamptz,
+  p_ends_at timestamptz,
+  p_status text,
+  p_challenge_ids uuid[]
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_id uuid;
+  v_slug text;
+  v_idx int;
+  v_cid uuid;
+BEGIN
+  IF NOT public.is_app_admin() THEN
+    RAISE EXCEPTION 'not_admin';
+  END IF;
+
+  IF p_ends_at <= p_starts_at THEN
+    RAISE EXCEPTION 'invalid_window';
+  END IF;
+
+  IF p_status NOT IN ('scheduled', 'active', 'completed', 'cancelled') THEN
+    RAISE EXCEPTION 'invalid_status';
+  END IF;
+
+  IF p_event_type NOT IN (
+    'rookie_week', 'no_equipment_cup', 'faction_war_weekend',
+    'city_clash', 'grit_open', 'comeback_week', 'custom'
+  ) THEN
+    RAISE EXCEPTION 'invalid_event_type';
+  END IF;
+
+  v_slug := lower(trim(regexp_replace(p_slug, '[^a-zA-Z0-9-]+', '-', 'g'), '-'));
+  IF length(v_slug) < 2 THEN
+    RAISE EXCEPTION 'invalid_slug';
+  END IF;
+
+  IF p_challenge_ids IS NULL OR array_length(p_challenge_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'no_challenges';
+  END IF;
+
+  IF array_length(p_challenge_ids, 1) > 5 THEN
+    RAISE EXCEPTION 'too_many_challenges';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM unnest(p_challenge_ids) AS cid
+    LEFT JOIN public.challenges c ON c.id = cid AND c.status = 'approved'
+    WHERE c.id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'challenge_not_approved';
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO public.events (
+      slug, title, description, event_type, starts_at, ends_at, status
+    )
+    VALUES (
+      v_slug,
+      trim(p_title),
+      COALESCE(trim(p_description), ''),
+      p_event_type,
+      p_starts_at,
+      p_ends_at,
+      p_status
+    )
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE public.events
+    SET
+      slug = v_slug,
+      title = trim(p_title),
+      description = COALESCE(trim(p_description), ''),
+      event_type = p_event_type,
+      starts_at = p_starts_at,
+      ends_at = p_ends_at,
+      status = p_status,
+      updated_at = NOW()
+    WHERE id = p_id
+    RETURNING id INTO v_id;
+
+    IF v_id IS NULL THEN
+      RAISE EXCEPTION 'event_not_found';
+    END IF;
+
+    DELETE FROM public.event_challenges WHERE event_id = v_id;
+  END IF;
+
+  v_idx := 0;
+  FOREACH v_cid IN ARRAY p_challenge_ids LOOP
+    v_idx := v_idx + 1;
+    INSERT INTO public.event_challenges (event_id, challenge_id, sort_order)
+    VALUES (v_id, v_cid, v_idx);
+  END LOOP;
+
+  RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.admin_upsert_event IS
+  'Admin only: create or update a micro-event and its challenge set (1–5 approved challenges).';
+
+CREATE OR REPLACE FUNCTION public.get_event_standings(
+  p_event_id UUID,
+  p_division TEXT,
+  p_limit INT DEFAULT 50
+)
+RETURNS TABLE (
+  user_id UUID,
+  username TEXT,
+  total_points NUMERIC,
+  challenges_scored INT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    es.user_id,
+    p.username,
+    SUM(es.points)::NUMERIC AS total_points,
+    COUNT(DISTINCT es.challenge_id)::INT AS challenges_scored
+  FROM public.event_scores es
+  JOIN public.profiles p ON p.id = es.user_id
+  WHERE es.event_id = p_event_id
+    AND es.division = p_division
+  GROUP BY es.user_id, p.username
+  ORDER BY total_points DESC, challenges_scored DESC, p.username ASC
+  LIMIT GREATEST(p_limit, 1);
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_event_challenge_standings(
+  p_event_id UUID,
+  p_challenge_id UUID,
+  p_division TEXT,
+  p_limit INT DEFAULT 50
+)
+RETURNS TABLE (
+  user_id UUID,
+  username TEXT,
+  points NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    es.user_id,
+    p.username,
+    es.points
+  FROM public.event_scores es
+  JOIN public.profiles p ON p.id = es.user_id
+  WHERE es.event_id = p_event_id
+    AND es.challenge_id = p_challenge_id
+    AND es.division = p_division
+  ORDER BY es.points DESC, es.updated_at ASC
+  LIMIT GREATEST(p_limit, 1);
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_event_recap(
+  p_event_id UUID,
+  p_top_n INT DEFAULT 3
+)
+RETURNS TABLE (
+  division TEXT,
+  user_id UUID,
+  username TEXT,
+  total_points NUMERIC,
+  rank INT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH totals AS (
+    SELECT
+      es.division,
+      es.user_id,
+      p.username,
+      SUM(es.points)::NUMERIC AS total_points
+    FROM public.event_scores es
+    JOIN public.profiles p ON p.id = es.user_id
+    WHERE es.event_id = p_event_id
+    GROUP BY es.division, es.user_id, p.username
+  ),
+  ranked AS (
+    SELECT
+      division,
+      user_id,
+      username,
+      total_points,
+      ROW_NUMBER() OVER (
+        PARTITION BY division
+        ORDER BY total_points DESC, username ASC
+      )::INT AS rank
+    FROM totals
+  )
+  SELECT division, user_id, username, total_points, rank
+  FROM ranked
+  WHERE rank <= GREATEST(p_top_n, 1)
+  ORDER BY division ASC, rank ASC;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_upsert_event(
+  uuid, text, text, text, text, timestamptz, timestamptz, text, uuid[]
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_upsert_event(
+  uuid, text, text, text, text, timestamptz, timestamptz, text, uuid[]
+) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.get_event_standings(UUID, TEXT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_standings(UUID, TEXT, INT) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.get_event_challenge_standings(UUID, TEXT, TEXT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_challenge_standings(UUID, TEXT, TEXT, INT) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.get_event_recap(UUID, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_recap(UUID, INT) TO authenticated;


### PR DESCRIPTION
## Summary
- Migration **`024`**: `events`, `event_challenges`, `event_scores`, trigger on validated scores, RPCs standings/recap/admin upsert
- Admin `/app/admin/events` — schedule 1–5 challenges, event types, window, status
- User `/app/events` + `/app/events/[slug]` — division leaderboards, challenge links, recap when completed
- Overview card for active micro-events · i18n EN/FR · unit tests

Fixes #92

## Test plan
- [ ] Apply migration `024` on Supabase
- [ ] Admin: create event `active` with 2 approved challenges
- [ ] Submit validated score during window → appears in event leaderboard (viewer division)
- [ ] Set event `completed` → recap shows top 3 per division
- [ ] `pnpm check` green

## Ops
Apply prod migrations in order: **`022`** → **`023`** → **`024`**

Made with [Cursor](https://cursor.com)