### PR TITLE
feat(analytics): identify users + enrich PostHog events

### DIFF
--- a/src/features/auth/AuthProvider.tsx
+++ b/src/features/auth/AuthProvider.tsx
@@ -3,6 +3,15 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
+import { identifyUser, resetAnalyticsIdentity } from '@/lib/analytics/trackEvent';
+
+function syncAnalyticsIdentity(user: User | null): void {
+  if (user) {
+    identifyUser(user.id, user.email ? { email: user.email } : undefined);
+  } else {
+    resetAnalyticsIdentity();
+  }
+}
 
 type AuthState = {
   user: User | null;
@@ -33,6 +42,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       try {
         const { data } = await supabase.auth.getSession();
         if (!isActive) return;
+        syncAnalyticsIdentity(data.session?.user ?? null);
         setState({
           user: data.session?.user ?? null,
           session: data.session ?? null,
@@ -49,6 +59,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
       if (!isActive) return;
+      syncAnalyticsIdentity(session?.user ?? null);
       setState({
         user: session?.user ?? null,
         session: session ?? null,

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -3,6 +3,7 @@ import type { AnalyticsEventName } from '@/lib/analytics/events';
 type EventProperties = Record<string, string | number | boolean | null | undefined>;
 
 const DISTINCT_ID_KEY = 'tg_analytics_distinct_id';
+const LIB = 'truegrynd-web';
 
 function getDistinctId(): string {
   if (typeof window === 'undefined') return 'server';
@@ -17,6 +18,26 @@ function getDistinctId(): string {
   }
 }
 
+function resolvePostHog(): { apiKey: string; host: string } | null {
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!apiKey) return null;
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
+  return { apiKey, host };
+}
+
+function capture(body: Record<string, unknown>): void {
+  const cfg = resolvePostHog();
+  if (!cfg) return;
+  void fetch(`${cfg.host}/capture/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ api_key: cfg.apiKey, ...body }),
+    keepalive: true,
+  }).catch(() => {
+    /* analytics must not break UX */
+  });
+}
+
 export function trackEvent(name: AnalyticsEventName, properties?: EventProperties): void {
   if (typeof window === 'undefined') return;
 
@@ -24,21 +45,59 @@ export function trackEvent(name: AnalyticsEventName, properties?: EventPropertie
     new CustomEvent('truegrynd:analytics', { detail: { name, properties: properties ?? {} } }),
   );
 
-  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
-  if (!apiKey) return;
-
-  void fetch(`${host}/capture/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      api_key: apiKey,
-      event: name,
-      distinct_id: getDistinctId(),
-      properties: { ...properties, source: 'web' },
-    }),
-    keepalive: true,
-  }).catch(() => {
-    /* analytics must not break UX */
+  capture({
+    event: name,
+    distinct_id: getDistinctId(),
+    properties: {
+      ...properties,
+      source: 'web',
+      $lib: LIB,
+      $current_url: window.location.href,
+    },
   });
+}
+
+/**
+ * Tie the anonymous distinct id to the authenticated user so events stitch into
+ * real per-person funnels (signup → first score → share). Idempotent: a no-op
+ * once already identified to this user. Call on login / session restore.
+ */
+export function identifyUser(userId: string, setProps?: EventProperties): void {
+  if (typeof window === 'undefined' || !userId) return;
+  if (!resolvePostHog()) return;
+
+  let anonId = '';
+  try {
+    anonId = localStorage.getItem(DISTINCT_ID_KEY) ?? '';
+  } catch {
+    anonId = '';
+  }
+  if (anonId === userId) return; // already identified to this user
+
+  capture({
+    event: '$identify',
+    distinct_id: userId,
+    properties: {
+      $anon_distinct_id: anonId || undefined,
+      $set: { ...setProps },
+      $lib: LIB,
+      source: 'web',
+    },
+  });
+
+  try {
+    localStorage.setItem(DISTINCT_ID_KEY, userId);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Drop the identified id on logout so a fresh anonymous id is minted next time. */
+export function resetAnalyticsIdentity(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(DISTINCT_ID_KEY);
+  } catch {
+    /* ignore */
+  }
 }


### PR DESCRIPTION
Makes PostHog events usable for real funnels instead of anonymous UUIDs.

- **`identifyUser()`** — ties the anonymous `distinct_id` to the Supabase user id at login/session restore (idempotent), `$set`s the email. Events now stitch into per-person funnels (signup → first score → share).
- **`resetAnalyticsIdentity()`** on logout — fresh anon id on shared devices.
- **`trackEvent`** now sends `$current_url` + `$lib` → PostHog URL / Library columns populated.
- Wired into `AuthProvider` (getSession + onAuthStateChange).

**Verified live:** `$identify` POSTs to PostHog EU (`200`), `distinct_id` becomes the user id, email shows on the person; regular events carry `$current_url`. typecheck + lint + 218 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)