### PR TITLE
chore(clean-code): split oversized components + dedupe shared UI

### DIFF
--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+const BASE =
+  'inline-flex w-full items-center justify-center rounded-md px-4 py-3 text-sm font-black uppercase tracking-[0.18em] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+/** Full-width primary (red) call-to-action link. */
+export function PrimaryButtonLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link href={href} className={`${BASE} bg-primary text-primary-foreground hover:opacity-90`}>
+      {label}
+    </Link>
+  );
+}
+
+/** Full-width secondary (outlined) link — quieter than the primary CTA. */
+export function SecondaryButtonLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className={`${BASE} border border-border bg-background text-foreground hover:bg-muted`}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/features/challenges/components/Leaderboard.tsx
+++ b/src/features/challenges/components/Leaderboard.tsx
@@ -7,7 +7,7 @@ import { useLocale, useTranslations } from 'next-intl';
 
 import { LeaderboardFiltersBar } from '@/features/challenges/components/LeaderboardFilters';
 import { LeaderboardPresetsBar } from '@/features/challenges/components/LeaderboardPresets';
-import { RespectButton } from '@/features/challenges/components/RespectButton';
+import { LeaderboardRow } from '@/features/challenges/components/LeaderboardRow';
 import { useChallengeLeaderboard } from '@/features/challenges/hooks/useChallengeLeaderboard';
 import { useScoreRespects } from '@/features/challenges/hooks/useScoreRespects';
 import { applyLeaderboardFilters } from '@/features/challenges/lib/applyFilters';
@@ -19,15 +19,12 @@ import {
 } from '@/features/challenges/lib/leaderboardPresets';
 import { resolveLeaderboardFilters } from '@/features/challenges/lib/resolveLeaderboardFilters';
 import { sortScoresByType } from '@/features/challenges/lib/leaderboardSort';
-import { formatScore } from '@/features/challenges/lib/scoreFormat';
 import {
   EMPTY_FILTERS,
   type LeaderboardEntry,
   type LeaderboardFilters,
 } from '@/features/challenges/lib/types';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
