### PR TITLE
feat(monetization): V2-12 finisher cosmetics exploration

### DIFF
--- a/docs/MONETIZATION_V2-12.md
+++ b/docs/MONETIZATION_V2-12.md
@@ -1,0 +1,151 @@
+# V2-12 — Monétisation exploratoire
+
+> **Issue GitHub :** [#98](https://github.com/igorms-pro/truegrynd/issues/98)  
+> **Statut :** hypothèse retenue + prototype UI (sans Stripe, sans paywall fonctionnel)  
+> **Principe produit :** le rang sportif reste gratuit — payer ne doit jamais améliorer un classement.
+
+---
+
+## 1. Synthèse décisionnelle
+
+| Option                         | Verdict          | Raison                                                                                                               |
+| ------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Finisher Card cosmetics**    | **Retenue (H1)** | Liée au loop growth (`growth_share_finisher`), zéro pay-to-win, prototype léger, valeur perçue sur le partage social |
+| Premium Passport               | Reportée         | Le passport est déjà le CV compétitif core V2 — paywall risque de casser l'identité amateur                          |
+| Micro-event packs payants      | Reportée         | Ops + perception « ticket » contraire au positionnement V2                                                           |
+| Sponsor challenges             | Reportée         | Nécessite pipeline commercial, pas adapté au stade solo                                                              |
+| **Pivot V3 gym ($100/mo B2B)** | **Conditionnel** | Voir §4 — pas prioritaire sans signal B2B organique                                                                  |
+
+**Hypothèse H1 — Finisher cosmetics :** vendre des **cadres / skins** de Finisher Card (neon, gold, carbon…) à ~2–4 € one-shot ou bundle saisonnier. Le score, le rang et le contenu restent identiques ; seul le rendu visuel change à l'export PNG.
+
+---
+
+## 2. Métriques V2 — lecture PostHog
+
+Référence stratégie : [V2_STRATEGY.md](./V2_STRATEGY.md) § Métriques.
+
+### 2.1 Events déjà câblés (client → PostHog HTTP)
+
+| Event PostHog                          | Source code               | Usage monétisation                              |
+| -------------------------------------- | ------------------------- | ----------------------------------------------- |
+| `growth_share_finisher`                | `FinisherCardActions`     | **Signal direct H1** — taux de partage finisher |
+| `growth_share_weekly_invite`           | `WeeklyChallengeInvite`   | Proxy engagement weekly                         |
+| `growth_share_rival_invite`            | `RivalMatchShareInvite`   | Proxy rival loop                                |
+| `growth_share_referral`                | `RecruitCta`              | Acquisition faction                             |
+| `growth_signup_completed`              | `OnboardingFlow`          | Funnel top                                      |
+| `growth_first_score_submitted`         | `firstScore.ts`           | Activation J7                                   |
+| `monetization_cosmetics_teaser_viewed` | `FinisherCosmeticsTeaser` | Intérêt exploratoire V2-12                      |
+| `monetization_cosmetics_interest`      | `FinisherCosmeticsTeaser` | **Intent H1** — clic « me tenir au courant »    |
+
+Config : `NEXT_PUBLIC_POSTHOG_KEY` + `NEXT_PUBLIC_POSTHOG_HOST` (voir `.env.local.example`).
+
+### 2.2 HogQL — à exécuter dans PostHog (Insights → SQL)
+
+**Partages finisher (30 j)** — signal principal H1 :
+
+```sql
+SELECT count() AS shares
+FROM events
+WHERE event = 'growth_share_finisher'
+  AND timestamp > now() - INTERVAL 30 DAY
+```
+
+**Taux partage / finisher views (proxy)** — si page finish trackée indirectement via shares uniquement :
+
+```sql
+SELECT
+  countIf(event = 'growth_share_finisher') AS shares,
+  countIf(event = 'growth_first_score_submitted') AS first_scores
+FROM events
+WHERE timestamp > now() - INTERVAL 30 DAY
+  AND event IN ('growth_share_finisher', 'growth_first_score_submitted')
+```
+
+**Intent cosmetics (post-déploiement V2-12)** :
+
+```sql
+SELECT
+  countIf(event = 'monetization_cosmetics_teaser_viewed') AS views,
+  countIf(event = 'monetization_cosmetics_interest') AS interest_clicks
+FROM events
+WHERE timestamp > now() - INTERVAL 14 DAY
+  AND event LIKE 'monetization_cosmetics%'
+```
+
+**Seuil go/no-go H1 (proposé, à affiner avec volume réel) :**
+
+- `growth_share_finisher` ≥ 50 / 30j **ou** ratio shares / `growth_first_score_submitted` ≥ 15 %
+- `monetization_cosmetics_interest` / views ≥ 8 % sur 14 j post-teaser
+- Aucune régression sur `growth_first_score_submitted` (monétisation ne doit pas freiner l'activation)
+
+### 2.3 Gaps analytics — métriques V2 non encore eventisées
+
+| Métrique stratégie            | Source recommandée                      | Action                                                    |
+| ----------------------------- | --------------------------------------- | --------------------------------------------------------- |
+| Weekly challenge participants | Supabase `scores` + weekly flag         | Requête SQL admin / future event `weekly_score_submitted` |
+| % users en division           | Supabase `profiles.division`            | Snapshot SQL                                              |
+| Rétention weekly 4 semaines   | PostHog cohort signup → score semaine N | Cohort insight                                            |
+| Rival match completion        | Supabase `rival_matches.status`         | RPC dashboard                                             |
+| Promotion Rookie → Regular    | Supabase `division_history`             | Migration existante                                       |
+| Video-ranked vs honor         | Supabase `scores.is_validated`          | SQL ratio                                                 |
+
+Ces gaps ne bloquent pas H1 : le partage finisher est le proxy le plus direct pour des cosmetics.
+
+---
+
+## 3. Spécification H1 — Finisher cosmetics
+
+### 3.1 Offre (exploratoire)
+
+- **Gratuit :** frame `standard` (actuel)
+- **Premium (futur) :** `neon`, `gold`, `carbon` — achat one-shot ou bundle event
+- **Jamais payant :** rang, percentile, division, rating, accès leaderboard
+
+### 3.2 Prototype livré (V2-12)
+
+- Section **Finisher styles** sur `/app/profile/passport`
+- Aperçu canvas des 3 frames premium sur un score fictif
+- CTA « Notify me » → event `monetization_cosmetics_interest` (pas de paiement)
+- Implémentation frame : `src/lib/finisher/frameStyles.ts` + option `frameStyle` dans `drawFinisherCard`
+
+### 3.3 Pricing cible (hypothèse, non implémenté)
+
+| SKU                      | Prix indicatif | Notes                   |
+| ------------------------ | -------------- | ----------------------- |
+| Single frame             | 2,99 €         | Impulsion post-share    |
+| Season bundle (3 frames) | 6,99 €         | Aligné micro-events     |
+| Faction pack             | 4,99 €         | Couleur faction + frame |
+
+Stripe Checkout **uniquement** après validation des seuils §2.2.
+
+---
+
+## 4. Pivot V3 B2B — quand prioriser le gym
+
+Lire [V3_STRATEGY.md](./V3_STRATEGY.md) pour le modèle $100/mo Pro (TV Broadcaster, leagues inter-box, Judge Console).
+
+**Basculer V3 en priorité #1 si :**
+
+1. ≥ 3 gyms/boxes distinctes avec ≥ 10 athlètes actifs chacune sur 30 j (requête `profiles` + affiliation future), **ou**
+2. Demandes répétées de vérification coach / dashboard gym (support ou analytics), **ou**
+3. Intent cosmetics < 3 % ET share finisher < 5 % sur 60 j → le loop B2C social ne porte pas la monétisation
+
+**Sinon :** exécuter H1 cosmetics d'abord (coût dev faible, aligné growth V2-11).
+
+---
+
+## 5. Prochaines étapes (post-V2-12)
+
+1. Déployer le teaser passport + monitorer PostHog 14 j
+2. Si seuils OK → issue dédiée Stripe + table `user_cosmetics` + sélecteur frame sur finish page
+3. Si seuils KO → réévaluer premium passport (sections privées) ou amorcer discovery V3 avec 2–3 boxes pilotes
+4. Documenter décision finale dans `issues.md` § V2-12
+
+---
+
+## 6. Références
+
+- [V2_STRATEGY.md § V2.5](./V2_STRATEGY.md)
+- [V3_STRATEGY.md](./V3_STRATEGY.md)
+- `src/lib/analytics/events.ts`
+- `src/features/profile/components/passport/FinisherCosmeticsTeaser.tsx`

--- a/docs/V3_STRATEGY.md
+++ b/docs/V3_STRATEGY.md
@@ -1,15 +1,3 @@
-Désolé pour le contretemps, l'affichage précédent a dû être corrompu par l'interpréteur de texte.
-
-Voici le lien direct pour télécharger ton fichier proprement au format Markdown, prêt à être poussé sur ton dépôt :
-
-[Télécharger v3_strategy.md](https://www.google.com/search?q=sandbox:/v3_strategy.md)
-
-### Pour le créer directement en ligne de commande dans ton repo :
-
-Si tu es sur ton terminal dans le dossier de ton projet, tu peux aussi simplement exécuter cette commande pour générer le fichier instantanément :
-
-````bash
-cat << 'EOF' > v3_strategy.md
 # Truegrynd V3 Strategy — The Hybrid B2B2C Ecosystem
 
 ## 1. Executive Summary & Thesis
@@ -17,13 +5,13 @@ cat << 'EOF' > v3_strategy.md
 Truegrynd V2 focused on building the ultimate accessible competitive fitness app for individual athletes. V3 introduces the structural pivot to a **B2B2C model**, turning the B2C engagement engine into a Trojan Horse to capture the European Hybrid & Functional Fitness facility market.
 
 **The Market Gap (Europe vs. US):**
-US giants (*Wodify, SugarWOD, BTWB*) were built in 2012–2015 for pure CrossFit (barbells & gymnastics). They are heavy, expensive ($150–$250/mo), act as rigid accounting/booking tools, and completely ignore the explosion of **Hybrid Training & Hyrox-style endurance** (VMA, running pacing, ergs) in Europe. Furthermore, gym management platforms in Europe (*Resawod, Deciplus, Xplor*) are administrative, corporate, and completely devoid of community "vibe".
+US giants (_Wodify, SugarWOD, BTWB_) were built in 2012–2015 for pure CrossFit (barbells & gymnastics). They are heavy, expensive ($150–$250/mo), act as rigid accounting/booking tools, and completely ignore the explosion of **Hybrid Training & Hyrox-style endurance** (VMA, running pacing, ergs) in Europe. Furthermore, gym management platforms in Europe (_Resawod, Deciplus, Xplor_) are administrative, corporate, and completely devoid of community "vibe".
 
 **The Truegrynd V3 Thesis:**
 Gym owners don't want another invoicing tool; they want **community retention and automated session animation**. Truegrynd V3 owns the competitive layer, the community engagement, and the hybrid athletic identity, operating alongside existing booking systems.
 
-* **B2C Objective:** Create user acquisition, athletic identity (*Passport*), and organic growth loops.
-* **B2B Objective:** Monetize affiliates (Gyms, Boxes, Clubs) at **$100/month** by offering automated retention, league competition, and interactive facility animation.
+- **B2C Objective:** Create user acquisition, athletic identity (_Passport_), and organic growth loops.
+- **B2B Objective:** Monetize affiliates (Gyms, Boxes, Clubs) at **$100/month** by offering automated retention, league competition, and interactive facility animation.
 
 ---
 
@@ -32,77 +20,90 @@ Gym owners don't want another invoicing tool; they want **community retention an
 To maintain extreme efficiency as a solopreneur, the platform uses a single unified codebase with **Role-Based Access Control (RBAC)** to route users dynamically:
 
 - **Role: ATHLETE (/app interface)**
-  * Free / Freemium
-  * Passport & Rating
-  * Weekly Challenges
-  * Rival Matches
-  * Generates organic traction
+  - Free / Freemium
+  - Passport & Rating
+  - Weekly Challenges
+  - Rival Matches
+  - Generates organic traction
 
 - **Role: PRO (/pro interface)**
-  * $100/mo subscription
-  * TV Broadcaster Mode
-  * Inter-Gym Leagues
-  * Pacing Automation
-  * Monetizes the structures
+  - $100/mo subscription
+  - TV Broadcaster Mode
+  - Inter-Gym Leagues
+  - Pacing Automation
+  - Monetizes the structures
 
 - **Role: ADMIN (/admin interface)**
-  * Platform control (Your backend)
-  * Global Workout Engine
-  * Audit & Verification
-  * Systems Config
+  - Platform control (Your backend)
+  - Global Workout Engine
+  - Audit & Verification
+  - Systems Config
 
 ---
 
 ## 3. Product Specifications
 
 ### ─── OPTION B2C: L'Arène (The Athlete Interface) ───
-*Focus: Frictionless score submission, status progression, and social loops.*
+
+_Focus: Frictionless score submission, status progression, and social loops._
 
 #### 1. The Hybrid Passport & Multi-Axis Rating
-* **Truegrynd Rating:** Evaluates performance across 5 native axes (*Engine, Power, Strength, Grit, Consistency*).
-* **Cardio-Ready Engine:** The *Engine* metric captures running performance benchmarks (e.g., VMA, 5K/10K times) to contextualize the athlete's aerobic engine without requiring real-time GPS tracking.
-* **The Passport:** Digital athletic résumé showcasing reached divisions, historical metrics, earned badges, and verified match history.
+
+- **Truegrynd Rating:** Evaluates performance across 5 native axes (_Engine, Power, Strength, Grit, Consistency_).
+- **Cardio-Ready Engine:** The _Engine_ metric captures running performance benchmarks (e.g., VMA, 5K/10K times) to contextualize the athlete's aerobic engine without requiring real-time GPS tracking.
+- **The Passport:** Digital athletic résumé showcasing reached divisions, historical metrics, earned badges, and verified match history.
 
 #### 2. Lean Score Submission & Anti-Cheat Proof Levels
+
 To scale without human moderation, tracking is decentralized via layered proof:
-* **Honor Level:** Simple manual text entry. Fits casual users who want to compare against peers without leaderboard pressure.
-* **Community Verified:** User pastes a public workout link (Strava, Garmin, Nike Run) or uploads a picture of the machine console/smartwatch screen.
-* **Judge Verified:** One-click validation by an affiliated coach or gym owner through their Pro Dashboard. Automatically upgrades the score to premium global ranking status.
+
+- **Honor Level:** Simple manual text entry. Fits casual users who want to compare against peers without leaderboard pressure.
+- **Community Verified:** User pastes a public workout link (Strava, Garmin, Nike Run) or uploads a picture of the machine console/smartwatch screen.
+- **Judge Verified:** One-click validation by an affiliated coach or gym owner through their Pro Dashboard. Automatically upgrades the score to premium global ranking status.
 
 #### 3. Equipment-Agnostic Scaling Engine
+
 Challenges are designed to be inclusive, offering 3 standardized official scaling options based on available infrastructure:
-* *No Equipment:* Bodyweight, outdoor running, park-ready.
-* *Light Equipment:* Home-gym setups, dumbbells, kettlebells.
-* *Full Gym:* Access to functional fitness boxes, ergs (Row/Ski/Bike), and barbell stations.
+
+- _No Equipment:_ Bodyweight, outdoor running, park-ready.
+- _Light Equipment:_ Home-gym setups, dumbbells, kettlebells.
+- _Full Gym:_ Access to functional fitness boxes, ergs (Row/Ski/Bike), and barbell stations.
 
 #### 4. Growth Loops
-* **Rival Matches:** Automated 1v1 matchmaker pairings against users in the same division with similar Truegrynd Ratings.
-* **Finisher Cards:** High-quality, automated Instagram Story-ready image generation at the completion of weekly events (*"Top 12% Regular — Grit Engine Challenge"*).
+
+- **Rival Matches:** Automated 1v1 matchmaker pairings against users in the same division with similar Truegrynd Ratings.
+- **Finisher Cards:** High-quality, automated Instagram Story-ready image generation at the completion of weekly events (_"Top 12% Regular — Grit Engine Challenge"_).
 
 ### ─── OPTION B2B: L'Espace Pro (Truegrynd Business) ───
-*Focus: Value-driven features justifying the $100/mo fee by saving coaches' time and entertaining members.*
+
+_Focus: Value-driven features justifying the $100/mo fee by saving coaches' time and entertaining members._
 
 #### 1. TV Broadcaster Mode
-* An optimized, read-only web interface meant to be cast on facilities' large television screens.
-* **Live Arena Effect:** When an athlete submits their score on their personal app in the locker room or gym floor, the TV screen instantly animates, updates the daily local leaderboard, and triggers visual cues representing their faction/team. It replaces the old-school whiteboard with a premium, live sports-broadcast aesthetic.
+
+- An optimized, read-only web interface meant to be cast on facilities' large television screens.
+- **Live Arena Effect:** When an athlete submits their score on their personal app in the locker room or gym floor, the TV screen instantly animates, updates the daily local leaderboard, and triggers visual cues representing their faction/team. It replaces the old-school whiteboard with a premium, live sports-broadcast aesthetic.
 
 #### 2. Inter-Box & Inter-Gym Leagues
-* Affiliated gyms can opt-into local, national, or regional digital leagues directly from the dashboard.
-* Truegrynd automates friendly club-vs-club matches (e.g., *Box Antibes vs. Box Marseille*). Gym performance scores are calculated using member averages across scaling groups. This converts isolated, solo workouts into high-retention club pride.
+
+- Affiliated gyms can opt-into local, national, or regional digital leagues directly from the dashboard.
+- Truegrynd automates friendly club-vs-club matches (e.g., _Box Antibes vs. Box Marseille_). Gym performance scores are calculated using member averages across scaling groups. This converts isolated, solo workouts into high-retention club pride.
 
 #### 3. The Judge Console (One-Click Verification)
-* A specialized feed aggregating all scores submitted by members assigned to that specific gym.
-* Coaches can quickly review and click "Verify" on performances they witnessed on the floor. This immediately pushes the athlete's score to the highest rank on global boards, valuing both the coach's local authority and the athlete's effort.
+
+- A specialized feed aggregating all scores submitted by members assigned to that specific gym.
+- Coaches can quickly review and click "Verify" on performances they witnessed on the floor. This immediately pushes the athlete's score to the highest rank on global boards, valuing both the coach's local authority and the athlete's effort.
 
 #### 4. Automated Hybrid Pacing Assistant
-* Programming hybrid workouts is notoriously difficult for coaches because running/rowing capacities vary heavily per member.
-* **The Feature:** The coach inputs a workout layout (e.g., *3x 1000m Run + 50 Wall Balls*). Truegrynd Pro pulls individual athlete data from their *Passports* and automatically displays targeted, customized splits and pacing strategies directly inside the athletes' apps (e.g., *"Your target split for interval 1: 4m15s"*). The coach delivers advanced individual programming in 2 clicks.
+
+- Programming hybrid workouts is notoriously difficult for coaches because running/rowing capacities vary heavily per member.
+- **The Feature:** The coach inputs a workout layout (e.g., _3x 1000m Run + 50 Wall Balls_). Truegrynd Pro pulls individual athlete data from their _Passports_ and automatically displays targeted, customized splits and pacing strategies directly inside the athletes' apps (e.g., _"Your target split for interval 1: 4m15s"_). The coach delivers advanced individual programming in 2 clicks.
 
 ---
 
 ## 4. Engineering & Database Blueprint
 
 ### Relational Schema Foundations
+
 To implement this cleanly, the schema uses explicit relations tying athletes to their physical facilities:
 
 ```sql
@@ -128,8 +129,7 @@ CREATE TABLE public.gyms (
 ALTER TABLE public.scores ADD COLUMN proof_status proof_level DEFAULT 'honor';
 ALTER TABLE public.scores ADD COLUMN verified_by_coach_id UUID REFERENCES public.profiles(id);
 ALTER TABLE public.scores ADD COLUMN proof_url TEXT; -- image or external strava link
-
-````
+```
 
 ### Security & Multi-Tenancy (Row-Level Security)
 
@@ -151,7 +151,6 @@ USING (
         AND profiles.affiliated_gym_id = scores.gym_id
     )
 );
-
 ```
 
 ---
@@ -174,8 +173,3 @@ By combining highly defensible B2B enterprise revenue (SaaS cash-flow with <2% m
 - Major functional fitness/Hyrox events organizers needing a 52-week top-of-funnel platform.
 - Multi-facility fitness franchises wanting proprietary gamification technology to increase membership retention.
 - Emerging apparel or fitness equipment manufacturers looking to acquire a captive, highly qualified athletic data marketplace in Europe.
-  EOF
-
-```
-
-```

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -85,7 +85,7 @@ Arène async mondiale, **Smart Proof**, **Factions**, **UGC modéré**, **Finish
 - [x] **V2-09** — Micro-events async (24h / 7j / 30j) — 🟢 [#92](https://github.com/igorms-pro/truegrynd/issues/92) PR [#93](https://github.com/igorms-pro/truegrynd/pull/93) · migration **`024`** prod
 - [x] **V2-10** — Proof Levels — 🟢 [#95](https://github.com/igorms-pro/truegrynd/issues/95) PR [#96](https://github.com/igorms-pro/truegrynd/pull/96) · migration **`027`** prod
 - [x] **V2-11** — Growth loops (cards, invitations, comeback weeks) — 🟢 [#94](https://github.com/igorms-pro/truegrynd/issues/94) PR [#97](https://github.com/igorms-pro/truegrynd/pull/97)
-- [ ] **V2-12** — Monétisation exploratoire (après signal d'usage)
+- [ ] **V2-12** — Monétisation exploratoire (après signal d'usage) — 🟡 [#98](https://github.com/igorms-pro/truegrynd/issues/98) · branche `feature/issue-98-monetization-exploratory`
 
 ---
 
@@ -721,11 +721,13 @@ Branche : `chore/issue-69-production-hardening`
 
 ### V2-12. Monétisation Exploratoire
 
-- [ ] **Principe** : ne pas bloquer le core compétitif trop tôt.
-- [ ] **Hypothèses** : premium passport, cosmetics cards, micro-event packs, sponsor challenges, gym/team dashboards.
-- [ ] **Validation** : attendre signal d'usage (weekly retention, rival completion, share rate).
-- [ ] **Stripe** : seulement après choix clair d'une offre.
-- [ ] **No pay-to-win** : payer ne doit jamais améliorer un rang sportif.
+- [x] **Principe** : ne pas bloquer le core compétitif trop tôt.
+- [x] **Hypothèse retenue (H1)** : Finisher Card cosmetics (frames premium, no pay-to-win) — voir [docs/MONETIZATION_V2-12.md](../MONETIZATION_V2-12.md).
+- [x] **Validation** : templates HogQL PostHog + seuils go/no-go documentés ; events `monetization_cosmetics_*`.
+- [x] **Prototype** : teaser passport (`FinisherCosmeticsTeaser`) + frames `neon` / `gold` / `carbon` dans `drawCard`.
+- [ ] **Stripe** : seulement après choix clair d'une offre et seuils analytics.
+- [x] **No pay-to-win** : payer ne doit jamais améliorer un rang sportif.
+- [x] **Comparaison V3 B2B** : critères de pivot documentés (§4 MONETIZATION_V2-12).
 
 ---
 
@@ -767,6 +769,7 @@ Préfixes : **FEAT** · **FIX** · **CHORE** · **DOC** · **PERF**
 | **V2 — Accessible competition**               | 🟢 V2-00–09 [#92](https://github.com/igorms-pro/truegrynd/issues/92) PR [#93](https://github.com/igorms-pro/truegrynd/pull/93) · prod migrations **`015`–`026`** (Jun 2026 — drift repair + **`026`** micro-events backfill)                        |
 | **V2-10 — Proof levels**                      | 🟢 [#95](https://github.com/igorms-pro/truegrynd/issues/95) PR [#96](https://github.com/igorms-pro/truegrynd/pull/96) · migration **`027`** prod                                                                                                    |
 | **V2-11 — Growth loops**                      | 🟢 [#94](https://github.com/igorms-pro/truegrynd/issues/94) PR [#97](https://github.com/igorms-pro/truegrynd/pull/97)                                                                                                                               |
+| **V2-12 — Monétisation exploratoire**         | 🟡 [#98](https://github.com/igorms-pro/truegrynd/issues/98) · `feature/issue-98-monetization-exploratory`                                                                                                                                           |
 | **QA V1**                                     | 🟢 GO (juin 2026) — périmètre critique testé                                                                                                                                                                                                        |
 
 **Suite produit :** **V2-12** monétisation exploratoire (après signal d'usage analytics) · V3 gym · notifs rivals (hors scope sauf demande).

--- a/src/features/finisher-card/lib/drawCard.test.ts
+++ b/src/features/finisher-card/lib/drawCard.test.ts
@@ -13,6 +13,10 @@ function createCanvas(): HTMLCanvasElement {
       fillRect: () => undefined,
       strokeRect: () => undefined,
       fillText: () => undefined,
+      beginPath: () => undefined,
+      moveTo: () => undefined,
+      lineTo: () => undefined,
+      stroke: () => undefined,
       font: '',
       fillStyle: '',
       strokeStyle: '',
@@ -80,5 +84,25 @@ describe('drawFinisherCard', () => {
         weeklyBadge: 'W22 · 2026',
       }),
     ).not.toThrow();
+  });
+
+  it('renders premium frame styles without throwing', () => {
+    const canvas = createCanvas();
+    for (const frameStyle of ['neon', 'gold', 'carbon'] as const) {
+      expect(() =>
+        drawFinisherCard(canvas, {
+          width: 360,
+          height: 640,
+          faction: 'horde',
+          division: 'regular',
+          username: 'grinder',
+          challengeTitle: 'Weekly Grit',
+          scoreType: 'reps',
+          scoreValue: 88,
+          topPercent: 15,
+          frameStyle,
+        }),
+      ).not.toThrow();
+    }
   });
 });

--- a/src/features/finisher-card/lib/drawCard.ts
+++ b/src/features/finisher-card/lib/drawCard.ts
@@ -1,5 +1,6 @@
 import type { FinisherCardDrawOptions } from '@/lib/finisher/buildFinisherCardOptions';
 import { getDivisionColor } from '@/lib/divisions';
+import type { FinisherFrameStyle } from '@/lib/finisher/frameStyles';
 import type { Faction } from '@/lib/types/database.types';
 
 type Options = FinisherCardDrawOptions;
@@ -247,6 +248,74 @@ export function drawFinisherCard(canvas: HTMLCanvasElement, options: Options): v
   ctx.fillStyle = muted;
   ctx.font = `900 ${factionSize}px system-ui, -apple-system, Segoe UI, sans-serif`;
   ctx.fillText(truncateToWidth(ctx, factionLabel, maxTextW), textX, factionY);
+
+  drawFinisherFrame(ctx, {
+    innerX,
+    innerY,
+    innerW,
+    innerH,
+    accent,
+    frameStyle: options.frameStyle ?? 'standard',
+    lineWidth: Math.max(2, Math.floor(canvas.width * 0.011)),
+  });
+}
+
+function drawFinisherFrame(
+  ctx: CanvasRenderingContext2D,
+  params: {
+    innerX: number;
+    innerY: number;
+    innerW: number;
+    innerH: number;
+    accent: string;
+    frameStyle: FinisherFrameStyle;
+    lineWidth: number;
+  },
+): void {
+  const { innerX, innerY, innerW, innerH, accent, frameStyle, lineWidth } = params;
+  if (frameStyle === 'standard') return;
+
+  const inset = Math.max(4, Math.floor(innerW * 0.02));
+
+  if (frameStyle === 'neon') {
+    ctx.strokeStyle = accent;
+    ctx.lineWidth = lineWidth * 2;
+    ctx.strokeRect(innerX + inset, innerY + inset, innerW - inset * 2, innerH - inset * 2);
+    ctx.strokeStyle = '#f9fafb';
+    ctx.lineWidth = lineWidth;
+    ctx.strokeRect(innerX + inset * 2, innerY + inset * 2, innerW - inset * 4, innerH - inset * 4);
+    return;
+  }
+
+  if (frameStyle === 'gold') {
+    ctx.strokeStyle = '#ffb800';
+    ctx.lineWidth = lineWidth * 3;
+    ctx.strokeRect(innerX + inset, innerY + inset, innerW - inset * 2, innerH - inset * 2);
+    ctx.fillStyle = 'rgba(255, 184, 0, 0.08)';
+    ctx.fillRect(innerX + inset, innerY + inset, innerW - inset * 2, innerH - inset * 2);
+    return;
+  }
+
+  if (frameStyle === 'carbon') {
+    ctx.strokeStyle = '#3a3a4a';
+    ctx.lineWidth = lineWidth * 2;
+    ctx.strokeRect(innerX + inset, innerY + inset, innerW - inset * 2, innerH - inset * 2);
+    const step = Math.max(8, Math.floor(innerW * 0.04));
+    ctx.strokeStyle = 'rgba(42, 42, 58, 0.6)';
+    ctx.lineWidth = 1;
+    for (let x = innerX + inset; x < innerX + innerW - inset; x += step) {
+      ctx.beginPath();
+      ctx.moveTo(x, innerY + inset);
+      ctx.lineTo(x, innerY + innerH - inset);
+      ctx.stroke();
+    }
+    for (let y = innerY + inset; y < innerY + innerH - inset; y += step) {
+      ctx.beginPath();
+      ctx.moveTo(innerX + inset, y);
+      ctx.lineTo(innerX + innerW - inset, y);
+      ctx.stroke();
+    }
+  }
 }
 
 function formatSeconds(totalSeconds: number): string {

--- a/src/features/profile/components/PassportScreen.tsx
+++ b/src/features/profile/components/PassportScreen.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from 'next-intl';
 
 import { FinisherGallery } from '@/features/finisher-card';
 import { ProfileRatingCard } from '@/features/profile/components/ProfileRatingCard';
+import { FinisherCosmeticsTeaser } from '@/features/profile/components/passport/FinisherCosmeticsTeaser';
 import { PassportBadgesSection } from '@/features/profile/components/passport/PassportBadgesSection';
 import { PassportDivisionSection } from '@/features/profile/components/passport/PassportDivisionSection';
 import { PassportPrivacySection } from '@/features/profile/components/passport/PassportPrivacySection';
@@ -97,6 +98,14 @@ export function PassportScreen() {
       <PassportWeeklySection weeklies={passportData?.weeklies ?? []} loading={dataLoading} />
 
       <PassportRivalsSection wins={passportData?.rivalWins ?? []} loading={dataLoading} />
+
+      {profile.username && profile.faction ? (
+        <FinisherCosmeticsTeaser
+          username={profile.username}
+          faction={profile.faction}
+          division={profile.division}
+        />
+      ) : null}
 
       <FinisherGallery
         userId={profile.id}

--- a/src/features/profile/components/passport/FinisherCosmeticsTeaser.tsx
+++ b/src/features/profile/components/passport/FinisherCosmeticsTeaser.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { drawFinisherCard } from '@/features/finisher-card/lib/drawCard';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+import { buildFinisherCardOptionsThumb } from '@/lib/finisher/buildFinisherCardOptions';
+import type { FinisherFrameStyle } from '@/lib/finisher/frameStyles';
+import { PREMIUM_FINISHER_FRAMES } from '@/lib/finisher/frameStyles';
+import type { Division, Faction } from '@/lib/types/database.types';
+
+const INTEREST_KEY = 'tg_monetization_cosmetics_interest';
+
+type Props = {
+  username: string;
+  faction: Faction;
+  division: Division;
+};
+
+function FramePreview({
+  frameStyle,
+  username,
+  faction,
+  division,
+  label,
+}: {
+  frameStyle: FinisherFrameStyle;
+  username: string;
+  faction: Faction;
+  division: Division;
+  label: string;
+}) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  const options = useMemo(
+    () =>
+      buildFinisherCardOptionsThumb({
+        faction,
+        division,
+        username,
+        challengeTitle: 'Weekly Grit Open',
+        scoreType: 'reps',
+        scoreValue: 142,
+        ranked: true,
+        frameStyle,
+      }),
+    [division, faction, frameStyle, username],
+  );
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    drawFinisherCard(canvas, options);
+  }, [options]);
+
+  return (
+    <figure className="space-y-2">
+      <canvas ref={ref} className="block h-auto w-full rounded-sm border border-border" />
+      <figcaption className="text-center text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+        {label}
+      </figcaption>
+    </figure>
+  );
+}
+
+export function FinisherCosmeticsTeaser({ username, faction, division }: Props) {
+  const t = useTranslations('profile.passport.cosmetics');
+  const [interested, setInterested] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return localStorage.getItem(INTEREST_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    trackEvent(ANALYTICS_EVENTS.monetizationCosmeticsViewed);
+  }, []);
+
+  const onInterest = useCallback(() => {
+    try {
+      localStorage.setItem(INTEREST_KEY, '1');
+    } catch {
+      /* ignore */
+    }
+    setInterested(true);
+    trackEvent(ANALYTICS_EVENTS.monetizationCosmeticsInterest, { surface: 'passport_teaser' });
+  }, []);
+
+  const frameLabels: Record<FinisherFrameStyle, string> = {
+    standard: t('frames.standard'),
+    neon: t('frames.neon'),
+    gold: t('frames.gold'),
+    carbon: t('frames.carbon'),
+  };
+
+  return (
+    <section
+      className="rounded-sm border border-dashed border-accent/40 bg-muted/10 p-4 space-y-4"
+      aria-labelledby="passport-cosmetics-title"
+    >
+      <div>
+        <p className="text-[10px] font-black uppercase tracking-[0.2em] text-accent">
+          {t('kicker')}
+        </p>
+        <h2
+          id="passport-cosmetics-title"
+          className="mt-1 text-xs font-black uppercase tracking-[0.18em] text-foreground"
+        >
+          {t('title')}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">{t('body')}</p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        {PREMIUM_FINISHER_FRAMES.map((frame) => (
+          <FramePreview
+            key={frame}
+            frameStyle={frame}
+            username={username}
+            faction={faction}
+            division={division}
+            label={frameLabels[frame]}
+          />
+        ))}
+      </div>
+
+      <p className="text-xs text-muted-foreground">{t('noPayToWin')}</p>
+
+      <button
+        type="button"
+        onClick={onInterest}
+        disabled={interested}
+        aria-label={interested ? t('interestDone') : t('interestCta')}
+        className="inline-flex min-h-11 w-full items-center justify-center rounded-md border border-border bg-card px-4 py-3 text-xs font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-60"
+      >
+        {interested ? t('interestDone') : t('interestCta')}
+      </button>
+    </section>
+  );
+}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -5,6 +5,8 @@ export const ANALYTICS_EVENTS = {
   shareFinisher: 'growth_share_finisher',
   signupCompleted: 'growth_signup_completed',
   firstScoreSubmitted: 'growth_first_score_submitted',
+  monetizationCosmeticsViewed: 'monetization_cosmetics_teaser_viewed',
+  monetizationCosmeticsInterest: 'monetization_cosmetics_interest',
 } as const;
 
 export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];

--- a/src/lib/finisher/buildFinisherCardOptions.ts
+++ b/src/lib/finisher/buildFinisherCardOptions.ts
@@ -1,3 +1,4 @@
+import type { FinisherFrameStyle } from '@/lib/finisher/frameStyles';
 import type { Division, Faction, ScoreType } from '@/lib/types/database.types';
 
 export type FinisherCardDrawOptions = {
@@ -22,6 +23,8 @@ export type FinisherCardDrawOptions = {
   ratingDeltaText?: string;
   /** V2-11: e.g. "+892 WAR PTS". */
   warPointsText?: string;
+  /** V2-12: cosmetic frame (standard free; premium frames exploratory). */
+  frameStyle?: FinisherFrameStyle;
 };
 
 type RankedLabels = {
@@ -89,6 +92,7 @@ type ThumbParams = {
   scoreType: ScoreType;
   scoreValue: number;
   ranked: boolean;
+  frameStyle?: FinisherFrameStyle;
 };
 
 export function buildFinisherCardOptionsThumb(params: ThumbParams): FinisherCardDrawOptions {
@@ -105,6 +109,7 @@ export function buildFinisherCardOptionsThumb(params: ThumbParams): FinisherCard
     scoreType: params.scoreType,
     scoreValue: params.scoreValue,
     topPercent: null,
+    frameStyle: params.frameStyle ?? 'standard',
     ...labels,
   };
 }

--- a/src/lib/finisher/frameStyles.ts
+++ b/src/lib/finisher/frameStyles.ts
@@ -1,0 +1,9 @@
+export const FINISHER_FRAME_STYLES = ['standard', 'neon', 'gold', 'carbon'] as const;
+
+export type FinisherFrameStyle = (typeof FINISHER_FRAME_STYLES)[number];
+
+export const PREMIUM_FINISHER_FRAMES: FinisherFrameStyle[] = ['neon', 'gold', 'carbon'];
+
+export function isPremiumFinisherFrame(style: FinisherFrameStyle): boolean {
+  return style !== 'standard';
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1061,6 +1061,20 @@
           "finishers": "Finisher card gallery",
           "rivalWins": "Rival match wins"
         }
+      },
+      "cosmetics": {
+        "kicker": "COMING SOON",
+        "title": "FINISHER STYLES",
+        "body": "Premium card frames for your shares — same score, louder look. Help us pick what ships first.",
+        "noPayToWin": "Rank and leaderboard access stay free. Cosmetics change visuals only.",
+        "interestCta": "NOTIFY ME",
+        "interestDone": "ON THE LIST",
+        "frames": {
+          "standard": "STANDARD",
+          "neon": "NEON",
+          "gold": "GOLD",
+          "carbon": "CARBON"
+        }
       }
     },
     "header": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1061,6 +1061,20 @@
           "finishers": "Galerie finisher cards",
           "rivalWins": "Victoires en rival match"
         }
+      },
+      "cosmetics": {
+        "kicker": "BIENTÔT",
+        "title": "STYLES FINISHER",
+        "body": "Cadres premium pour tes partages — même score, look plus fort. Aide-nous à prioriser.",
+        "noPayToWin": "Rang et leaderboard restent gratuits. Les cosmetics ne changent que le visuel.",
+        "interestCta": "ME TENIR AU COURANT",
+        "interestDone": "INSCRIT",
+        "frames": {
+          "standard": "STANDARD",
+          "neon": "NÉON",
+          "gold": "OR",
+          "carbon": "CARBONE"
+        }
       }
     },
     "header": {


### PR DESCRIPTION
Fixes #98

## Summary
- Document H1 hypothesis (Finisher Card cosmetics) in `docs/MONETIZATION_V2-12.md` with PostHog HogQL templates and go/no-go thresholds
- Passport teaser: premium frame previews (`neon`, `gold`, `carbon`) + interest CTA with analytics events
- Repair corrupted `docs/V3_STRATEGY.md`
- No Stripe, no pay-to-win — sport rank stays free

## Test plan
- [x] `pnpm typecheck` + `pnpm test:run`
- [ ] Open `/app/profile/passport` — see Finisher styles section, click Notify me
- [ ] Verify PostHog events when `NEXT_PUBLIC_POSTHOG_KEY` is set

Made with [Cursor](https://cursor.com)