### PR TITLE
fix(passport): cosmetics teaser always visible (restore H1 signal)

### DIFF
--- a/src/features/profile/components/PassportScreen.tsx
+++ b/src/features/profile/components/PassportScreen.tsx
@@ -93,21 +93,12 @@ export function PassportScreen() {
       id: 'activity',
       label: tTabs('activity'),
       content: (
-        <>
-          {profile.username && profile.faction ? (
-            <FinisherCosmeticsTeaser
-              username={profile.username}
-              faction={profile.faction}
-              division={profile.division}
-            />
-          ) : null}
-          <FinisherGallery
-            userId={profile.id}
-            username={profile.username}
-            faction={profile.faction}
-            division={profile.division}
-          />
-        </>
+        <FinisherGallery
+          userId={profile.id}
+          username={profile.username}
+          faction={profile.faction}
+          division={profile.division}
+        />
       ),
     },
     {
@@ -134,6 +125,14 @@ export function PassportScreen() {
       <PassportShareBar publicPath={publicPath} />
 
       <Tabs tabs={tabs} ariaLabel={t('title')} />
+
+      {profile.username && profile.faction ? (
+        <FinisherCosmeticsTeaser
+          username={profile.username}
+          faction={profile.faction}
+          division={profile.division}
+        />
+      ) : null}
 
       <PassportPrivacySection profile={profile} onSaved={refetchProfile} />
     </section>


### PR DESCRIPTION
Found during the prod smoke (#104).

The passport tab redesign buried `FinisherCosmeticsTeaser` inside the **Activity** tab, so `monetization_cosmetics_teaser_viewed` only fired when that tab was opened — killing the H1 monetization signal. This renders the teaser outside the tabs (always visible on the passport), restoring the event on every load.

typecheck + lint + 218 tests green.

Refs #104