-import { ProofLevelBadge } from '@/components/ProofLevelBadge';
-import { ReportScoreButton } from '@/features/challenges/components/ReportScoreButton';
 import type { ScoreType } from '@/lib/types/database.types';
 
 type Props = {
@@ -37,90 +34,6 @@ type Props = {
   /** 'preview' = compact top rows + link to the full page; 'full' = filterable page. */
   mode?: 'preview' | 'full';
 };
-
-function rankColorClass(rank: number): string {
-  if (rank === 1) return 'text-yellow-400';
-  if (rank === 2) return 'text-zinc-300';
-  if (rank === 3) return 'text-amber-600';
-  return 'text-muted-foreground';
-}
-
-function LeaderboardRow({
-  rank,
-  entry,
-  scoreType,
-  currentUserId,
-  respectCount,
-  isRespected,
-  respectDisabled,
-  onRespectToggle,
-  showDivisionBadge,
-  isCurrentUser,
-  youLabel,
-}: {
-  rank: number;
-  entry: LeaderboardEntry;
-  scoreType: ScoreType;
-  currentUserId: string | null;
-  respectCount: number;
-  isRespected: boolean;
-  respectDisabled: boolean;
-  onRespectToggle: (scoreId: string) => Promise<void>;
-  showDivisionBadge: boolean;
-  isCurrentUser: boolean;
-  youLabel: string;
-}) {
-  const username = entry.profile?.username ?? '—';
-  return (
-    <li
-      className={[
-        'border-b border-border px-3 py-2 last:border-b-0',
-        isCurrentUser ? 'bg-accent/10 ring-1 ring-inset ring-accent/40' : '',
-      ].join(' ')}
-    >
-      <div className="grid grid-cols-[3rem_1fr_auto_auto] items-center gap-3">
-        <span className={`font-mono text-sm font-black tabular-nums ${rankColorClass(rank)}`}>
-          #{rank}
-        </span>
-        <div className="min-w-0">
-          <span className="flex items-center gap-2">
-            <span className="truncate text-sm font-bold text-foreground">{username}</span>
-            {isCurrentUser ? (
-              <span className="shrink-0 rounded-sm bg-accent px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-accent-foreground">
-                {youLabel}
-              </span>
-            ) : null}
-          </span>
-          <div className="mt-1 flex flex-wrap items-center gap-2">
-            <ProofLevelBadge level={entry.proof_level} compact />
-            {showDivisionBadge && entry.profile?.division ? (
-              <span className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-                {entry.profile.division}
-              </span>
-            ) : null}
-          </div>
-        </div>
-        <span className="font-mono text-sm tabular-nums text-foreground">
-          {formatScore(entry.value, scoreType)}
-        </span>
-        <RespectButton
-          scoreId={entry.id}
-          scoreUserId={entry.user_id}
-          currentUserId={currentUserId}
-          count={respectCount}
-          respected={isRespected}
-          disabled={respectDisabled}
-          onToggle={onRespectToggle}
-        />
-      </div>
-      <ReportScoreButton
-        scoreId={entry.id}
-        scoreUserId={entry.user_id}
-        currentUserId={currentUserId}
-      />
-    </li>
-  );
-}
 
 const PROOF_SUMMARY_KEY: Record<string, string> = {
   video_ranked: 'videoRanked',

--- a/src/features/challenges/components/LeaderboardRow.tsx
+++ b/src/features/challenges/components/LeaderboardRow.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { ProofLevelBadge } from '@/components/ProofLevelBadge';
+import { ReportScoreButton } from '@/features/challenges/components/ReportScoreButton';
+import { RespectButton } from '@/features/challenges/components/RespectButton';
+import { formatScore } from '@/features/challenges/lib/scoreFormat';
+import type { LeaderboardEntry } from '@/features/challenges/lib/types';
+import { rankMedalColorClass } from '@/lib/rankMedal';
+import type { ScoreType } from '@/lib/types/database.types';
+
+type Props = {
+  rank: number;
+  entry: LeaderboardEntry;
+  scoreType: ScoreType;
+  currentUserId: string | null;
+  respectCount: number;
+  isRespected: boolean;
+  respectDisabled: boolean;
+  onRespectToggle: (scoreId: string) => Promise<void>;
+  showDivisionBadge: boolean;
+  isCurrentUser: boolean;
+  youLabel: string;
+};
+
+/** One ranked row: medal-coloured rank, username (+ YOU tag), proof badge, score, respect, report. */
+export function LeaderboardRow({
+  rank,
+  entry,
+  scoreType,
+  currentUserId,
+  respectCount,
+  isRespected,
+  respectDisabled,
+  onRespectToggle,
+  showDivisionBadge,
+  isCurrentUser,
+  youLabel,
+}: Props) {
+  const username = entry.profile?.username ?? '—';
+  return (
+    <li
+      className={[
+        'border-b border-border px-3 py-2 last:border-b-0',
+        isCurrentUser ? 'bg-accent/10 ring-1 ring-inset ring-accent/40' : '',
+      ].join(' ')}
+    >
+      <div className="grid grid-cols-[3rem_1fr_auto_auto] items-center gap-3">
+        <span className={`font-mono text-sm font-black tabular-nums ${rankMedalColorClass(rank)}`}>
+          #{rank}
+        </span>
+        <div className="min-w-0">
+          <span className="flex items-center gap-2">
+            <span className="truncate text-sm font-bold text-foreground">{username}</span>
+            {isCurrentUser ? (
+              <span className="shrink-0 rounded-sm bg-accent px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-accent-foreground">
+                {youLabel}
+              </span>
+            ) : null}
+          </span>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <ProofLevelBadge level={entry.proof_level} compact />
+            {showDivisionBadge && entry.profile?.division ? (
+              <span className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+                {entry.profile.division}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <span className="font-mono text-sm tabular-nums text-foreground">
+          {formatScore(entry.value, scoreType)}
+        </span>
+        <RespectButton
+          scoreId={entry.id}
+          scoreUserId={entry.user_id}
+          currentUserId={currentUserId}
+          count={respectCount}
+          respected={isRespected}
+          disabled={respectDisabled}
+          onToggle={onRespectToggle}
+        />
+      </div>
+      <ReportScoreButton
+        scoreId={entry.id}
+        scoreUserId={entry.user_id}
+        currentUserId={currentUserId}
+      />
+    </li>
+  );
+}

--- a/src/features/factions/components/FactionHallOfFame.tsx
+++ b/src/features/factions/components/FactionHallOfFame.tsx
@@ -8,6 +8,7 @@ import { formatClanPoints } from '@/features/factions/lib/formatClanPoints';
 import type { MemberRow } from '@/features/factions/services/clanHud';
 import { publicProfilePath } from '@/lib/profile/publicProfilePath';
 import { getFactionBadgeClasses } from '@/lib/factionStyles';
+import { rankMedalColorClass } from '@/lib/rankMedal';
 import type { Faction } from '@/lib/types/database.types';
 
 type Props = {
@@ -15,13 +16,6 @@ type Props = {
   members: MemberRow[];
   currentUserId: string | null;
 };
-
-function rankColorClass(rank: number): string {
-  if (rank === 1) return 'text-yellow-400';
-  if (rank === 2) return 'text-zinc-300';
-  if (rank === 3) return 'text-amber-600';
-  return 'text-muted-foreground';
-}
 
 export function FactionHallOfFame({ faction, members, currentUserId }: Props) {
   const locale = useLocale();
@@ -61,7 +55,9 @@ export function FactionHallOfFame({ faction, members, currentUserId }: Props) {
                   className={linkClass}
                 >
                   <div className="flex items-center gap-3">
-                    <span className={`text-xs font-black tabular-nums ${rankColorClass(idx + 1)}`}>
+                    <span
+                      className={`text-xs font-black tabular-nums ${rankMedalColorClass(idx + 1)}`}
+                    >
                       #{idx + 1}
                     </span>
                     <p className="text-sm font-black uppercase tracking-tight">{m.username}</p>

--- a/src/features/factions/components/FactionPageScreen.tsx
+++ b/src/features/factions/components/FactionPageScreen.tsx
@@ -7,6 +7,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { ClanFactionWarMeta } from '@/features/factions/components/ClanFactionWarMeta';
 import { FactionHallOfFame } from '@/features/factions/components/FactionHallOfFame';
 import { FactionRecentProof } from '@/features/factions/components/FactionRecentProof';
+import { FactionStandingsBar } from '@/features/factions/components/FactionStandingsBar';
 import { RecruitCta } from '@/features/factions/components/RecruitCta';
 import { useFactionPage } from '@/features/factions/hooks/useFactionPage';
 import { formatClanPoints } from '@/features/factions/lib/formatClanPoints';
@@ -86,7 +87,6 @@ export function FactionPageScreen({ slug }: Props) {
   const rank = rankIndex >= 0 ? rankIndex + 1 : null;
   const row = sortedRankings.find((r) => r.faction === faction);
   const isOwnFaction = userFaction === faction;
-  const maxPoints = Math.max(1, sortedRankings[0]?.points ?? 0);
   const myPoints = row?.points ?? 0;
   const gapText =
     rank === 1
@@ -158,34 +158,13 @@ export function FactionPageScreen({ slug }: Props) {
           <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
             {t('standingsTitle')}
           </p>
-          <div className="space-y-2">
-            {sortedRankings.map((r) => {
-              const mine = r.faction === faction;
-              return (
-                <div key={r.faction} className="flex items-center gap-2">
-                  <span
-                    className={[
-                      'w-28 shrink-0 truncate text-[10px] font-black uppercase tracking-[0.14em]',
-                      mine ? 'text-foreground' : 'text-muted-foreground',
-                    ].join(' ')}
-                  >
-                    {tClan(r.faction)}
-                  </span>
-                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
-                    <span
-                      className={
-                        mine ? 'block h-full bg-accent' : 'block h-full bg-muted-foreground/40'
-                      }
-                      style={{ width: `${Math.round((r.points / maxPoints) * 100)}%` }}
-                    />
-                  </span>
-                  <span className="w-14 shrink-0 text-right font-mono text-[11px] tabular-nums text-muted-foreground">
-                    {formatClanPoints(r.points)}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
+          <FactionStandingsBar
+            rankings={rankings}
+            myFaction={faction}
+            getLabel={(f) => tClan(f)}
+            showPoints
+            formatPoints={formatClanPoints}
+          />
           <p className="text-xs font-black uppercase tracking-[0.14em] text-accent">{gapText}</p>
         </div>
       </article>

--- a/src/features/factions/components/FactionStandingsBar.tsx
+++ b/src/features/factions/components/FactionStandingsBar.tsx
@@ -1,0 +1,60 @@
+import type { Faction } from '@/lib/types/database.types';
+
+type StandingRow = { faction: Faction; points: number };
+
+type Props = {
+  rankings: readonly StandingRow[];
+  myFaction: Faction;
+  /** Display label for a faction (callers pass their own i18n namespace). */
+  getLabel: (faction: Faction) => string;
+  /** Show the raw points on the right of each bar. */
+  showPoints?: boolean;
+  formatPoints?: (points: number) => string;
+};
+
+/**
+ * Horizontal "faction standings" bars (one per faction, width ∝ points, the
+ * viewer's faction highlighted). Shared by the Overview faction card and the
+ * faction page war stats so the visualization lives in one place.
+ */
+export function FactionStandingsBar({
+  rankings,
+  myFaction,
+  getLabel,
+  showPoints = false,
+  formatPoints = (n) => n.toLocaleString(),
+}: Props) {
+  const sorted = [...rankings].sort((a, b) => b.points - a.points);
+  const maxPoints = Math.max(1, sorted[0]?.points ?? 0);
+
+  return (
+    <div className="space-y-2">
+      {sorted.map((row) => {
+        const mine = row.faction === myFaction;
+        return (
+          <div key={row.faction} className="flex items-center gap-2">
+            <span
+              className={[
+                'w-28 shrink-0 truncate text-[10px] font-black uppercase tracking-[0.14em]',
+                mine ? 'text-foreground' : 'text-muted-foreground',
+              ].join(' ')}
+            >
+              {getLabel(row.faction)}
+            </span>
+            <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+              <span
+                className={mine ? 'block h-full bg-accent' : 'block h-full bg-muted-foreground/40'}
+                style={{ width: `${Math.round((row.points / maxPoints) * 100)}%` }}
+              />
+            </span>
+            {showPoints ? (
+              <span className="w-14 shrink-0 text-right font-mono text-[11px] tabular-nums text-muted-foreground">
+                {formatPoints(row.points)}
+              </span>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/overview/components/OverviewFactionCard.tsx
+++ b/src/features/overview/components/OverviewFactionCard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+import { FactionStandingsBar } from '@/features/factions/components/FactionStandingsBar';
+import { useClanHud } from '@/features/factions/hooks/useClanHud';
+import type { Faction } from '@/lib/types/database.types';
+
+/** Tappable Overview card: your faction's rank, points, gap, standings bars and contribution. */
+export function OverviewFactionCard({ href, userFaction }: { href: string; userFaction: Faction }) {
+  const t = useTranslations('overview');
+  const tFactions = useTranslations('factions');
+  const { state } = useClanHud();
+
+  const rankings =
+    state.status === 'ready' ? [...state.rankings].sort((a, b) => b.points - a.points) : [];
+  const myIndex = rankings.findIndex((r) => r.faction === userFaction);
+  const myRow = myIndex >= 0 ? rankings[myIndex] : null;
+  const rank = myIndex >= 0 ? myIndex + 1 : null;
+  const leaderPoints = rankings[0]?.points ?? 0;
+  const gapText =
+    myRow && rank
+      ? rank === 1
+        ? t('factionLeadingBy', { gap: myRow.points - (rankings[1]?.points ?? 0) })
+        : t('factionGapToFirst', { gap: leaderPoints - myRow.points })
+      : null;
+
+  return (
+    <Link
+      href={href}
+      aria-label={t('viewFactionAria')}
+      className="group block rounded-lg border border-border bg-card p-5 hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('factionStandingTitle')}
+        </p>
+        <ArrowRight
+          className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-foreground"
+          aria-hidden
+        />
+      </div>
+
+      {state.status === 'loading' ? (
+        <p className="mt-3 text-sm text-muted-foreground">{t('loading')}</p>
+      ) : null}
+
+      {state.status === 'error' ? (
+        <p className="mt-3 text-sm text-muted-foreground">{t('error')}</p>
+      ) : null}
+
+      {state.status === 'ready' && myRow && rank ? (
+        <div className="mt-3 space-y-4">
+          <div className="flex items-end justify-between gap-4">
+            <div>
+              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
+                {t('factionRankLabel')}
+              </p>
+              <p className="mt-1 text-4xl font-black tabular-nums leading-none">#{rank}</p>
+            </div>
+            <div className="text-right">
+              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
+                {t('factionPointsLabel')}
+              </p>
+              <p className="mt-1 text-2xl font-black tabular-nums leading-none text-accent">
+                {myRow.points.toLocaleString()}
+              </p>
+            </div>
+          </div>
+
+          {gapText ? (
+            <p className="text-xs font-black uppercase tracking-[0.14em] text-accent">{gapText}</p>
+          ) : null}
+
+          <FactionStandingsBar
+            rankings={state.rankings}
+            myFaction={userFaction}
+            getLabel={(f) => tFactions(f)}
+          />
+
+          <p className="text-xs text-muted-foreground">
+            {t('factionYourShare', { points: state.myContribution.toLocaleString() })}
+          </p>
+        </div>
+      ) : null}
+    </Link>
+  );
+}

--- a/src/features/overview/components/OverviewHeroCard.tsx
+++ b/src/features/overview/components/OverviewHeroCard.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { Flame } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { PrimaryButtonLink, SecondaryButtonLink } from '@/components/ButtonLink';
+import { getDivisionBadgeClasses } from '@/lib/divisions';
+import { getFactionBadgeClasses } from '@/lib/factionStyles';
+import type { Division, Faction } from '@/lib/types/database.types';
+
+type Props = {
+  username: string | null;
+  division: Division;
+  faction: Faction | null;
+  streakDays: number;
+  ratingValue: number | null;
+  primaryHref: string;
+  primaryLabel: string;
+  /** Render the CTA as secondary (the comeback banner owns the primary action). */
+  primaryAsSecondary: boolean;
+};
+
+/** Overview identity hero: name, division/faction badges, streak, rating, and the single CTA. */
+export function OverviewHeroCard({
+  username,
+  division,
+  faction,
+  streakDays,
+  ratingValue,
+  primaryHref,
+  primaryLabel,
+  primaryAsSecondary,
+}: Props) {
+  const t = useTranslations('overview');
+  const tFactions = useTranslations('factions');
+  const divisionBadge = getDivisionBadgeClasses(division);
+  const factionBadge = faction ? getFactionBadgeClasses(faction) : null;
+  const factionName = faction ? tFactions(faction) : null;
+
+  return (
+    <article className="rounded-lg border border-border bg-card p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="truncate text-xl font-black uppercase tracking-tight">{username ?? '—'}</p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <span
+              className={[
+                'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+                divisionBadge.bg,
+                divisionBadge.text,
+                divisionBadge.border,
+              ].join(' ')}
+            >
+              {division}
+            </span>
+            {faction && factionBadge && factionName ? (
+              <span
+                className={[
+                  'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
+                  factionBadge.bg,
+                  factionBadge.text,
+                  factionBadge.border,
+                ].join(' ')}
+              >
+                {factionName}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div
+          className="flex shrink-0 items-center gap-2"
+          role="group"
+          aria-label={t('streakLine', { days: streakDays })}
+        >
+          <Flame
+            className={
+              streakDays > 0
+                ? 'h-5 w-5 shrink-0 text-accent'
+                : 'h-5 w-5 shrink-0 text-muted-foreground'
+            }
+            aria-hidden
+          />
+          <span className="text-lg font-black tabular-nums tracking-tight">
+            {t('streakValue', { days: streakDays })}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-5 flex items-end justify-between gap-4 border-t border-border pt-5">
+        <div>
+          <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
+            {t('heroRating')}
+          </p>
+          <p className="mt-1 text-5xl font-black tabular-nums leading-none tracking-tight">
+            {ratingValue !== null ? ratingValue : '—'}
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">{t('heroRatingHint')}</p>
+        </div>
+      </div>
+
+      <div className="mt-5">
+        {primaryAsSecondary ? (
+          <SecondaryButtonLink href={primaryHref} label={primaryLabel} />
+        ) : (
+          <PrimaryButtonLink href={primaryHref} label={primaryLabel} />
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/features/overview/components/OverviewScreen.tsx
+++ b/src/features/overview/components/OverviewScreen.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { ArrowRight, Flame } from 'lucide-react';
-import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { SecondaryButtonLink } from '@/components/ButtonLink';
 import { factionPath } from '@/features/factions/lib/factionSlug';
-import { useClanHud } from '@/features/factions/hooks/useClanHud';
 import {
   resolveWeeklyDisplayLabel,
   useWeeklyChallenge,
 } from '@/features/overview/hooks/useWeeklyChallenge';
+import { OverviewFactionCard } from '@/features/overview/components/OverviewFactionCard';
+import { OverviewHeroCard } from '@/features/overview/components/OverviewHeroCard';
 import { EventCard } from '@/features/events/components/EventCard';
 import { useActiveEvents } from '@/features/events/hooks/useActiveEvents';
 import { ComebackWeekBanner } from '@/features/growth/components/ComebackWeekBanner';
@@ -17,39 +17,13 @@ import { WeeklyChallengeInvite } from '@/features/growth/components/WeeklyChalle
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { useProfileRating } from '@/features/profile/hooks/useProfileRating';
 import { getComebackEligibility } from '@/lib/growth/comebackWeek';
-import { getDivisionBadgeClasses } from '@/lib/divisions';
-import { getFactionBadgeClasses } from '@/lib/factionStyles';
 import { getWeeklyTimeRemaining } from '@/lib/weekly';
-import type { Faction } from '@/lib/types/database.types';
-
-function PrimaryButtonLink({ href, label }: { href: string; label: string }) {
-  return (
-    <Link
-      href={href}
-      className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      {label}
-    </Link>
-  );
-}
-
-function SecondaryButtonLink({ href, label }: { href: string; label: string }) {
-  return (
-    <Link
-      href={href}
-      className="inline-flex w-full items-center justify-center rounded-md border border-border bg-background px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      {label}
-    </Link>
-  );
-}
 
 export function OverviewScreen() {
   const locale = useLocale();
   const tApp = useTranslations('app');
   const t = useTranslations('overview');
   const tWeekly = useTranslations('weekly');
-  const tFactions = useTranslations('factions');
 
   const { state: weeklyState } = useWeeklyChallenge();
   const { state: eventsState } = useActiveEvents();
@@ -59,10 +33,7 @@ export function OverviewScreen() {
   const clanHref = `/${locale}/app/clan`;
   const readyProfile = appProfile;
   const userFaction = readyProfile?.faction ?? null;
-  const factionBadge = userFaction ? getFactionBadgeClasses(userFaction) : null;
-  const factionName = userFaction ? tFactions(userFaction) : null;
   const factionHref = userFaction ? factionPath(locale, userFaction) : clanHref;
-  const divisionBadge = readyProfile ? getDivisionBadgeClasses(readyProfile.division) : null;
 
   const weekly = weeklyState.status === 'ready' ? weeklyState.weekly : null;
   const weeklyLabel = weekly ? resolveWeeklyDisplayLabel(weekly) : null;
@@ -105,80 +76,17 @@ export function OverviewScreen() {
         />
       ) : null}
 
-      {/* HERO — identity + rating + streak + the single primary action */}
       {readyProfile ? (
-        <article className="rounded-lg border border-border bg-card p-5">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <p className="truncate text-xl font-black uppercase tracking-tight">
-                {readyProfile.username ?? '—'}
-              </p>
-              <div className="mt-2 flex flex-wrap items-center gap-2">
-                {divisionBadge ? (
-                  <span
-                    className={[
-                      'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
-                      divisionBadge.bg,
-                      divisionBadge.text,
-                      divisionBadge.border,
-                    ].join(' ')}
-                  >
-                    {readyProfile.division}
-                  </span>
-                ) : null}
-                {userFaction && factionBadge && factionName ? (
-                  <span
-                    className={[
-                      'inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em]',
-                      factionBadge.bg,
-                      factionBadge.text,
-                      factionBadge.border,
-                    ].join(' ')}
-                  >
-                    {factionName}
-                  </span>
-                ) : null}
-              </div>
-            </div>
-            <div
-              className="flex shrink-0 items-center gap-2"
-              role="group"
-              aria-label={t('streakLine', { days: readyProfile.streak_days })}
-            >
-              <Flame
-                className={
-                  readyProfile.streak_days > 0
-                    ? 'h-5 w-5 shrink-0 text-accent'
-                    : 'h-5 w-5 shrink-0 text-muted-foreground'
-                }
-                aria-hidden
-              />
-              <span className="text-lg font-black tabular-nums tracking-tight">
-                {t('streakValue', { days: readyProfile.streak_days })}
-              </span>
-            </div>
-          </div>
-
-          <div className="mt-5 flex items-end justify-between gap-4 border-t border-border pt-5">
-            <div>
-              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
-                {t('heroRating')}
-              </p>
-              <p className="mt-1 text-5xl font-black tabular-nums leading-none tracking-tight">
-                {ratingValue !== null ? ratingValue : '—'}
-              </p>
-              <p className="mt-2 text-xs text-muted-foreground">{t('heroRatingHint')}</p>
-            </div>
-          </div>
-
-          <div className="mt-5">
-            {showComeback ? (
-              <SecondaryButtonLink href={primaryHref} label={primaryLabel} />
-            ) : (
-              <PrimaryButtonLink href={primaryHref} label={primaryLabel} />
-            )}
-          </div>
-        </article>
+        <OverviewHeroCard
+          username={readyProfile.username}
+          division={readyProfile.division}
+          faction={userFaction}
+          streakDays={readyProfile.streak_days}
+          ratingValue={ratingValue}
+          primaryHref={primaryHref}
+          primaryLabel={primaryLabel}
+          primaryAsSecondary={showComeback}
+        />
       ) : (
         <article className="rounded-lg border border-border bg-card p-5">
           <p className="text-sm text-muted-foreground">{t('loading')}</p>
@@ -188,12 +96,7 @@ export function OverviewScreen() {
       {/* CONTENT ROW — faction standing + weekly (quiet, tappable) */}
       <div className="grid gap-4 md:grid-cols-2">
         {userFaction ? (
-          <FactionStandingCard
-            href={factionHref}
-            userFaction={userFaction}
-            t={t}
-            tFactions={tFactions}
-          />
+          <OverviewFactionCard href={factionHref} userFaction={userFaction} />
         ) : (
           <article className="rounded-lg border border-border bg-card p-5">
             <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
@@ -281,114 +184,5 @@ export function OverviewScreen() {
         ) : null}
       </article>
     </section>
-  );
-}
-
-function FactionStandingCard({
-  href,
-  userFaction,
-  t,
-  tFactions,
-}: {
-  href: string;
-  userFaction: Faction;
-  t: ReturnType<typeof useTranslations>;
-  tFactions: ReturnType<typeof useTranslations>;
-}) {
-  const { state } = useClanHud();
-
-  const rankings =
-    state.status === 'ready' ? [...state.rankings].sort((a, b) => b.points - a.points) : [];
-  const myIndex = rankings.findIndex((r) => r.faction === userFaction);
-  const myRow = myIndex >= 0 ? rankings[myIndex] : null;
-  const rank = myIndex >= 0 ? myIndex + 1 : null;
-  const leaderPoints = rankings[0]?.points ?? 0;
-  const maxPoints = Math.max(1, leaderPoints);
-  const gapText =
-    myRow && rank
-      ? rank === 1
-        ? t('factionLeadingBy', { gap: myRow.points - (rankings[1]?.points ?? 0) })
-        : t('factionGapToFirst', { gap: leaderPoints - myRow.points })
-      : null;
-
-  return (
-    <Link
-      href={href}
-      aria-label={t('viewFactionAria')}
-      className="group block rounded-lg border border-border bg-card p-5 hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-          {t('factionStandingTitle')}
-        </p>
-        <ArrowRight
-          className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5 group-hover:text-foreground"
-          aria-hidden
-        />
-      </div>
-
-      {state.status === 'loading' ? (
-        <p className="mt-3 text-sm text-muted-foreground">{t('loading')}</p>
-      ) : null}
-
-      {state.status === 'error' ? (
-        <p className="mt-3 text-sm text-muted-foreground">{t('error')}</p>
-      ) : null}
-
-      {state.status === 'ready' && myRow && rank ? (
-        <div className="mt-3 space-y-4">
-          <div className="flex items-end justify-between gap-4">
-            <div>
-              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
-                {t('factionRankLabel')}
-              </p>
-              <p className="mt-1 text-4xl font-black tabular-nums leading-none">#{rank}</p>
-            </div>
-            <div className="text-right">
-              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
-                {t('factionPointsLabel')}
-              </p>
-              <p className="mt-1 text-2xl font-black tabular-nums leading-none text-accent">
-                {myRow.points.toLocaleString()}
-              </p>
-            </div>
-          </div>
-
-          {gapText ? (
-            <p className="text-xs font-black uppercase tracking-[0.14em] text-accent">{gapText}</p>
-          ) : null}
-
-          <div className="space-y-2">
-            {rankings.map((row) => {
-              const mine = row.faction === userFaction;
-              return (
-                <div key={row.faction} className="flex items-center gap-2">
-                  <span
-                    className={[
-                      'w-24 shrink-0 truncate text-[10px] font-black uppercase tracking-[0.14em]',
-                      mine ? 'text-foreground' : 'text-muted-foreground',
-                    ].join(' ')}
-                  >
-                    {tFactions(row.faction)}
-                  </span>
-                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
-                    <span
-                      className={
-                        mine ? 'block h-full bg-accent' : 'block h-full bg-muted-foreground/50'
-                      }
-                      style={{ width: `${Math.round((row.points / maxPoints) * 100)}%` }}
-                    />
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-
-          <p className="text-xs text-muted-foreground">
-            {t('factionYourShare', { points: state.myContribution.toLocaleString() })}
-          </p>
-        </div>
-      ) : null}
-    </Link>
   );
 }

--- a/src/lib/rankMedal.ts
+++ b/src/lib/rankMedal.ts
@@ -1,0 +1,11 @@
+/**
+ * Tailwind text-color class for a leaderboard rank: gold / silver / bronze for
+ * the podium, muted for everyone else. Shared by every ranked list (arena
+ * leaderboard, faction hall of fame, …) so the medal palette stays in one place.
+ */
+export function rankMedalColorClass(rank: number): string {
+  if (rank === 1) return 'text-yellow-400';
+  if (rank === 2) return 'text-zinc-300';
+  if (rank === 3) return 'text-amber-600';
+  return 'text-muted-foreground';
+}


### PR DESCRIPTION
Pure refactor — **no behaviour change**. typecheck + lint + 218 tests green; Overview & Faction pages verified visually identical.

### Shared modules (dedupe)
- `lib/rankMedal` — medal colour (gold/silver/bronze), was duplicated in `Leaderboard` + `FactionHallOfFame`.
- `components/ButtonLink` — `PrimaryButtonLink` / `SecondaryButtonLink` primitives.
- `FactionStandingsBar` — the faction mini-bars used by Overview + the faction page.

### Splits
- **Leaderboard** → extract `LeaderboardRow` into its own file.
- **Overview** (394 → ~200 l) → `OverviewHeroCard` + `OverviewFactionCard`; orchestrator only now.
- **FactionPageScreen** → uses `FactionStandingsBar` (inline bars removed).
- **FactionHallOfFame** → uses shared `rankMedalColorClass`.

Closes #106