### PR TITLE
feat(growth): V2-11 growth loops (#94)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -15,6 +15,10 @@ NEXT_PUBLIC_SITE_URL=https://truegrynd.vercel.app
 E2E_TEST_EMAIL=test@example.com
 E2E_TEST_PASSWORD=testpassword123
 
+# Optional analytics (V2-11 growth loops — PostHog HTTP capture)
+# NEXT_PUBLIC_POSTHOG_KEY=phc_...
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
 # --- Admin AI triage (Supabase Edge Function, not Vercel) ---
 # Deploy: supabase functions deploy admin-challenge-ai-review
 # Secrets (Supabase Dashboard → Project → Edge Functions → Secrets):

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -713,11 +713,11 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-11. Growth Loops
 
-- [ ] **Finisher cards V2** : division, rating delta, faction contribution, weekly badge.
-- [ ] **Invitations** : inviter quelqu'un sur un rival match ou weekly challenge.
-- [ ] **Comeback weeks** : relancer ceux qui ont raté 1-2 semaines sans culpabilisation.
-- [ ] **Referral V2** : faction + division context (“Join Horde Rookie Week”).
-- [ ] **Analytics** : mesurer share → signup → first score.
+- [x] **Finisher cards V2** : division, rating delta, faction contribution, weekly/event badge, tagline faction+division.
+- [x] **Invitations** : share link rival match + weekly challenge (Overview, rival detail).
+- [x] **Comeback weeks** : banner Overview si 1–2 semaines d'inactivité (+ event comeback_week).
+- [x] **Referral V2** : `?faction=&division=&weekly=` + capture auth/onboarding.
+- [x] **Analytics** : events share/signup/first score (PostHog HTTP optionnel).
 
 ### V2-12. Monétisation Exploratoire
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -83,8 +83,8 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 - [x] **V2-07** — Rival Matches (1v1 / petits groupes) — 🟢 [#85](https://github.com/igorms-pro/truegrynd/issues/85) · PR1–3 [#86](https://github.com/igorms-pro/truegrynd/pull/86) [#87](https://github.com/igorms-pro/truegrynd/pull/87) [#88](https://github.com/igorms-pro/truegrynd/pull/88) · PR4 [#89](https://github.com/igorms-pro/truegrynd/pull/89) · migrations **`021`** **`022`** prod
 - [x] **V2-08** — Team Wars / Faction Wars par division — 🟢 [#90](https://github.com/igorms-pro/truegrynd/issues/90) PR [#91](https://github.com/igorms-pro/truegrynd/pull/91) · migration **`023`** prod
 - [x] **V2-09** — Micro-events async (24h / 7j / 30j) — 🟢 [#92](https://github.com/igorms-pro/truegrynd/issues/92) PR [#93](https://github.com/igorms-pro/truegrynd/pull/93) · migration **`024`** prod
-- [ ] **V2-10** — Proof Levels — 🟡 [#95](https://github.com/igorms-pro/truegrynd/issues/95) PR [#96](https://github.com/igorms-pro/truegrynd/pull/96) · migration **`027`** prod
-- [ ] **V2-11** — Growth loops (cards, invitations, comeback weeks) — [#94](https://github.com/igorms-pro/truegrynd/issues/94)
+- [x] **V2-10** — Proof Levels — 🟢 [#95](https://github.com/igorms-pro/truegrynd/issues/95) PR [#96](https://github.com/igorms-pro/truegrynd/pull/96) · migration **`027`** prod
+- [ ] **V2-11** — Growth loops (cards, invitations, comeback weeks) — 🟡 [#94](https://github.com/igorms-pro/truegrynd/issues/94)
 - [ ] **V2-12** — Monétisation exploratoire (après signal d'usage)
 
 ---
@@ -709,7 +709,7 @@ Branche : `chore/issue-69-production-hardening`
 - [x] **Règles** : filtres LB `video_ranked+` / `community_verified+` / `judge_verified`.
 - [x] **Admin/judge** : `/app/admin/proof` + RPC `admin_set_score_proof_level`.
 - [x] **Trust** : signalement score sur leaderboard (table `reports` existante).
-- [ ] **Ops** : merge PR + QA prod.
+- [x] **Ops** : merge PR [#96](https://github.com/igorms-pro/truegrynd/pull/96) + migration **`027`** prod.
 
 ### V2-11. Growth Loops
 
@@ -765,10 +765,11 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | **Post-QA polish (#67)**                      | 🟢 [#67](https://github.com/igorms-pro/truegrynd/issues/67) mergé — PR [#68](https://github.com/igorms-pro/truegrynd/pull/68) ; migration **`014`** prod                                                                                            |
 | **Production hardening (#69)**                | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70) — section **L**                                                                                                               |
 | **V2 — Accessible competition**               | 🟢 V2-00–09 [#92](https://github.com/igorms-pro/truegrynd/issues/92) PR [#93](https://github.com/igorms-pro/truegrynd/pull/93) · prod migrations **`015`–`026`** (Jun 2026 — drift repair + **`026`** micro-events backfill)                        |
-| **V2-10 — Proof levels**                      | 🟡 [#95](https://github.com/igorms-pro/truegrynd/issues/95) PR [#96](https://github.com/igorms-pro/truegrynd/pull/96) · migration **`027`** prod                                                                                                    |
+| **V2-10 — Proof levels**                      | 🟢 [#95](https://github.com/igorms-pro/truegrynd/issues/95) PR [#96](https://github.com/igorms-pro/truegrynd/pull/96) · migration **`027`** prod                                                                                                    |
+| **V2-11 — Growth loops**                      | 🟡 [#94](https://github.com/igorms-pro/truegrynd/issues/94) · branche `feature/issue-94-growth-loops`                                                                                                                                               |
 | **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                        |
 
-**Suite produit :** merge **V2-10** ([#95](https://github.com/igorms-pro/truegrynd/issues/95)) → QA proof badges / filtres LB / admin proof → **V2-11** growth ([#94](https://github.com/igorms-pro/truegrynd/issues/94)).
+**Suite produit :** **V2-11** growth ([#94](https://github.com/igorms-pro/truegrynd/issues/94)) — finisher V2, invitations rival/weekly, comeback weeks, referral contextuel.
 
 ---
 

--- a/src/app/[locale]/auth/page.tsx
+++ b/src/app/[locale]/auth/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { AuthScreen } from '@/features/auth/components/AuthScreen';
+import { ReferralCapture } from '@/features/growth/components/ReferralCapture';
 
 function AuthPageFallback() {
   const t = useTranslations('auth');
@@ -17,6 +18,7 @@ function AuthPageFallback() {
 export default function AuthPage() {
   return (
     <Suspense fallback={<AuthPageFallback />}>
+      <ReferralCapture />
       <AuthScreen />
     </Suspense>
   );

--- a/src/features/factions/components/ClanScreen.tsx
+++ b/src/features/factions/components/ClanScreen.tsx
@@ -6,6 +6,10 @@ import { ClanArenaCta } from '@/features/factions/components/ClanArenaCta';
 import { ClanFactionWarCard } from '@/features/factions/components/ClanFactionWarCard';
 import { ClanTopMembersCard } from '@/features/factions/components/ClanTopMembersCard';
 import { RecruitCta } from '@/features/factions/components/RecruitCta';
+import {
+  resolveWeeklyDisplayLabel,
+  useWeeklyChallenge,
+} from '@/features/overview/hooks/useWeeklyChallenge';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { useClanHud } from '@/features/factions/hooks/useClanHud';
 
@@ -14,8 +18,13 @@ export function ClanScreen() {
   const t = useTranslations('clan');
 
   const { state, refetch } = useClanHud();
+  const { state: weeklyState } = useWeeklyChallenge();
   const appProfile = useOptionalAppProfile();
   const currentUserId = appProfile?.id ?? null;
+  const weeklyLabel =
+    weeklyState.status === 'ready' && weeklyState.weekly
+      ? resolveWeeklyDisplayLabel(weeklyState.weekly)
+      : null;
 
   return (
     <section className="space-y-6">
@@ -50,6 +59,8 @@ export function ClanScreen() {
         <RecruitCta
           faction={state.faction}
           siteUrl={process.env.NEXT_PUBLIC_SITE_URL ?? 'https://truegrynd.app'}
+          division={appProfile?.division ?? null}
+          weeklyLabel={weeklyLabel}
         />
       ) : null}
 

--- a/src/features/factions/components/RecruitCta.tsx
+++ b/src/features/factions/components/RecruitCta.tsx
@@ -3,50 +3,88 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
-import { buildReferralUrl } from '@/features/factions/lib/referral';
+import {
+  buildReferralShareCopy,
+  buildReferralUrl,
+  type ReferralParams,
+} from '@/features/factions/lib/referral';
 import { getFactionBadgeClasses } from '@/lib/factionStyles';
-import type { Faction } from '@/lib/types/database.types';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+import type { Division, Faction } from '@/lib/types/database.types';
 
 type Props = {
   faction: Faction;
   siteUrl: string;
+  division?: Division | null;
+  weeklyLabel?: string | null;
 };
 
-export function RecruitCta({ faction, siteUrl }: Props) {
+export function RecruitCta({ faction, siteUrl, division = null, weeklyLabel = null }: Props) {
   const t = useTranslations('clan.recruit');
   const tFaction = useTranslations('clan.faction');
   const [copied, setCopied] = useState(false);
 
-  const referralUrl = buildReferralUrl(siteUrl, faction);
+  const referralParams = useMemo((): ReferralParams => {
+    const params: ReferralParams = { faction };
+    if (division) params.division = division;
+    if (weeklyLabel) params.weekly = weeklyLabel;
+    return params;
+  }, [division, faction, weeklyLabel]);
+
+  const referralUrl = buildReferralUrl(siteUrl, referralParams);
+  const shareCopy = buildReferralShareCopy(referralParams);
   const factionName = tFaction(faction);
-  const factionParams = useMemo(() => ({ faction: factionName }), [factionName]);
+  const shareParams = useMemo(
+    () => ({
+      faction: factionName,
+      division: division?.toUpperCase() ?? '',
+      weekly: weeklyLabel ?? '',
+    }),
+    [division, factionName, weeklyLabel],
+  );
   const factionStyles = getFactionBadgeClasses(faction);
+
+  const shareTitle =
+    shareCopy.titleKey === 'contextual'
+      ? t('shareTitleContextual', shareParams)
+      : t('shareTitle', { faction: factionName });
+  const shareText =
+    shareCopy.textKey === 'contextual'
+      ? t('shareTextContextual', shareParams)
+      : t('shareText', { faction: factionName });
+
+  const trackShare = useCallback(() => {
+    trackEvent(ANALYTICS_EVENTS.shareReferral, {
+      faction,
+      division: division ?? '',
+      weekly: weeklyLabel ?? '',
+    });
+  }, [division, faction, weeklyLabel]);
 
   const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(referralUrl);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+      trackShare();
     } catch {
       /* clipboard not available */
     }
-  }, [referralUrl]);
+  }, [referralUrl, trackShare]);
 
   const handleShare = useCallback(async () => {
     if (typeof navigator.share === 'function') {
       try {
-        await navigator.share({
-          title: t('shareTitle', factionParams),
-          text: t('shareText', factionParams),
-          url: referralUrl,
-        });
+        await navigator.share({ title: shareTitle, text: shareText, url: referralUrl });
+        trackShare();
       } catch {
         /* user cancelled or not supported */
       }
     } else {
       await handleCopy();
     }
-  }, [factionParams, handleCopy, referralUrl, t]);
+  }, [handleCopy, referralUrl, shareText, shareTitle, trackShare]);
 
   return (
     <article
@@ -65,7 +103,7 @@ export function RecruitCta({ faction, siteUrl }: Props) {
         <button
           type="button"
           onClick={() => void handleShare()}
-          aria-label={t('shareAria', factionParams)}
+          aria-label={t('shareAria', { faction: factionName })}
           className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {t('share')}

--- a/src/features/factions/lib/referral.test.ts
+++ b/src/features/factions/lib/referral.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildReferralUrl, parseReferralFaction } from '@/features/factions/lib/referral';
+import {
+  buildReferralUrl,
+  parseReferralDivision,
+  parseReferralFaction,
+  parseReferralParams,
+} from '@/features/factions/lib/referral';
 
 describe('parseReferralFaction', () => {
   it('returns valid factions', () => {
@@ -16,15 +21,47 @@ describe('parseReferralFaction', () => {
   });
 });
 
+describe('parseReferralDivision', () => {
+  it('returns valid divisions', () => {
+    expect(parseReferralDivision('rookie')).toBe('rookie');
+    expect(parseReferralDivision('elite')).toBe('elite');
+  });
+
+  it('rejects invalid values', () => {
+    expect(parseReferralDivision('legend')).toBeNull();
+  });
+});
+
+describe('parseReferralParams', () => {
+  it('parses full referral context from search params', () => {
+    const params = new URLSearchParams(
+      'faction=horde&division=rookie&weekly=W22&event=comeback&rival=match-1',
+    );
+    expect(parseReferralParams(params)).toEqual({
+      faction: 'horde',
+      division: 'rookie',
+      weekly: 'W22',
+      event: 'comeback',
+      rival: 'match-1',
+    });
+  });
+});
+
 describe('buildReferralUrl', () => {
   it('appends faction param', () => {
     const url = buildReferralUrl('https://truegrynd.app', 'horde');
     expect(url).toBe('https://truegrynd.app/?faction=horde');
   });
 
-  it('preserves existing params', () => {
-    const url = buildReferralUrl('https://truegrynd.app?x=1', 'nomads');
+  it('preserves existing params and adds context', () => {
+    const url = buildReferralUrl('https://truegrynd.app?x=1', {
+      faction: 'nomads',
+      division: 'regular',
+      weekly: 'W22',
+    });
     expect(url).toContain('x=1');
     expect(url).toContain('faction=nomads');
+    expect(url).toContain('division=regular');
+    expect(url).toContain('weekly=W22');
   });
 });

--- a/src/features/factions/lib/referral.ts
+++ b/src/features/factions/lib/referral.ts
@@ -1,55 +1,160 @@
-import type { Faction } from '@/lib/types/database.types';
+import { isDivision } from '@/lib/divisions';
+import type { Division, Faction } from '@/lib/types/database.types';
 
-const STORAGE_KEY = 'tg_referral_faction';
+const STORAGE_KEY = 'tg_referral_context';
+const LEGACY_STORAGE_KEY = 'tg_referral_faction';
 const TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 const VALID_FACTIONS: ReadonlySet<string> = new Set<string>(['nomads', 'horde', 'iron_alliance']);
 
-type StoredReferral = {
+export type ReferralParams = {
   faction: Faction;
+  division?: Division;
+  weekly?: string;
+  event?: string;
+  rival?: string;
+};
+
+type StoredReferral = ReferralParams & {
   expiresAt: number;
 };
 
+function isValidFaction(value: string): value is Faction {
+  return VALID_FACTIONS.has(value);
+}
+
 export function parseReferralFaction(value: string | null): Faction | null {
-  if (!value || !VALID_FACTIONS.has(value)) return null;
-  return value as Faction;
+  if (!value || !isValidFaction(value)) return null;
+  return value;
 }
 
-export function storeReferralFaction(faction: Faction): void {
-  try {
-    const entry: StoredReferral = { faction, expiresAt: Date.now() + TTL_MS };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
-  } catch {
-    /* quota or private mode — ignore */
-  }
+export function parseReferralDivision(value: string | null): Division | null {
+  if (!value || !isDivision(value)) return null;
+  return value;
 }
 
-export function loadReferralFaction(): Faction | null {
+export function parseReferralParams(searchParams: URLSearchParams): ReferralParams | null {
+  const faction = parseReferralFaction(searchParams.get('faction'));
+  if (!faction) return null;
+
+  const division = parseReferralDivision(searchParams.get('division'));
+  const weekly = searchParams.get('weekly')?.trim() || undefined;
+  const event = searchParams.get('event')?.trim() || undefined;
+  const rival = searchParams.get('rival')?.trim() || undefined;
+
+  return {
+    faction,
+    ...(division ? { division } : {}),
+    ...(weekly ? { weekly } : {}),
+    ...(event ? { event } : {}),
+    ...(rival ? { rival } : {}),
+  };
+}
+
+function readStoredReferral(): StoredReferral | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const entry = JSON.parse(raw) as StoredReferral;
-    if (!entry.faction || !VALID_FACTIONS.has(entry.faction)) return null;
-    if (Date.now() > entry.expiresAt) {
-      localStorage.removeItem(STORAGE_KEY);
+    if (raw) {
+      const entry = JSON.parse(raw) as StoredReferral;
+      if (!entry.faction || !isValidFaction(entry.faction)) return null;
+      if (Date.now() > entry.expiresAt) {
+        localStorage.removeItem(STORAGE_KEY);
+        return null;
+      }
+      return entry;
+    }
+
+    const legacyRaw = localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (!legacyRaw) return null;
+    const legacy = JSON.parse(legacyRaw) as { faction: Faction; expiresAt: number };
+    if (!legacy.faction || !isValidFaction(legacy.faction)) return null;
+    if (Date.now() > legacy.expiresAt) {
+      localStorage.removeItem(LEGACY_STORAGE_KEY);
       return null;
     }
-    return entry.faction;
+    return { faction: legacy.faction, expiresAt: legacy.expiresAt };
   } catch {
     return null;
   }
 }
 
-export function clearReferralFaction(): void {
+export function storeReferralContext(params: ReferralParams): void {
+  try {
+    const entry: StoredReferral = { ...params, expiresAt: Date.now() + TTL_MS };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    /* quota or private mode */
+  }
+}
+
+export function storeReferralFaction(faction: Faction): void {
+  storeReferralContext({ faction });
+}
+
+export function loadReferralContext(): ReferralParams | null {
+  const entry = readStoredReferral();
+  if (!entry) return null;
+  return {
+    faction: entry.faction,
+    ...(entry.division ? { division: entry.division } : {}),
+    ...(entry.weekly ? { weekly: entry.weekly } : {}),
+    ...(entry.event ? { event: entry.event } : {}),
+    ...(entry.rival ? { rival: entry.rival } : {}),
+  };
+}
+
+export function loadReferralFaction(): Faction | null {
+  return loadReferralContext()?.faction ?? null;
+}
+
+export function clearReferralContext(): void {
   try {
     localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
   } catch {
     /* ignore */
   }
 }
 
-export function buildReferralUrl(baseUrl: string, faction: Faction): string {
+export function clearReferralFaction(): void {
+  clearReferralContext();
+}
+
+export function buildReferralUrl(baseUrl: string, params: ReferralParams | Faction): string {
+  const context: ReferralParams = typeof params === 'string' ? { faction: params } : params;
   const url = new URL(baseUrl);
-  url.searchParams.set('faction', faction);
+  url.searchParams.set('faction', context.faction);
+  if (context.division) url.searchParams.set('division', context.division);
+  if (context.weekly) url.searchParams.set('weekly', context.weekly);
+  if (context.event) url.searchParams.set('event', context.event);
+  if (context.rival) url.searchParams.set('rival', context.rival);
   return url.toString();
+}
+
+export function buildReferralShareCopy(params: ReferralParams): {
+  titleKey: 'contextual' | 'default';
+  textKey: 'contextual' | 'default';
+  titleParams: Record<string, string>;
+  textParams: Record<string, string>;
+} {
+  const factionName = params.faction.replace('_', ' ').toUpperCase();
+  const divisionName = params.division?.toUpperCase() ?? '';
+  const weeklyLabel = params.weekly ?? '';
+
+  if (params.division || params.weekly) {
+    return {
+      titleKey: 'contextual',
+      textKey: 'contextual',
+      titleParams: { faction: factionName, division: divisionName, weekly: weeklyLabel },
+      textParams: { faction: factionName, division: divisionName, weekly: weeklyLabel },
+    };
+  }
+
+  return {
+    titleKey: 'default',
+    textKey: 'default',
+    titleParams: { faction: factionName },
+    textParams: { faction: factionName },
+  };
 }

--- a/src/features/finisher-card/components/FinishPageContent.tsx
+++ b/src/features/finisher-card/components/FinishPageContent.tsx
@@ -33,6 +33,10 @@ export function FinishPageContent() {
       scoreValue: ready.score.value,
       topPercent: ready.topPercent,
       weeklyBadge: ready.weeklyBadge ?? undefined,
+      eventBadge: ready.eventBadge ?? undefined,
+      tagline: ready.tagline,
+      ratingDeltaText: ready.ratingDeltaText ?? undefined,
+      warPointsText: ready.warPointsText ?? undefined,
       ranked,
       isValidated: ready.score.is_validated,
     });

--- a/src/features/finisher-card/components/FinisherCardActions.tsx
+++ b/src/features/finisher-card/components/FinisherCardActions.tsx
@@ -8,6 +8,8 @@ import {
   downloadBlob,
   sharePngBlob,
 } from '@/features/finisher-card/lib/canvasPng';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
 
 type Props = {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
@@ -45,6 +47,7 @@ export function FinisherCardActions({ canvasRef, disabled }: Props) {
       const blob = await getBlob();
       if (!blob) return;
       await sharePngBlob(blob, 'truegrynd-finisher.png');
+      trackEvent(ANALYTICS_EVENTS.shareFinisher, { surface: 'finish_page' });
     } finally {
       setWorking(false);
     }

--- a/src/features/finisher-card/hooks/useFinisherCard.test.ts
+++ b/src/features/finisher-card/hooks/useFinisherCard.test.ts
@@ -31,6 +31,12 @@ vi.mock('@/features/overview/hooks/useWeeklyChallenge', () => ({
   resolveWeeklyDisplayLabel: () => 'W22 · 2026',
 }));
 
+vi.mock('@/features/finisher-card/services/growthExtras', () => ({
+  fetchRatingDeltaNearSubmit: vi.fn().mockResolvedValue(null),
+  fetchActiveEventBadgeForChallenge: vi.fn().mockResolvedValue(null),
+  resolveFactionWarPoints: vi.fn().mockReturnValue(null),
+}));
+
 vi.mock('@/features/appshell', () => ({
   useRequireAppAccess: () => useRequireAppAccessMock(),
 }));

--- a/src/features/finisher-card/hooks/useFinisherCard.ts
+++ b/src/features/finisher-card/hooks/useFinisherCard.ts
@@ -3,11 +3,21 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useRequireAppAccess } from '@/features/appshell';
+import {
+  fetchActiveEventBadgeForChallenge,
+  fetchRatingDeltaNearSubmit,
+  resolveFactionWarPoints,
+} from '@/features/finisher-card/services/growthExtras';
+import { getScoreById } from '@/features/finisher-card/services/scores';
+import { resolveWeeklyDisplayLabel } from '@/features/overview/hooks/useWeeklyChallenge';
+import {
+  buildFinisherTagline,
+  formatRatingDelta,
+  formatWarPoints,
+} from '@/lib/growth/finisherTagline';
 import { getChallengeById } from '@/lib/challenges';
 import { formatTopPercent, getRankCounts, percentileFromCounts } from '@/lib/rank';
 import { getWeeklyChallengeForChallengeId } from '@/lib/weekly';
-import { resolveWeeklyDisplayLabel } from '@/features/overview/hooks/useWeeklyChallenge';
-import { getScoreById } from '@/features/finisher-card/services/scores';
 import type { Challenge, Division, Faction, Score } from '@/lib/types/database.types';
 
 type Params = {
@@ -30,6 +40,10 @@ export type FinisherCardState =
       faction: Faction;
       division: Division;
       weeklyBadge: string | null;
+      eventBadge: string | null;
+      tagline: string;
+      ratingDeltaText: string | null;
+      warPointsText: string | null;
     };
 
 type InnerState = Exclude<FinisherCardState, { status: 'gated' } | { status: 'missing_params' }>;
@@ -104,11 +118,26 @@ export function useFinisherCard(params: Params): FinisherCardState & { retry: ()
         const weeklyBadge = weekly ? resolveWeeklyDisplayLabel(weekly) : null;
         if (cancelled) return;
 
+        const [ratingDelta, eventBadge] = await Promise.all([
+          score.is_validated
+            ? fetchRatingDeltaNearSubmit(userId, score.submitted_at)
+            : Promise.resolve(null),
+          fetchActiveEventBadgeForChallenge(challenge.id),
+        ]);
+        if (cancelled) return;
+
         const { username, faction, division } = access.profile;
         if (!username || !faction) {
           setState({ status: 'error', message: 'profile_incomplete' });
           return;
         }
+
+        const warPoints = resolveFactionWarPoints(
+          score.is_validated,
+          score.value,
+          challenge.score_type,
+          Boolean(weekly),
+        );
 
         setState({
           status: 'ready',
@@ -119,6 +148,10 @@ export function useFinisherCard(params: Params): FinisherCardState & { retry: ()
           faction,
           division,
           weeklyBadge,
+          eventBadge,
+          tagline: buildFinisherTagline(faction, division),
+          ratingDeltaText: ratingDelta !== null ? formatRatingDelta(ratingDelta) : null,
+          warPointsText: warPoints !== null ? formatWarPoints(warPoints) : null,
         });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : 'unknown';

--- a/src/features/finisher-card/lib/drawCard.ts
+++ b/src/features/finisher-card/lib/drawCard.ts
@@ -87,7 +87,26 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
   ctx.font = `900 ${brandSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
   ctx.fillText('TRUEGRYND', textX, lineY(0.04));
 
-  const titleStartPct = options.weeklyBadge ? 0.1 : 0.13;
+  let badgeOffset = 0;
+  if (options.tagline) {
+    const taglineSize = fitFontSize(
+      ctx,
+      options.tagline,
+      maxTextW,
+      900,
+      'system-ui, -apple-system, Segoe UI, sans-serif',
+      Math.floor(innerW * 0.045),
+      10,
+    );
+    ctx.fillStyle = accent;
+    ctx.font = `900 ${taglineSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+    ctx.fillText(truncateToWidth(ctx, options.tagline, maxTextW), textX, lineY(0.085));
+    badgeOffset = 0.035;
+  }
+
+  const titleStartPct =
+    options.weeklyBadge || options.eventBadge ? 0.1 + badgeOffset : 0.13 + badgeOffset;
+  let badgeY = 0.085 + badgeOffset;
   if (options.weeklyBadge) {
     const weeklySize = fitFontSize(
       ctx,
@@ -103,8 +122,24 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
     ctx.fillText(
       truncateToWidth(ctx, options.weeklyBadge.toUpperCase(), maxTextW),
       textX,
-      lineY(0.085),
+      lineY(badgeY),
     );
+    badgeY += 0.035;
+  }
+
+  if (options.eventBadge) {
+    const eventSize = fitFontSize(
+      ctx,
+      options.eventBadge,
+      maxTextW,
+      900,
+      'system-ui, -apple-system, Segoe UI, sans-serif',
+      Math.floor(innerW * 0.05),
+      10,
+    );
+    ctx.fillStyle = '#ffb800';
+    ctx.font = `900 ${eventSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
+    ctx.fillText(truncateToWidth(ctx, options.eventBadge, maxTextW), textX, lineY(badgeY));
   }
 
   const titleSize = fitFontSize(
@@ -145,9 +180,10 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
   const labelY = compact ? lineY(0.54) : lineY(0.52);
   const rankY = compact ? lineY(0.6) : lineY(0.58);
   const rankSubY = compact ? lineY(0.66) : lineY(0.68);
-  const usernameY = compact ? lineY(0.76) : lineY(0.78);
-  const divisionY = compact ? lineY(0.82) : lineY(0.83);
-  const factionY = compact ? lineY(0.88) : lineY(0.89);
+  const hasGrowth = Boolean(options.ratingDeltaText || options.warPointsText);
+  const usernameY = compact ? lineY(hasGrowth ? 0.78 : 0.76) : lineY(hasGrowth ? 0.8 : 0.78);
+  const divisionY = compact ? lineY(hasGrowth ? 0.84 : 0.82) : lineY(hasGrowth ? 0.85 : 0.83);
+  const factionY = compact ? lineY(hasGrowth ? 0.9 : 0.88) : lineY(hasGrowth ? 0.91 : 0.89);
 
   const labelSize = Math.floor(innerW * (compact ? 0.06 : 0.072));
   ctx.fillStyle = muted;
@@ -185,6 +221,15 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
   ctx.font = `900 ${rankSubSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
   const rankSubLine = truncateToWidth(ctx, rankSub, maxTextW);
   ctx.fillText(rankSubLine, textX, rankSubY);
+
+  const growthY = compact ? lineY(0.72) : lineY(0.74);
+  if (hasGrowth) {
+    const growthText = [options.ratingDeltaText, options.warPointsText].filter(Boolean).join(' · ');
+    const growthSize = Math.floor(innerW * (compact ? 0.045 : 0.05));
+    ctx.fillStyle = '#ffb800';
+    ctx.font = `900 ${growthSize}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`;
+    ctx.fillText(truncateToWidth(ctx, growthText, maxTextW), textX, growthY);
+  }
 
   const usernameSize = Math.floor(innerW * (compact ? 0.06 : 0.072));
   ctx.fillStyle = accent;

--- a/src/features/finisher-card/services/growthExtras.ts
+++ b/src/features/finisher-card/services/growthExtras.ts
@@ -1,0 +1,61 @@
+import { supabase } from '@/lib/supabase';
+import type { ScoreType } from '@/lib/types/database.types';
+import { factionWarContributionPoints } from '@/features/factions/lib/factionWarPoints';
+
+type HistoryRow = {
+  rating_global: number;
+  recorded_at: string;
+};
+
+const SUBMIT_WINDOW_MS = 10 * 60 * 1000;
+
+export async function fetchRatingDeltaNearSubmit(
+  userId: string,
+  submittedAt: string,
+): Promise<number | null> {
+  const { data, error } = await supabase
+    .from('profile_rating_history')
+    .select('rating_global, recorded_at')
+    .eq('user_id', userId)
+    .order('recorded_at', { ascending: false })
+    .limit(2);
+
+  if (error || !data || data.length < 2) return null;
+
+  const [latest, previous] = data as HistoryRow[];
+  const submitTime = new Date(submittedAt).getTime();
+  const latestTime = new Date(latest.recorded_at).getTime();
+  if (Math.abs(latestTime - submitTime) > SUBMIT_WINDOW_MS) return null;
+
+  const delta = Number(latest.rating_global) - Number(previous.rating_global);
+  if (Math.abs(delta) < 0.01) return null;
+  return Math.round(delta * 10) / 10;
+}
+
+export async function fetchActiveEventBadgeForChallenge(
+  challengeId: string,
+): Promise<string | null> {
+  const nowIso = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('events')
+    .select('title, event_type, event_challenges!inner(challenge_id)')
+    .eq('status', 'active')
+    .lte('starts_at', nowIso)
+    .gt('ends_at', nowIso)
+    .eq('event_challenges.challenge_id', challengeId)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return String(data.title).toUpperCase();
+}
+
+export function resolveFactionWarPoints(
+  isValidated: boolean,
+  scoreValue: number,
+  scoreType: ScoreType,
+  hasActiveWeekly: boolean,
+): number | null {
+  if (!isValidated || !hasActiveWeekly) return null;
+  return factionWarContributionPoints(scoreValue, scoreType);
+}

--- a/src/features/growth/components/ComebackWeekBanner.tsx
+++ b/src/features/growth/components/ComebackWeekBanner.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+type Props = {
+  weeksAway: number;
+  weeklyChallengeId: string | null;
+  hasComebackEvent: boolean;
+};
+
+export function ComebackWeekBanner({ weeksAway, weeklyChallengeId, hasComebackEvent }: Props) {
+  const t = useTranslations('growth.comeback');
+  const locale = useLocale();
+
+  const ctaHref = weeklyChallengeId
+    ? `/${locale}/app/arena/${weeklyChallengeId}`
+    : `/${locale}/app/arena`;
+
+  return (
+    <article className="rounded-md border border-l-4 border-accent/60 border-border bg-card p-4">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-accent">
+        {hasComebackEvent ? t('eventKicker') : t('kicker')}
+      </p>
+      <p className="mt-2 text-sm text-foreground">{t('body', { weeks: weeksAway })}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{t('hint')}</p>
+      <Link
+        href={ctaHref}
+        className="mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t('cta')}
+      </Link>
+    </article>
+  );
+}

--- a/src/features/growth/components/ReferralCapture.tsx
+++ b/src/features/growth/components/ReferralCapture.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+import { parseReferralParams, storeReferralContext } from '@/features/factions/lib/referral';
+
+export function ReferralCapture(): null {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const params = parseReferralParams(searchParams);
+    if (params) storeReferralContext(params);
+  }, [searchParams]);
+
+  return null;
+}

--- a/src/features/growth/components/RivalMatchShareInvite.tsx
+++ b/src/features/growth/components/RivalMatchShareInvite.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { ShareInviteButton } from '@/features/growth/components/ShareInviteButton';
+import { type ReferralParams } from '@/features/factions/lib/referral';
+import { buildRivalInviteUrl } from '@/lib/growth/inviteLinks';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+import type { Division, Faction } from '@/lib/types/database.types';
+
+type Props = {
+  matchId: string;
+  faction: Faction | null;
+  division: Division | null;
+};
+
+export function RivalMatchShareInvite({ matchId, faction, division }: Props) {
+  const t = useTranslations('growth.rivalInvite');
+  const locale = useLocale();
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://truegrynd.app';
+
+  const inviteUrl = useMemo(() => {
+    if (!faction) return null;
+    const params: ReferralParams = { faction, ...(division ? { division } : {}) };
+    return buildRivalInviteUrl(siteUrl, locale, matchId, params);
+  }, [division, faction, locale, matchId, siteUrl]);
+
+  if (!inviteUrl) return null;
+
+  return (
+    <article className="rounded-md border border-border bg-card p-4">
+      <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">{t('title')}</p>
+      <p className="mt-2 text-sm text-muted-foreground">{t('body')}</p>
+      <p
+        className="mt-3 break-all rounded-md border border-border bg-muted/40 px-3 py-2 font-mono text-xs text-foreground"
+        title={inviteUrl}
+      >
+        {inviteUrl}
+      </p>
+      <div className="mt-3">
+        <ShareInviteButton
+          url={inviteUrl}
+          shareTitle={t('shareTitle')}
+          shareText={t('shareText')}
+          shareAria={t('shareAria')}
+          copyAria={t('copyAria')}
+          onShare={() => trackEvent(ANALYTICS_EVENTS.shareRivalInvite, { matchId })}
+          onCopy={() => trackEvent(ANALYTICS_EVENTS.shareRivalInvite, { matchId })}
+        />
+      </div>
+    </article>
+  );
+}

--- a/src/features/growth/components/ShareInviteButton.tsx
+++ b/src/features/growth/components/ShareInviteButton.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+type Props = {
+  url: string;
+  shareTitle: string;
+  shareText: string;
+  shareAria: string;
+  copyAria: string;
+  analyticsEvent?: string;
+  analyticsProps?: Record<string, string>;
+  onShare?: () => void;
+  onCopy?: () => void;
+};
+
+export function ShareInviteButton({
+  url,
+  shareTitle,
+  shareText,
+  shareAria,
+  copyAria,
+  analyticsEvent,
+  analyticsProps,
+  onShare,
+  onCopy,
+}: Props) {
+  const t = useTranslations('growth.share');
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      onCopy?.();
+    } catch {
+      /* clipboard unavailable */
+    }
+  }, [onCopy, url]);
+
+  const handleShare = useCallback(async () => {
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ title: shareTitle, text: shareText, url });
+        onShare?.();
+      } catch {
+        /* cancelled */
+      }
+    } else {
+      await handleCopy();
+    }
+  }, [handleCopy, onShare, shareText, shareTitle, url]);
+
+  const shareDataAttrs = useMemo(() => {
+    if (!analyticsEvent) return {};
+    return {
+      'data-analytics-event': analyticsEvent,
+      'data-analytics-props': JSON.stringify(analyticsProps ?? {}),
+    };
+  }, [analyticsEvent, analyticsProps]);
+
+  return (
+    <div className="flex flex-wrap gap-2" {...shareDataAttrs}>
+      <button
+        type="button"
+        onClick={() => void handleShare()}
+        aria-label={shareAria}
+        className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t('share')}
+      </button>
+      <button
+        type="button"
+        onClick={() => void handleCopy()}
+        aria-label={copyAria}
+        className="inline-flex min-h-11 items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {copied ? t('copied') : t('copy')}
+      </button>
+    </div>
+  );
+}

--- a/src/features/growth/components/WeeklyChallengeInvite.tsx
+++ b/src/features/growth/components/WeeklyChallengeInvite.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { ShareInviteButton } from '@/features/growth/components/ShareInviteButton';
+import { type ReferralParams } from '@/features/factions/lib/referral';
+import { buildWeeklyInviteUrl } from '@/lib/growth/inviteLinks';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+import type { Division, Faction } from '@/lib/types/database.types';
+
+type Props = {
+  challengeId: string;
+  faction: Faction;
+  division: Division;
+  weeklyLabel: string;
+};
+
+export function WeeklyChallengeInvite({ challengeId, faction, division, weeklyLabel }: Props) {
+  const t = useTranslations('growth.weeklyInvite');
+  const locale = useLocale();
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://truegrynd.app';
+
+  const inviteUrl = useMemo(() => {
+    const params: ReferralParams = { faction, division, weekly: weeklyLabel };
+    return buildWeeklyInviteUrl(siteUrl, locale, challengeId, params);
+  }, [challengeId, division, faction, locale, siteUrl, weeklyLabel]);
+
+  return (
+    <div className="rounded-md border border-border bg-muted/30 p-3">
+      <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('title')}
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground">{t('body')}</p>
+      <div className="mt-3">
+        <ShareInviteButton
+          url={inviteUrl}
+          shareTitle={t('shareTitle', {
+            faction,
+            division: division.toUpperCase(),
+            weekly: weeklyLabel,
+          })}
+          shareText={t('shareText', {
+            faction,
+            division: division.toUpperCase(),
+            weekly: weeklyLabel,
+          })}
+          shareAria={t('shareAria')}
+          copyAria={t('copyAria')}
+          onShare={() =>
+            trackEvent(ANALYTICS_EVENTS.shareWeeklyInvite, {
+              challengeId,
+              faction,
+              division,
+            })
+          }
+          onCopy={() =>
+            trackEvent(ANALYTICS_EVENTS.shareWeeklyInvite, {
+              challengeId,
+              faction,
+              division,
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/growth/index.ts
+++ b/src/features/growth/index.ts
@@ -1,0 +1,5 @@
+export { ComebackWeekBanner } from '@/features/growth/components/ComebackWeekBanner';
+export { ReferralCapture } from '@/features/growth/components/ReferralCapture';
+export { RivalMatchShareInvite } from '@/features/growth/components/RivalMatchShareInvite';
+export { ShareInviteButton } from '@/features/growth/components/ShareInviteButton';
+export { WeeklyChallengeInvite } from '@/features/growth/components/WeeklyChallengeInvite';

--- a/src/features/onboarding/components/OnboardingFlow.tsx
+++ b/src/features/onboarding/components/OnboardingFlow.tsx
@@ -6,11 +6,13 @@ import { useCallback, useEffect, useMemo, type ReactNode } from 'react';
 
 import { useRequireAuth } from '@/features/auth/hooks/useRequireAuth';
 import {
-  clearReferralFaction,
-  loadReferralFaction,
-  parseReferralFaction,
-  storeReferralFaction,
+  clearReferralContext,
+  loadReferralContext,
+  parseReferralParams,
+  storeReferralContext,
 } from '@/features/factions/lib/referral';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
 import { useOnboardingProfile } from '@/features/onboarding/hooks/useOnboardingProfile';
 import type { OnboardingStep } from '@/features/onboarding/lib/onboardingStep';
 import { OnboardingIdentityStep } from '@/features/onboarding/components/OnboardingIdentityStep';
@@ -44,13 +46,13 @@ export function OnboardingFlow() {
     return safeNext ?? `/${locale}/app/overview`;
   }, [locale, searchParams]);
 
-  const referralFaction = useMemo(() => {
-    const fromUrl = parseReferralFaction(searchParams.get('faction'));
+  const referralContext = useMemo(() => {
+    const fromUrl = parseReferralParams(searchParams);
     if (fromUrl) {
-      storeReferralFaction(fromUrl);
+      storeReferralContext(fromUrl);
       return fromUrl;
     }
-    return loadReferralFaction();
+    return loadReferralContext();
   }, [searchParams]);
 
   useEffect(() => {
@@ -125,10 +127,15 @@ export function OnboardingFlow() {
     content = (
       <OnboardingFactionStep
         userId={profile.id}
-        initialFaction={profile.faction ?? referralFaction}
+        initialFaction={profile.faction ?? referralContext?.faction ?? null}
         onBack={handleBack}
         onCompleted={async () => {
-          clearReferralFaction();
+          trackEvent(ANALYTICS_EVENTS.signupCompleted, {
+            faction: referralContext?.faction ?? '',
+            division: referralContext?.division ?? '',
+            weekly: referralContext?.weekly ?? '',
+          });
+          clearReferralContext();
           await reload();
         }}
       />

--- a/src/features/overview/components/OverviewScreen.tsx
+++ b/src/features/overview/components/OverviewScreen.tsx
@@ -11,7 +11,10 @@ import {
 } from '@/features/overview/hooks/useWeeklyChallenge';
 import { EventCard } from '@/features/events/components/EventCard';
 import { useActiveEvents } from '@/features/events/hooks/useActiveEvents';
+import { ComebackWeekBanner } from '@/features/growth/components/ComebackWeekBanner';
+import { WeeklyChallengeInvite } from '@/features/growth/components/WeeklyChallengeInvite';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { getComebackEligibility } from '@/lib/growth/comebackWeek';
 import { getFactionBadgeClasses } from '@/lib/factionStyles';
 import { getWeeklyTimeRemaining } from '@/lib/weekly';
 
@@ -47,6 +50,14 @@ export function OverviewScreen() {
   const weekly = weeklyState.status === 'ready' ? weeklyState.weekly : null;
   const weeklyLabel = weekly ? resolveWeeklyDisplayLabel(weekly) : null;
   const weeklyRemaining = weekly ? getWeeklyTimeRemaining(new Date(weekly.ends_at)) : null;
+  const comeback = readyProfile
+    ? getComebackEligibility(readyProfile.last_activity_at)
+    : { eligible: false, weeksAway: null };
+  const hasComebackEvent =
+    eventsState.status === 'ready' &&
+    eventsState.events.some((event) => event.event_type === 'comeback_week');
+  const siteFaction = userFaction;
+  const userDivision = readyProfile?.division ?? null;
 
   return (
     <section className="space-y-6">
@@ -56,6 +67,14 @@ export function OverviewScreen() {
         </h1>
         <p className="text-sm text-muted-foreground">{tApp('overviewBody')}</p>
       </header>
+
+      {comeback.eligible && comeback.weeksAway !== null ? (
+        <ComebackWeekBanner
+          weeksAway={comeback.weeksAway}
+          weeklyChallengeId={weekly?.challenge.id ?? null}
+          hasComebackEvent={hasComebackEvent}
+        />
+      ) : null}
 
       <div className="grid gap-4 md:grid-cols-2">
         <article className="rounded-md border border-border bg-card p-4">
@@ -105,6 +124,14 @@ export function OverviewScreen() {
                 href={`/${locale}/app/arena/${weekly.challenge.id}`}
                 label={t('ctaGo')}
               />
+              {siteFaction && userDivision && weeklyLabel ? (
+                <WeeklyChallengeInvite
+                  challengeId={weekly.challenge.id}
+                  faction={siteFaction}
+                  division={userDivision}
+                  weeklyLabel={weeklyLabel}
+                />
+              ) : null}
             </div>
           ) : null}
 

--- a/src/features/rivals/components/RivalMatchDetailScreen.tsx
+++ b/src/features/rivals/components/RivalMatchDetailScreen.tsx
@@ -5,6 +5,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { RivalMatchBackLink } from '@/features/rivals/components/RivalMatchBackLink';
 import { RivalMatchChallengeRow } from '@/features/rivals/components/RivalMatchChallengeRow';
 import { RivalMatchResultBanner } from '@/features/rivals/components/RivalMatchResultBanner';
+import { RivalMatchShareInvite } from '@/features/growth/components/RivalMatchShareInvite';
 import { useNowTick } from '@/features/rivals/hooks/useNowTick';
 import { useRivalMatch } from '@/features/rivals/hooks/useRivalMatch';
 import { useProfile } from '@/features/profile/hooks/useProfile';
@@ -22,8 +23,9 @@ export function RivalMatchDetailScreen({ matchId }: Props) {
   const profileState = useProfile();
   const { state, refetch } = useRivalMatch(matchId);
 
-  const currentUserId =
-    profileState.state.status === 'ready' ? profileState.state.profile.id : null;
+  const profile = profileState.state.status === 'ready' ? profileState.state.profile : null;
+
+  const currentUserId = profile?.id ?? null;
 
   const match = state.status === 'ready' ? state.match : null;
   const detail = state.status === 'ready' ? state.detail : null;
@@ -123,6 +125,14 @@ export function RivalMatchDetailScreen({ matchId }: Props) {
         ) : null}
         {isTerminal ? <p className="text-sm text-muted-foreground">{t('finalizedHint')}</p> : null}
       </header>
+
+      {match.status === 'pending' || match.status === 'active' ? (
+        <RivalMatchShareInvite
+          matchId={match.id}
+          faction={profile?.faction ?? null}
+          division={profile?.division ?? null}
+        />
+      ) : null}
 
       <RivalMatchResultBanner
         match={match}

--- a/src/features/submission/components/ScoreSubmissionScreen.tsx
+++ b/src/features/submission/components/ScoreSubmissionScreen.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 
 import { useChallenge } from '@/hooks/useChallenge';
 import { clearChallengeCommitment, recordChallengeCommitment } from '@/lib/commitments';
+import { trackFirstScoreIfNeeded } from '@/lib/analytics/firstScore';
 import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
 
 type Props = {
@@ -116,6 +117,9 @@ export function ScoreSubmissionScreen({ challengeId }: Props) {
         onSubmitted={(r) => {
           clearChallengeCommitment(challenge.id);
           setResult(r);
+          if (r.ranked) {
+            trackFirstScoreIfNeeded(r.ranked);
+          }
           router.push(
             `/${locale}/app/finish?challengeId=${challenge.id}&ranked=${String(r.ranked)}&scoreId=${encodeURIComponent(
               r.insertedId,

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,10 @@
+export const ANALYTICS_EVENTS = {
+  shareReferral: 'growth_share_referral',
+  shareRivalInvite: 'growth_share_rival_invite',
+  shareWeeklyInvite: 'growth_share_weekly_invite',
+  shareFinisher: 'growth_share_finisher',
+  signupCompleted: 'growth_signup_completed',
+  firstScoreSubmitted: 'growth_first_score_submitted',
+} as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];

--- a/src/lib/analytics/firstScore.ts
+++ b/src/lib/analytics/firstScore.ts
@@ -1,0 +1,20 @@
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+
+const FIRST_SCORE_KEY = 'tg_analytics_first_score';
+
+export function trackFirstScoreIfNeeded(ranked: boolean): void {
+  if (!ranked || typeof window === 'undefined') return;
+  try {
+    if (localStorage.getItem(FIRST_SCORE_KEY)) return;
+    localStorage.setItem(FIRST_SCORE_KEY, '1');
+    trackEvent(ANALYTICS_EVENTS.firstScoreSubmitted);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function resetFirstScoreTrackingForTests(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(FIRST_SCORE_KEY);
+}

--- a/src/lib/analytics/trackEvent.test.ts
+++ b/src/lib/analytics/trackEvent.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+
+describe('trackEvent', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('dispatches a custom analytics event', () => {
+    const handler = vi.fn();
+    window.addEventListener('truegrynd:analytics', handler as EventListener);
+
+    trackEvent(ANALYTICS_EVENTS.shareReferral, { faction: 'horde' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener('truegrynd:analytics', handler as EventListener);
+  });
+});

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -1,0 +1,44 @@
+import type { AnalyticsEventName } from '@/lib/analytics/events';
+
+type EventProperties = Record<string, string | number | boolean | null | undefined>;
+
+const DISTINCT_ID_KEY = 'tg_analytics_distinct_id';
+
+function getDistinctId(): string {
+  if (typeof window === 'undefined') return 'server';
+  try {
+    const existing = localStorage.getItem(DISTINCT_ID_KEY);
+    if (existing) return existing;
+    const id = crypto.randomUUID();
+    localStorage.setItem(DISTINCT_ID_KEY, id);
+    return id;
+  } catch {
+    return 'anonymous';
+  }
+}
+
+export function trackEvent(name: AnalyticsEventName, properties?: EventProperties): void {
+  if (typeof window === 'undefined') return;
+
+  window.dispatchEvent(
+    new CustomEvent('truegrynd:analytics', { detail: { name, properties: properties ?? {} } }),
+  );
+
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+  if (!apiKey) return;
+
+  void fetch(`${host}/capture/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: apiKey,
+      event: name,
+      distinct_id: getDistinctId(),
+      properties: { ...properties, source: 'web' },
+    }),
+    keepalive: true,
+  }).catch(() => {
+    /* analytics must not break UX */
+  });
+}

--- a/src/lib/finisher/buildFinisherCardOptions.test.ts
+++ b/src/lib/finisher/buildFinisherCardOptions.test.ts
@@ -25,7 +25,7 @@ describe('buildFinisherCardOptions', () => {
     expect(opts.width).toBe(1080);
     expect(opts.height).toBe(1920);
     expect(opts.topPercent).toBe(5);
-    expect(opts.rankTextOverride).toBe('RANKED');
+    expect(opts.rankTextOverride).toBe('TOP 5%');
   });
 
   it('builds thumb preview options without top percent', () => {

--- a/src/lib/finisher/buildFinisherCardOptions.ts
+++ b/src/lib/finisher/buildFinisherCardOptions.ts
@@ -14,17 +14,29 @@ export type FinisherCardDrawOptions = {
   rankSubOverride?: string;
   /** V2-03: e.g. "W22 · 2026" when score is on the current weekly challenge. */
   weeklyBadge?: string;
+  /** V2-11: active micro-event label. */
+  eventBadge?: string;
+  /** V2-11: e.g. "I SCORED FOR HORDE ROOKIE". */
+  tagline?: string;
+  /** V2-11: e.g. "+4.2 RATING". */
+  ratingDeltaText?: string;
+  /** V2-11: e.g. "+892 WAR PTS". */
+  warPointsText?: string;
 };
 
 type RankedLabels = {
   ranked: boolean;
   isValidated: boolean;
+  topPercent: number | null;
 };
 
-function rankLabels({ ranked, isValidated }: RankedLabels): {
+function rankLabels({ ranked, isValidated, topPercent }: RankedLabels): {
   rankTextOverride: string;
   rankSubOverride: string;
 } {
+  if (isValidated && topPercent !== null) {
+    return { rankTextOverride: `TOP ${topPercent}%`, rankSubOverride: 'WORLDWIDE (VALIDATED)' };
+  }
   if (ranked && isValidated) {
     return { rankTextOverride: 'RANKED', rankSubOverride: 'VALIDATED' };
   }
@@ -41,8 +53,11 @@ type FullParams = RankedLabels & {
   challengeTitle: string;
   scoreType: ScoreType;
   scoreValue: number;
-  topPercent: number | null;
   weeklyBadge?: string;
+  eventBadge?: string;
+  tagline?: string;
+  ratingDeltaText?: string;
+  warPointsText?: string;
 };
 
 export function buildFinisherCardOptionsFull(params: FullParams): FinisherCardDrawOptions {
@@ -58,6 +73,10 @@ export function buildFinisherCardOptionsFull(params: FullParams): FinisherCardDr
     scoreValue: params.scoreValue,
     topPercent: params.topPercent,
     weeklyBadge: params.weeklyBadge,
+    eventBadge: params.eventBadge,
+    tagline: params.tagline,
+    ratingDeltaText: params.ratingDeltaText,
+    warPointsText: params.warPointsText,
     ...labels,
   };
 }

--- a/src/lib/growth/comebackWeek.test.ts
+++ b/src/lib/growth/comebackWeek.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { getComebackEligibility } from '@/lib/growth/comebackWeek';
+import {
+  buildFinisherTagline,
+  formatRatingDelta,
+  formatWarPoints,
+} from '@/lib/growth/finisherTagline';
+
+describe('getComebackEligibility', () => {
+  const now = Date.UTC(2026, 5, 1, 12, 0, 0);
+
+  it('returns eligible when away 1–2 weeks', () => {
+    const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString();
+    expect(getComebackEligibility(tenDaysAgo, now)).toEqual({ eligible: true, weeksAway: 1 });
+  });
+
+  it('rejects recent activity', () => {
+    const twoDaysAgo = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
+    expect(getComebackEligibility(twoDaysAgo, now).eligible).toBe(false);
+  });
+
+  it('rejects long absence', () => {
+    const monthAgo = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
+    expect(getComebackEligibility(monthAgo, now).eligible).toBe(false);
+  });
+});
+
+describe('finisherTagline helpers', () => {
+  it('builds faction division tagline', () => {
+    expect(buildFinisherTagline('horde', 'rookie')).toBe('I SCORED FOR HORDE ROOKIE');
+  });
+
+  it('formats rating delta and war points', () => {
+    expect(formatRatingDelta(4.2)).toBe('+4.2 RATING');
+    expect(formatWarPoints(892)).toBe('+892 WAR PTS');
+  });
+});

--- a/src/lib/growth/comebackWeek.ts
+++ b/src/lib/growth/comebackWeek.ts
@@ -1,0 +1,29 @@
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+const MIN_WEEKS_AWAY = 1;
+const MAX_WEEKS_AWAY = 2.5;
+
+export type ComebackEligibility = {
+  eligible: boolean;
+  weeksAway: number | null;
+};
+
+export function getComebackEligibility(
+  lastActivityAt: string | null,
+  nowMs: number = Date.now(),
+): ComebackEligibility {
+  if (!lastActivityAt) {
+    return { eligible: false, weeksAway: null };
+  }
+
+  const elapsedMs = nowMs - new Date(lastActivityAt).getTime();
+  if (elapsedMs < MIN_WEEKS_AWAY * MS_PER_WEEK) {
+    return { eligible: false, weeksAway: null };
+  }
+
+  const weeksAway = elapsedMs / MS_PER_WEEK;
+  if (weeksAway > MAX_WEEKS_AWAY) {
+    return { eligible: false, weeksAway: null };
+  }
+
+  return { eligible: true, weeksAway: Math.floor(weeksAway) };
+}

--- a/src/lib/growth/finisherTagline.ts
+++ b/src/lib/growth/finisherTagline.ts
@@ -1,0 +1,16 @@
+import type { Division, Faction } from '@/lib/types/database.types';
+
+export function buildFinisherTagline(faction: Faction, division: Division): string {
+  const factionLabel = faction.replace('_', ' ').toUpperCase();
+  return `I SCORED FOR ${factionLabel} ${division.toUpperCase()}`;
+}
+
+export function formatRatingDelta(delta: number): string {
+  const rounded = Math.round(delta * 10) / 10;
+  const prefix = rounded > 0 ? '+' : '';
+  return `${prefix}${rounded} RATING`;
+}
+
+export function formatWarPoints(points: number): string {
+  return `+${Math.round(points)} WAR PTS`;
+}

--- a/src/lib/growth/inviteLinks.test.ts
+++ b/src/lib/growth/inviteLinks.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRivalInviteUrl, buildWeeklyInviteUrl } from '@/lib/growth/inviteLinks';
+
+describe('inviteLinks', () => {
+  it('builds rival invite url with referral params', () => {
+    const url = buildRivalInviteUrl('https://truegrynd.app', 'en', 'match-1', {
+      faction: 'horde',
+      division: 'rookie',
+    });
+    expect(url).toContain('/en/app/rivals/match-1');
+    expect(url).toContain('invite=1');
+    expect(url).toContain('faction=horde');
+    expect(url).toContain('division=rookie');
+  });
+
+  it('builds weekly invite url', () => {
+    const url = buildWeeklyInviteUrl('https://truegrynd.app', 'fr', 'challenge-1', {
+      faction: 'nomads',
+      division: 'regular',
+      weekly: 'W22',
+    });
+    expect(url).toContain('/fr/app/arena/challenge-1');
+    expect(url).toContain('weekly=W22');
+  });
+});

--- a/src/lib/growth/inviteLinks.ts
+++ b/src/lib/growth/inviteLinks.ts
@@ -1,0 +1,26 @@
+import type { ReferralParams } from '@/features/factions/lib/referral';
+import { buildReferralUrl } from '@/features/factions/lib/referral';
+
+export function buildRivalInviteUrl(
+  siteUrl: string,
+  locale: string,
+  matchId: string,
+  params: ReferralParams,
+): string {
+  const base = `${siteUrl.replace(/\/$/, '')}/${locale}/app/rivals/${matchId}`;
+  const url = new URL(base);
+  url.searchParams.set('invite', '1');
+  if (params.faction) url.searchParams.set('faction', params.faction);
+  if (params.division) url.searchParams.set('division', params.division);
+  return url.toString();
+}
+
+export function buildWeeklyInviteUrl(
+  siteUrl: string,
+  locale: string,
+  challengeId: string,
+  params: ReferralParams,
+): string {
+  const base = `${siteUrl.replace(/\/$/, '')}/${locale}/app/arena/${challengeId}`;
+  return buildReferralUrl(base, params);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -203,7 +203,9 @@
       "shareAria": "Share recruit link for {faction}",
       "copyAria": "Copy recruit link to clipboard",
       "shareTitle": "Truegrynd — Join {faction}",
-      "shareText": "Join {faction} on Truegrynd. Async fitness battles, no fluff."
+      "shareText": "Join {faction} on Truegrynd. Async fitness battles, no fluff.",
+      "shareTitleContextual": "Truegrynd — Join {faction} {division} Week",
+      "shareTextContextual": "Join {faction} {division} on Truegrynd. {weekly} is live — post a ranked score."
     }
   },
   "factionPage": {
@@ -861,6 +863,36 @@
       "not_invited": "You are not invited to this match.",
       "match_not_pending": "This invite is no longer pending.",
       "cannot_cancel": "Could not cancel this match."
+    }
+  },
+  "growth": {
+    "share": {
+      "share": "SHARE",
+      "copy": "COPY LINK",
+      "copied": "COPIED!"
+    },
+    "comeback": {
+      "kicker": "WELCOME BACK",
+      "eventKicker": "COMEBACK WEEK",
+      "body": "You stepped away for {weeks} week(s). No guilt — jump back in with one ranked score.",
+      "hint": "Your faction war still counts. One proof video is enough to re-enter the fight.",
+      "cta": "POST A SCORE"
+    },
+    "rivalInvite": {
+      "title": "INVITE A RIVAL",
+      "body": "Share this link so a friend can accept your duel.",
+      "shareTitle": "Truegrynd — Rival duel invite",
+      "shareText": "I challenged you on Truegrynd. Accept the duel.",
+      "shareAria": "Share rival match invite link",
+      "copyAria": "Copy rival match invite link"
+    },
+    "weeklyInvite": {
+      "title": "INVITE TO WEEKLY",
+      "body": "Recruit allies for this week's challenge.",
+      "shareTitle": "Truegrynd — Join {faction} {division} · {weekly}",
+      "shareText": "Join {faction} {division} on Truegrynd. This week's challenge is live.",
+      "shareAria": "Share weekly challenge invite link",
+      "copyAria": "Copy weekly challenge invite link"
     }
   },
   "finisher": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -203,7 +203,9 @@
       "shareAria": "Partager le lien de recrutement {faction}",
       "copyAria": "Copier le lien de recrutement",
       "shareTitle": "Truegrynd — Rejoins {faction}",
-      "shareText": "Rejoins {faction} sur Truegrynd. Compétition fitness async, sans blabla."
+      "shareText": "Rejoins {faction} sur Truegrynd. Compétition fitness async, sans blabla.",
+      "shareTitleContextual": "Truegrynd — Rejoins {faction} {division}",
+      "shareTextContextual": "Rejoins {faction} {division} sur Truegrynd. {weekly} est en cours — poste un score classé."
     }
   },
   "factionPage": {
@@ -861,6 +863,36 @@
       "not_invited": "Tu n'es pas invité sur ce match.",
       "match_not_pending": "Cette invitation n'est plus en attente.",
       "cannot_cancel": "Impossible d'annuler ce match."
+    }
+  },
+  "growth": {
+    "share": {
+      "share": "PARTAGER",
+      "copy": "COPIER LE LIEN",
+      "copied": "COPIÉ !"
+    },
+    "comeback": {
+      "kicker": "CONTENT DE TE REVOIR",
+      "eventKicker": "SEMAINE COMEBACK",
+      "body": "Tu as pris {weeks} semaine(s) de pause. Pas de culpabilité — reprends avec un score classé.",
+      "hint": "La guerre de faction compte toujours. Une vidéo preuve suffit pour revenir dans la course.",
+      "cta": "POSTER UN SCORE"
+    },
+    "rivalInvite": {
+      "title": "INVITER UN RIVAL",
+      "body": "Partage ce lien pour qu'un ami accepte ton duel.",
+      "shareTitle": "Truegrynd — Invitation duel rival",
+      "shareText": "Je te défie sur Truegrynd. Accepte le duel.",
+      "shareAria": "Partager le lien d'invitation rival",
+      "copyAria": "Copier le lien d'invitation rival"
+    },
+    "weeklyInvite": {
+      "title": "INVITER AU WEEKLY",
+      "body": "Recrute des alliés pour le défi de la semaine.",
+      "shareTitle": "Truegrynd — Rejoins {faction} {division} · {weekly}",
+      "shareText": "Rejoins {faction} {division} sur Truegrynd. Le défi de la semaine est live.",
+      "shareAria": "Partager le lien d'invitation weekly",
+      "copyAria": "Copier le lien d'invitation weekly"
     }
   },
   "finisher": {


### PR DESCRIPTION
## Summary
- Finisher cards V2: tagline faction+division, event badge, rating delta, faction war points, TOP X% when ranked
- Share invite links for weekly challenges (Overview) and rival matches (detail screen)
- Comeback week banner on Overview for users inactive 1–2 weeks
- Referral V2: `?faction=&division=&weekly=` captured on auth + onboarding; contextual RecruitCta copy
- Analytics: `trackEvent` + optional PostHog HTTP capture (share, signup, first score)

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run` (214 tests)
- [x] `pnpm lint`
- [ ] Manual: finish page shows enriched card after validated weekly score
- [ ] Manual: share weekly/rival links preserve referral params through signup
- [ ] Manual: comeback banner when `last_activity_at` > 7 days

Fixes #94

Made with [Cursor](https://cursor.com)