### PR TITLE
chore(clean-code): dedupe data-hook boilerplate via useAsyncResource

### DIFF
--- a/src/features/challenges/hooks/useWeeklyChallengeMatch.ts
+++ b/src/features/challenges/hooks/useWeeklyChallengeMatch.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import { getWeeklyChallengeForChallengeId, type ActiveWeeklyChallenge } from '@/lib/weekly';
 
 type State =
@@ -9,24 +10,15 @@ type State =
   | { status: 'ready'; weekly: ActiveWeeklyChallenge | null };
 
 export function useWeeklyChallengeMatch(challengeId: string): State {
-  const [state, setState] = useState<State>({ status: 'loading', weekly: null });
+  const { state: resource } = useAsyncResource<ActiveWeeklyChallenge | null>(
+    () => getWeeklyChallengeForChallengeId(challengeId),
+    [challengeId],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-
-    void (async () => {
-      try {
-        const weekly = await getWeeklyChallengeForChallengeId(challengeId);
-        if (!cancelled) setState({ status: 'ready', weekly });
-      } catch {
-        if (!cancelled) setState({ status: 'ready', weekly: null });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [challengeId]);
-
-  return state;
+  return useMemo<State>(() => {
+    if (resource.status === 'ready') return { status: 'ready', weekly: resource.data };
+    // A failed lookup is non-fatal: behave as "no weekly match" (was a swallowed catch).
+    if (resource.status === 'error') return { status: 'ready', weekly: null };
+    return { status: 'loading', weekly: null };
+  }, [resource]);
 }

--- a/src/features/events/hooks/useActiveEvents.ts
+++ b/src/features/events/hooks/useActiveEvents.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import { getActiveEvents, type ActiveEventSummary } from '@/lib/events/getActiveEvents';
 
 type State =
@@ -10,32 +11,17 @@ type State =
   | { status: 'error'; events: ActiveEventSummary[]; error: string };
 
 export function useActiveEvents(): { state: State; refetch: () => void } {
-  const [state, setState] = useState<State>({ status: 'loading', events: [], error: null });
-  const [reloadKey, setReloadKey] = useState(0);
+  const { state: resource, refetch } = useAsyncResource<ActiveEventSummary[]>(
+    () => getActiveEvents(),
+    [],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready') return { status: 'ready', events: resource.data, error: null };
+    if (resource.status === 'error')
+      return { status: 'error', events: [], error: resource.message };
+    return { status: 'loading', events: [], error: null };
+  }, [resource]);
 
-    void (async () => {
-      try {
-        const events = await getActiveEvents();
-        if (!cancelled) setState({ status: 'ready', events, error: null });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', events: [], error: message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [reloadKey]);
-
-  return {
-    state,
-    refetch: () => {
-      setState({ status: 'loading', events: [], error: null });
-      setReloadKey((k) => k + 1);
-    },
-  };
+  return { state, refetch };
 }

--- a/src/features/events/hooks/useEventDetail.ts
+++ b/src/features/events/hooks/useEventDetail.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import {
   fetchEventBySlug,
@@ -10,6 +10,7 @@ import {
   type EventRecapRow,
   type EventStanding,
 } from '@/features/events/services/events';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import type { Division } from '@/lib/types/database.types';
 
 type State =
@@ -42,57 +43,42 @@ type State =
       error: string;
     };
 
+type Result =
+  | { kind: 'found'; event: EventDetail; standings: EventStanding[]; recap: EventRecapRow[] }
+  | { kind: 'not_found' };
+
 const empty = { standings: [] as EventStanding[], recap: [] as EventRecapRow[] };
 
 export function useEventDetail(
   slug: string,
   division: Division,
 ): { state: State; refetch: () => void } {
-  const [state, setState] = useState<State>({
-    status: 'loading',
-    event: null,
-    ...empty,
-    error: null,
-  });
-  const [reloadKey, setReloadKey] = useState(0);
+  const { state: resource, refetch } = useAsyncResource<Result>(async () => {
+    const event = await fetchEventBySlug(slug);
+    if (!event) return { kind: 'not_found' };
+    const [standings, recap] = await Promise.all([
+      fetchEventStandings(event.id, division),
+      event.status === 'completed' ? fetchEventRecap(event.id) : Promise.resolve([]),
+    ]);
+    return { kind: 'found', event, standings, recap };
+  }, [slug, division]);
 
-  useEffect(() => {
-    let cancelled = false;
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready') {
+      return resource.data.kind === 'found'
+        ? {
+            status: 'ready',
+            event: resource.data.event,
+            standings: resource.data.standings,
+            recap: resource.data.recap,
+            error: null,
+          }
+        : { status: 'not_found', event: null, ...empty, error: null };
+    }
+    if (resource.status === 'error')
+      return { status: 'error', event: null, ...empty, error: resource.message };
+    return { status: 'loading', event: null, ...empty, error: null };
+  }, [resource]);
 
-    void (async () => {
-      try {
-        const event = await fetchEventBySlug(slug);
-        if (!event) {
-          if (!cancelled) setState({ status: 'not_found', event: null, ...empty, error: null });
-          return;
-        }
-
-        const [standings, recap] = await Promise.all([
-          fetchEventStandings(event.id, division),
-          event.status === 'completed' ? fetchEventRecap(event.id) : Promise.resolve([]),
-        ]);
-
-        if (!cancelled) {
-          setState({ status: 'ready', event, standings, recap, error: null });
-        }
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) {
-          setState({ status: 'error', event: null, ...empty, error: message });
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [slug, division, reloadKey]);
-
-  return {
-    state,
-    refetch: () => {
-      setState({ status: 'loading', event: null, ...empty, error: null });
-      setReloadKey((k) => k + 1);
-    },
-  };
+  return { state, refetch };
 }

--- a/src/features/events/hooks/useEventsList.ts
+++ b/src/features/events/hooks/useEventsList.ts
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import { listPublicEvents, type ActiveEventSummary } from '@/lib/events/getActiveEvents';
 
 type State =
@@ -10,32 +11,17 @@ type State =
   | { status: 'error'; events: ActiveEventSummary[]; error: string };
 
 export function useEventsList(): { state: State; refetch: () => void } {
-  const [state, setState] = useState<State>({ status: 'loading', events: [], error: null });
-  const [reloadKey, setReloadKey] = useState(0);
+  const { state: resource, refetch } = useAsyncResource<ActiveEventSummary[]>(
+    () => listPublicEvents(),
+    [],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready') return { status: 'ready', events: resource.data, error: null };
+    if (resource.status === 'error')
+      return { status: 'error', events: [], error: resource.message };
+    return { status: 'loading', events: [], error: null };
+  }, [resource]);
 
-    void (async () => {
-      try {
-        const events = await listPublicEvents();
-        if (!cancelled) setState({ status: 'ready', events, error: null });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', events: [], error: message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [reloadKey]);
-
-  return {
-    state,
-    refetch: () => {
-      setState({ status: 'loading', events: [], error: null });
-      setReloadKey((k) => k + 1);
-    },
-  };
+  return { state, refetch };
 }

--- a/src/features/factions/hooks/useClanHud.ts
+++ b/src/features/factions/hooks/useClanHud.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import {
@@ -9,6 +9,7 @@ import {
   type FactionRow,
   type MemberRow,
 } from '@/features/factions/services/clanHud';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import type { Faction } from '@/lib/types/database.types';
 
 type ReadyState = ClanHudData & {
@@ -20,72 +21,44 @@ type ReadyState = ClanHudData & {
 type State =
   | { status: 'loading'; rankings: null; members: null; error: null; war: null; myContribution: 0 }
   | ReadyState
-  | {
-      status: 'error';
-      rankings: null;
-      members: null;
-      error: string;
-      war: null;
-      myContribution: 0;
-    };
-
-const initial: State = {
-  status: 'loading',
-  rankings: null,
-  members: null,
-  error: null,
-  war: null,
-  myContribution: 0,
-};
+  | { status: 'error'; rankings: null; members: null; error: string; war: null; myContribution: 0 };
 
 export function useClanHud(): { state: State; refetch: () => void } {
   const appProfile = useOptionalAppProfile();
-  const [state, setState] = useState<State>(initial);
-  const [reloadKey, setReloadKey] = useState(0);
+  const faction = appProfile?.faction ?? null;
 
-  useEffect(() => {
-    if (!appProfile?.faction) return;
-    const faction = appProfile.faction;
-    const division = appProfile.division;
+  const { state: resource, refetch } = useAsyncResource<ClanHudData>(
+    () =>
+      getClanHudData({
+        faction: faction as Faction,
+        division: appProfile!.division,
+        userId: appProfile!.id,
+      }),
+    [appProfile],
+    { enabled: faction !== null },
+  );
 
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await getClanHudData({
-          faction,
-          division,
-          userId: appProfile.id,
-        });
-        if (cancelled) return;
-        setState({
-          status: 'ready',
-          ...data,
-          error: null,
-          faction,
-        });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled)
-          setState({
-            status: 'error',
-            rankings: null,
-            members: null,
-            error: message,
-            war: null,
-            myContribution: 0,
-          });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready' && faction)
+      return { status: 'ready', ...resource.data, error: null, faction };
+    if (resource.status === 'error')
+      return {
+        status: 'error',
+        rankings: null,
+        members: null,
+        error: resource.message,
+        war: null,
+        myContribution: 0,
+      };
+    return {
+      status: 'loading',
+      rankings: null,
+      members: null,
+      error: null,
+      war: null,
+      myContribution: 0,
     };
-  }, [appProfile, reloadKey]);
-
-  const refetch = useCallback(() => {
-    setState(initial);
-    setReloadKey((k) => k + 1);
-  }, []);
+  }, [resource, faction]);
 
   return { state, refetch };
 }

--- a/src/features/factions/hooks/useFactionPage.ts
+++ b/src/features/factions/hooks/useFactionPage.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { parseFactionSlug } from '@/features/factions/lib/factionSlug';
@@ -10,6 +10,7 @@ import {
   type FactionRow,
   type MemberRow,
 } from '@/features/factions/services/clanHud';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import type { Faction } from '@/lib/types/database.types';
 
 type ReadyState = ClanHudData & {
@@ -24,69 +25,37 @@ type State =
   | { status: 'invalid'; faction: null; rankings: null; members: null; error: null }
   | { status: 'error'; faction: Faction | null; rankings: null; members: null; error: string };
 
-const initial: State = {
-  status: 'loading',
-  faction: null,
-  rankings: null,
-  members: null,
-  error: null,
-};
-
 export function useFactionPage(slug: string): { state: State; refetch: () => void } {
   const parsed = parseFactionSlug(slug);
   const appProfile = useOptionalAppProfile();
-  const [state, setState] = useState<State>(initial);
-  const [reloadKey, setReloadKey] = useState(0);
 
-  useEffect(() => {
-    if (!parsed || !appProfile?.division) return;
+  const { state: resource, refetch } = useAsyncResource<ClanHudData>(
+    () =>
+      getClanHudData({
+        faction: parsed as Faction,
+        division: appProfile!.division,
+        userId: appProfile!.id,
+        limit: 10,
+      }),
+    [parsed, appProfile],
+    { enabled: parsed !== null && Boolean(appProfile?.division) },
+  );
 
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await getClanHudData({
-          faction: parsed,
-          division: appProfile.division,
-          userId: appProfile.id,
-          limit: 10,
-        });
-        if (cancelled) return;
-        setState({
-          status: 'ready',
-          faction: parsed,
-          ...data,
-          error: null,
-        });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) {
-          setState({
-            status: 'error',
-            faction: parsed,
-            rankings: null,
-            members: null,
-            error: message,
-          });
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [parsed, appProfile, reloadKey]);
-
-  const refetch = useCallback(() => {
-    setState(initial);
-    setReloadKey((k) => k + 1);
-  }, []);
-
-  if (!parsed) {
-    return {
-      state: { status: 'invalid', faction: null, rankings: null, members: null, error: null },
-      refetch,
-    };
-  }
+  const state = useMemo<State>(() => {
+    if (!parsed)
+      return { status: 'invalid', faction: null, rankings: null, members: null, error: null };
+    if (resource.status === 'ready')
+      return { status: 'ready', faction: parsed, ...resource.data, error: null };
+    if (resource.status === 'error')
+      return {
+        status: 'error',
+        faction: parsed,
+        rankings: null,
+        members: null,
+        error: resource.message,
+      };
+    return { status: 'loading', faction: parsed, rankings: null, members: null, error: null };
+  }, [parsed, resource]);
 
   return { state, refetch };
 }

--- a/src/features/factions/hooks/useFactionRecentVideos.ts
+++ b/src/features/factions/hooks/useFactionRecentVideos.ts
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import {
   listRecentFactionVideos,
   type FactionProofRow,
 } from '@/features/factions/services/clanHud';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import type { Faction } from '@/lib/types/database.types';
 
 type State =
@@ -14,23 +15,15 @@ type State =
   | { status: 'error'; rows: [] };
 
 export function useFactionRecentVideos(faction: Faction | null): State {
-  const [state, setState] = useState<State>({ status: 'loading', rows: [] });
+  const { state: resource } = useAsyncResource<FactionProofRow[]>(
+    () => listRecentFactionVideos(faction as Faction),
+    [faction],
+    { enabled: faction !== null },
+  );
 
-  useEffect(() => {
-    if (!faction) return undefined;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const rows = await listRecentFactionVideos(faction);
-        if (!cancelled) setState({ status: 'ready', rows });
-      } catch {
-        if (!cancelled) setState({ status: 'error', rows: [] });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [faction]);
-
-  return state;
+  return useMemo<State>(() => {
+    if (resource.status === 'ready') return { status: 'ready', rows: resource.data };
+    if (resource.status === 'error') return { status: 'error', rows: [] };
+    return { status: 'loading', rows: [] };
+  }, [resource]);
 }

--- a/src/features/profile/hooks/usePassportData.ts
+++ b/src/features/profile/hooks/usePassportData.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import {
   divisionsReached,
@@ -13,6 +13,7 @@ import {
   type RivalWin,
   type WeeklyCompletion,
 } from '@/features/profile/services/passport';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import type { Division } from '@/lib/types/database.types';
 
 type PassportData = {
@@ -28,54 +29,36 @@ type State =
   | { status: 'ready'; data: PassportData; error: null }
   | { status: 'error'; data: null; error: string };
 
-const initial: State = { status: 'loading', data: null, error: null };
-
 export function usePassportData(
   userId: string | null,
   currentDivision: Division | null,
 ): { state: State; refetch: () => void } {
-  const [state, setState] = useState<State>(initial);
-  const [reloadKey, setReloadKey] = useState(0);
+  const { state: resource, refetch } = useAsyncResource<PassportData>(
+    async () => {
+      const [history, topScores, weeklies, rivalWins] = await Promise.all([
+        fetchProfileRatingHistory(userId as string),
+        fetchPassportTopScores(userId as string),
+        listWeeklyCompletions(userId as string),
+        listRivalWins(userId as string),
+      ]);
+      return {
+        history,
+        topScores,
+        weeklies,
+        rivalWins,
+        divisions: divisionsReached(currentDivision as Division, history),
+      };
+    },
+    [userId, currentDivision],
+    { enabled: userId !== null && currentDivision !== null },
+  );
 
-  useEffect(() => {
-    if (!userId || !currentDivision) return undefined;
-
-    let cancelled = false;
-    void (async () => {
-      try {
-        const [history, topScores, weeklies, rivalWins] = await Promise.all([
-          fetchProfileRatingHistory(userId),
-          fetchPassportTopScores(userId),
-          listWeeklyCompletions(userId),
-          listRivalWins(userId),
-        ]);
-        if (cancelled) return;
-        setState({
-          status: 'ready',
-          data: {
-            history,
-            topScores,
-            weeklies,
-            rivalWins,
-            divisions: divisionsReached(currentDivision, history),
-          },
-          error: null,
-        });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', data: null, error: message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [currentDivision, reloadKey, userId]);
-
-  const refetch = useCallback(() => {
-    setState(initial);
-    setReloadKey((k) => k + 1);
-  }, []);
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready') return { status: 'ready', data: resource.data, error: null };
+    if (resource.status === 'error')
+      return { status: 'error', data: null, error: resource.message };
+    return { status: 'loading', data: null, error: null };
+  }, [resource]);
 
   return { state, refetch };
 }

--- a/src/features/profile/hooks/useProfileHistory.ts
+++ b/src/features/profile/hooks/useProfileHistory.ts
@@ -1,19 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { listChallengeCommitments } from '@/features/profile/lib/challengeCommitments';
 import { enrichScoresWithTopPercent } from '@/features/profile/lib/enrichScoresWithTopPercent';
 import { buildHistoryItems, filterHistoryByTab } from '@/features/profile/lib/filterHistoryByTab';
 import { listMyScores } from '@/features/profile/services/scores';
 import type { HistoryItem, HistoryTab } from '@/features/profile/types';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 
 type State =
   | { status: 'loading'; data: null; error: null }
   | { status: 'error'; data: null; error: string }
   | { status: 'ready'; data: HistoryItem[]; error: null };
-
-const initial: State = { status: 'loading', data: null, error: null };
 
 const SCORE_FETCH_LIMIT = 100;
 
@@ -24,46 +23,35 @@ export function useProfileHistory(userId: string | null): {
   filteredItems: HistoryItem[];
   refetch: () => void;
 } {
-  const [state, setState] = useState<State>(initial);
   const [activeTab, setActiveTab] = useState<HistoryTab>('all');
-  const [reloadKey, setReloadKey] = useState(0);
 
-  useEffect(() => {
-    if (!userId) return undefined;
+  const { state: resource, refetch } = useAsyncResource<HistoryItem[]>(
+    async () => {
+      const rawScores = await listMyScores(userId as string, SCORE_FETCH_LIMIT);
+      const enriched = await enrichScoresWithTopPercent(rawScores);
+      const scoreChallengeIds = new Set(enriched.map((s) => s.challengeId));
+      const commitments = listChallengeCommitments().filter(
+        (c) => !scoreChallengeIds.has(c.challengeId),
+      );
+      const scores = enriched.map((s) => ({ ...s, kind: 'score' as const }));
+      const inProgress = commitments.map((c) => ({
+        kind: 'in_progress' as const,
+        challengeId: c.challengeId,
+        challengeTitle: c.challengeTitle,
+        committedAt: c.committedAt,
+      }));
+      return buildHistoryItems(scores, inProgress);
+    },
+    [userId],
+    { enabled: userId !== null },
+  );
 
-    let cancelled = false;
-    void (async () => {
-      try {
-        const rawScores = await listMyScores(userId, SCORE_FETCH_LIMIT);
-        const enriched = await enrichScoresWithTopPercent(rawScores);
-        const scoreChallengeIds = new Set(enriched.map((s) => s.challengeId));
-        const commitments = listChallengeCommitments().filter(
-          (c) => !scoreChallengeIds.has(c.challengeId),
-        );
-        const scores = enriched.map((s) => ({ ...s, kind: 'score' as const }));
-        const inProgress = commitments.map((c) => ({
-          kind: 'in_progress' as const,
-          challengeId: c.challengeId,
-          challengeTitle: c.challengeTitle,
-          committedAt: c.committedAt,
-        }));
-        const items = buildHistoryItems(scores, inProgress);
-        if (!cancelled) setState({ status: 'ready', data: items, error: null });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', data: null, error: message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [reloadKey, userId]);
-
-  const refetch = useCallback(() => {
-    setState(initial);
-    setReloadKey((k) => k + 1);
-  }, []);
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready') return { status: 'ready', data: resource.data, error: null };
+    if (resource.status === 'error')
+      return { status: 'error', data: null, error: resource.message };
+    return { status: 'loading', data: null, error: null };
+  }, [resource]);
 
   const filteredItems = useMemo(() => {
     if (state.status !== 'ready') return [];

--- a/src/features/profile/hooks/useProfileRating.ts
+++ b/src/features/profile/hooks/useProfileRating.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import { fetchProfileRating } from '@/features/profile/services/profileRating';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import type { ProfileRating } from '@/lib/rating';
 
 type State =
@@ -10,38 +11,22 @@ type State =
   | { status: 'error'; rating: null; error: string }
   | { status: 'ready'; rating: ProfileRating | null; error: null };
 
-const initial: State = { status: 'loading', rating: null, error: null };
-
 export function useProfileRating(userId: string | null): {
   state: State;
   refetch: () => void;
 } {
-  const [state, setState] = useState<State>(initial);
-  const [reloadKey, setReloadKey] = useState(0);
+  const { state: resource, refetch } = useAsyncResource<ProfileRating | null>(
+    () => fetchProfileRating(userId as string),
+    [userId],
+    { enabled: userId !== null },
+  );
 
-  useEffect(() => {
-    if (!userId) return undefined;
-
-    let cancelled = false;
-    void (async () => {
-      try {
-        const rating = await fetchProfileRating(userId);
-        if (!cancelled) setState({ status: 'ready', rating, error: null });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', rating: null, error: message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [userId, reloadKey]);
-
-  const refetch = useCallback(() => {
-    setState(initial);
-    setReloadKey((key) => key + 1);
-  }, []);
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready') return { status: 'ready', rating: resource.data, error: null };
+    if (resource.status === 'error')
+      return { status: 'error', rating: null, error: resource.message };
+    return { status: 'loading', rating: null, error: null };
+  }, [resource]);
 
   return { state, refetch };
 }

--- a/src/features/profile/hooks/usePublicProfile.ts
+++ b/src/features/profile/hooks/usePublicProfile.ts
@@ -1,16 +1,15 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import { getProfileByUsername } from '@/features/profile/services/profile';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import type { Profile } from '@/lib/types/database.types';
 
 type State =
   | { status: 'loading'; profile: null; error: null }
   | { status: 'ready'; profile: Profile; error: null }
   | { status: 'error'; profile: null; error: string };
-
-const initial: State = { status: 'loading', profile: null, error: null };
 
 const invalidUsernameState: State = {
   status: 'error',
@@ -20,34 +19,20 @@ const invalidUsernameState: State = {
 
 export function usePublicProfile(username: string): { state: State; refetch: () => void } {
   const trimmed = username.trim();
-  const [state, setState] = useState<State>(initial);
-  const [reloadKey, setReloadKey] = useState(0);
+  const { state: resource, refetch } = useAsyncResource<Profile>(
+    () => getProfileByUsername(trimmed),
+    [trimmed],
+    { enabled: trimmed !== '' },
+  );
 
-  useEffect(() => {
-    if (!trimmed) return undefined;
+  const state = useMemo<State>(() => {
+    if (!trimmed) return invalidUsernameState;
+    if (resource.status === 'ready')
+      return { status: 'ready', profile: resource.data, error: null };
+    if (resource.status === 'error')
+      return { status: 'error', profile: null, error: resource.message };
+    return { status: 'loading', profile: null, error: null };
+  }, [trimmed, resource]);
 
-    let cancelled = false;
-    void (async () => {
-      try {
-        const profile = await getProfileByUsername(trimmed);
-        if (!cancelled) setState({ status: 'ready', profile, error: null });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', profile: null, error: message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [trimmed, reloadKey]);
-
-  const refetch = useCallback(() => {
-    setState(initial);
-    setReloadKey((k) => k + 1);
-  }, []);
-
-  const resolvedState = trimmed ? state : invalidUsernameState;
-
-  return { state: resolvedState, refetch };
+  return { state, refetch };
 }

--- a/src/features/rivals/hooks/useMyRivalMatches.ts
+++ b/src/features/rivals/hooks/useMyRivalMatches.ts
@@ -1,19 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import {
   listMyRivalMatches,
   respondRivalMatchInvite,
   type RivalMatchView,
 } from '@/features/rivals/services/rivalMatches';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 
 type State =
   | { status: 'loading'; matches: null; error: null }
   | { status: 'error'; matches: null; error: string }
   | { status: 'ready'; matches: RivalMatchView[]; error: null };
-
-const initial: State = { status: 'loading', matches: null, error: null };
 
 export function useMyRivalMatches(userId: string | null): {
   state: State;
@@ -22,33 +21,21 @@ export function useMyRivalMatches(userId: string | null): {
   respond: (matchId: string, accept: boolean) => Promise<void>;
   respondingId: string | null;
 } {
-  const [state, setState] = useState<State>(initial);
-  const [reloadKey, setReloadKey] = useState(0);
   const [respondingId, setRespondingId] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!userId) return undefined;
+  const { state: resource, refetch } = useAsyncResource<RivalMatchView[]>(
+    () => listMyRivalMatches(userId as string),
+    [userId],
+    { enabled: userId !== null },
+  );
 
-    let cancelled = false;
-    void (async () => {
-      try {
-        const matches = await listMyRivalMatches(userId);
-        if (!cancelled) setState({ status: 'ready', matches, error: null });
-      } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : 'unknown';
-        if (!cancelled) setState({ status: 'error', matches: null, error: message });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [reloadKey, userId]);
-
-  const refetch = useCallback(() => {
-    setState(initial);
-    setReloadKey((key) => key + 1);
-  }, []);
+  const state = useMemo<State>(() => {
+    if (resource.status === 'ready')
+      return { status: 'ready', matches: resource.data, error: null };
+    if (resource.status === 'error')
+      return { status: 'error', matches: null, error: resource.message };
+    return { status: 'loading', matches: null, error: null };
+  }, [resource]);
 
   const respond = useCallback(
     async (matchId: string, accept: boolean) => {

--- a/src/hooks/useAsyncResource.ts
+++ b/src/hooks/useAsyncResource.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { asyncError, asyncLoading, asyncReady, type AsyncState } from '@/lib/async-state';
+
+type Options = {
+  /** When false, no fetch runs and the state stays `idle`. */
+  enabled?: boolean;
+};
+
+/**
+ * One place for the "fetch outside React Query" lifecycle: loading → ready/error,
+ * cancellation on unmount/dep-change, and a `refetch`. Replaces the hand-rolled
+ * useState + useEffect + cancelled-flag + try/catch boilerplate that was copied
+ * across ~20 data hooks.
+ *
+ * The hook keeps the previous state on dependency changes (no flash to loading);
+ * `refetch()` explicitly resets to loading.
+ */
+export function useAsyncResource<T>(
+  fetcher: () => Promise<T>,
+  deps: ReadonlyArray<unknown>,
+  options: Options = {},
+): { state: AsyncState<T>; refetch: () => void } {
+  const { enabled = true } = options;
+  const [state, setState] = useState<AsyncState<T>>(() =>
+    enabled ? asyncLoading<T>() : { status: 'idle' },
+  );
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await fetcher();
+        if (!cancelled) setState(asyncReady(data));
+      } catch (e: unknown) {
+        if (!cancelled) setState(asyncError(e instanceof Error ? e.message : 'unknown'));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // fetcher is intentionally excluded — callers pass stable `deps` instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, reloadKey, enabled]);
+
+  const refetch = useCallback(() => {
+    setState(asyncLoading<T>());
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  return { state, refetch };
+}


### PR DESCRIPTION
Pure refactor — **no behaviour change**. typecheck + lint + 218 tests green; live-smoked Overview / Faction / Passport / Rivals / Events / History (all load, no stuck loading, 0 console errors).

### Why
`src/lib/async-state.ts` existed but was **imported by nobody**, while ~20 hooks each hand-rolled the identical `useState + useEffect + cancelled-flag + try/catch + setState` lifecycle.

### What
- **`hooks/useAsyncResource(fetcher, deps, { enabled })`** → `AsyncState<T>` + `refetch`, built on the now-used `async-state` helper.
- Migrated **12 single-fetch hooks** to it, each keeping its **public API byte-identical** so consumers/tests are untouched: `useProfileRating`, `useFactionRecentVideos`, `useActiveEvents`, `useEventsList`, `useEventDetail`, `usePublicProfile`, `useProfileHistory`, `useMyRivalMatches`, `useClanHud`, `useFactionPage`, `usePassportData`, `useWeeklyChallengeMatch`.
- Left bespoke ones alone (polling `useRivalMatch`, request-key `useMyChallengeParticipation`, multi-step `useFinisherCard`, admin mutation hooks).