### PR TITLE
feat(rbac): V3-00 — user_role + role-aware guards

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -1,7 +1,7 @@
 # Truegrynd – Backlog
 
 > **Tracker vivant** (suivi + tâches en cours).  
-> Détail historique V1/V2 (sections A–L, V2-00–12) : **[archive-v1-v2-detail.md](./archive-v1-v2-detail.md)**
+> Détail historique V1/V2 (sections A–L, V2-00–12) : **[archive-v1-v2-detail.md](./archive-v1-v2-detail.md)** · Stratégie V3 : **[V3_STRATEGY.md](../V3_STRATEGY.md)**
 
 **Dernière mise à jour :** 18 juin 2026
 
@@ -9,51 +9,64 @@
 
 ## Prochaine action
 
-🟢 **[#100 — QA V2](https://github.com/igorms-pro/truegrynd/issues/100)** clos (GO avec fixes · mergé PR [#101](https://github.com/igorms-pro/truegrynd/pull/101)).
+🔵 **V3 — Écosystème B2B2C (gym 100 $/mo).** Démarrage du **socle (Phase 0)**.  
+👉 Première branche : **V3-00 RBAC** ([#109](https://github.com/igorms-pro/truegrynd/issues/109)).
 
-**Reste avant V3/Stripe** (détail dans #100) : passe **prod (Vercel)** + **PostHog Live** · duel rival end-to-end (2 comptes) · supprimer le défi « Test » en DB.
+_Reste V2 (non bloquant, suivi dans [#100](https://github.com/igorms-pro/truegrynd/issues/100)) :_ passe **prod Vercel** + **PostHog Live** · duel rival end-to-end (2 comptes) · pagination leaderboard 100k (backend).
+
+---
+
+## V3 — Écosystème B2B2C
+
+Pivot B2B2C : l'arène B2C gratuite reste le moteur d'acquisition, les salles paient (rôle PRO). Codebase unique + RBAC. Détail : [V3_STRATEGY.md](../V3_STRATEGY.md).
+
+### Phase 0 — Socle (buildable maintenant, réutilise le moteur V2)
+
+| Issue                                                                | Rôle                                                | Dépend     |
+| -------------------------------------------------------------------- | --------------------------------------------------- | ---------- |
+| **V3-00** [#109](https://github.com/igorms-pro/truegrynd/issues/109) | RBAC : enum rôle + guards `/pro` `/admin`           | —          |
+| **V3-01** [#110](https://github.com/igorms-pro/truegrynd/issues/110) | Table `gyms` + affiliation + RLS multi-tenant       | 00         |
+| **V3-02** [#111](https://github.com/igorms-pro/truegrynd/issues/111) | Proof levels + `verified_by_coach_id` (no conflict) | 00, 01     |
+| **V3-03** [#112](https://github.com/igorms-pro/truegrynd/issues/112) | **Judge Console** (validation coach 1-clic)         | 00, 01, 02 |
+
+### Phase 1 — Surface PRO (après 1re box pilote)
+
+| Issue                                                                | Rôle                           | Dépend |
+| -------------------------------------------------------------------- | ------------------------------ | ------ |
+| **V3-04** [#113](https://github.com/igorms-pro/truegrynd/issues/113) | Shell `/pro` + onboarding gym  | 00, 01 |
+| **V3-05** [#114](https://github.com/igorms-pro/truegrynd/issues/114) | TV Broadcaster Mode (Realtime) | 04     |
+| **V3-06** [#115](https://github.com/igorms-pro/truegrynd/issues/115) | Ligues inter-box               | 04     |
+| **V3-07** [#116](https://github.com/igorms-pro/truegrynd/issues/116) | Pacing Assistant auto          | 04     |
+
+### Phase 2 — Monétisation / GTM
+
+| Issue                                                                | Rôle                                   | Dépend |
+| -------------------------------------------------------------------- | -------------------------------------- | ------ |
+| **V3-08** [#117](https://github.com/igorms-pro/truegrynd/issues/117) | Stripe abo gym 100 $/mo                | 04     |
+| **V3-09** [#118](https://github.com/igorms-pro/truegrynd/issues/118) | Trigger PLG (demande coach → offre)    | 01, 03 |
+| **V3-10** [#119](https://github.com/igorms-pro/truegrynd/issues/119) | Cosmetics Stripe B2C (H1, indépendant) | —      |
 
 ---
 
 ## Suivi synthétique
 
-| Bloc                                 | Avancement                                                                                                                                                     |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **V1 core** (UGC, admin, B–G)        | 🟢 PR [#30](https://github.com/igorms-pro/truegrynd/pull/30)–[#55](https://github.com/igorms-pro/truegrynd/pull/55) · migrations **`006`–`014`** prod          |
-| **V1.5** (faction, profil, settings) | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57)–[#62](https://github.com/igorms-pro/truegrynd/issues/62)                                           |
-| **Pré-V2 polish**                    | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63)–[#68](https://github.com/igorms-pro/truegrynd/issues/68)                                           |
-| **Production hardening**             | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70)                                          |
-| **V2-00–12**                         | 🟢 [#71](https://github.com/igorms-pro/truegrynd/issues/71)–[#99](https://github.com/igorms-pro/truegrynd/pull/99) · migrations **`015`–`027`** prod           |
-| **QA V1**                            | 🟢 GO (juin 2026)                                                                                                                                              |
-| **QA V2** (gate V3)                  | 🟢 [#100](https://github.com/igorms-pro/truegrynd/issues/100) GO avec fixes · PR [#101](https://github.com/igorms-pro/truegrynd/pull/101) · reste prod+PostHog |
-
-**Suite produit (post-QA GO) :** HogQL cosmetics ([MONETIZATION_V2-12.md](../MONETIZATION_V2-12.md) §2.2) **ou** V3 gym ([V3_STRATEGY.md](../V3_STRATEGY.md) §4) · notifs rivals push = hors scope
+| Bloc                                 | Avancement                                                                                                                                                                            |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **V1 core** (UGC, admin, B–G)        | 🟢 PR [#30](https://github.com/igorms-pro/truegrynd/pull/30)–[#55](https://github.com/igorms-pro/truegrynd/pull/55) · migrations **`006`–`014`**                                      |
+| **V1.5** (faction, profil, settings) | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57)–[#62](https://github.com/igorms-pro/truegrynd/issues/62)                                                                  |
+| **Pré-V2 polish**                    | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63)–[#68](https://github.com/igorms-pro/truegrynd/issues/68)                                                                  |
+| **Production hardening**             | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70)                                                                 |
+| **V2-00–12**                         | 🟢 [#71](https://github.com/igorms-pro/truegrynd/issues/71)–[#99](https://github.com/igorms-pro/truegrynd/pull/99) · migrations **`015`–`027`**                                       |
+| **QA V2 + clean code**               | 🟢 [#100](https://github.com/igorms-pro/truegrynd/issues/100) · PRs [#101](https://github.com/igorms-pro/truegrynd/pull/101)–[#108](https://github.com/igorms-pro/truegrynd/pull/108) |
+| **V3 B2B2C**                         | 🔵 en cours · [#109](https://github.com/igorms-pro/truegrynd/issues/109)–[#119](https://github.com/igorms-pro/truegrynd/issues/119)                                                   |
 
 ---
 
-## M. QA V2 — clos (GO avec fixes)
+## Post-MVP (non planifié)
 
-**Issue :** [#100](https://github.com/igorms-pro/truegrynd/issues/100) (clos) · **PR :** [#101](https://github.com/igorms-pro/truegrynd/pull/101) (mergé)
-
-QA fonctionnelle locale OK + fixes (finisher card, comeback plural, CTA submit) + refonte design (Overview, Arena + page leaderboard dédiée, Faction, Profil onglets).
-
-**Reste à faire avant V3/Stripe** (suivi dans #100) :
-
-- [ ] Passe **prod (Vercel)** + login réel
-- [ ] **PostHog Live** — vérifier les events
-- [ ] Duel rival end-to-end (2 comptes)
-- [ ] Supprimer le défi poubelle « Test » en DB
-- [ ] Leaderboard 100k = pagination serveur (tâche backend séparée)
-
----
-
-## Post-MVP (pas démarré)
-
-| Piste                                        | Doc                                               | Gate                    |
-| -------------------------------------------- | ------------------------------------------------- | ----------------------- |
-| Stripe Finisher cosmetics                    | [MONETIZATION_V2-12.md](../MONETIZATION_V2-12.md) | QA #100 GO + HogQL §2.2 |
-| V3 gym / RBAC coach                          | [V3_STRATEGY.md](../V3_STRATEGY.md) §4            | QA #100 GO              |
-| V1.1 leftovers (Sentry, rate limit IA, etc.) | [archive](./archive-v1-v2-detail.md)              | issue dédiée si besoin  |
+| Piste                                        | Doc / suivi                          |
+| -------------------------------------------- | ------------------------------------ |
+| V1.1 leftovers (Sentry, rate limit IA, etc.) | [archive](./archive-v1-v2-detail.md) |
 
 **Hors scope :** rang sportif payant · notifs rivals push (sauf demande explicite)
 
@@ -61,12 +74,12 @@ QA fonctionnelle locale OK + fixes (finisher card, comeback plural, CTA submit) 
 
 ## Légende & workflow
 
-🔴 not started · 🟡 in progress · 🟢 done · ⏸️ blocked · 🔵 QA · 🟣 on hold
+🔴 not started · 🟡 in progress · 🟢 done · ⏸️ blocked · 🔵 QA / en cours · 🟣 on hold
 
 1. **GitHub Issue** → branche `feature/issue-N-slug` (voir `.cursor/rules/issue-workflow.mdc`)
 2. PR ≤ ~400 lignes · RLS review si migration `008+`
-3. Mettre à jour **Suivi synthétique** ici : 🟡 → PR → 🟢
+3. Mettre à jour **Suivi synthétique** ici : 🔵 → PR → 🟢
 
 ---
 
-**Références :** [CONTEXT.md](../CONTEXT.md) · [V2_STRATEGY.md](../V2_STRATEGY.md) · [PROJECT.md](../../PROJECT.md)
+**Références :** [CONTEXT.md](../CONTEXT.md) · [V2_STRATEGY.md](../V2_STRATEGY.md) · [V3_STRATEGY.md](../V3_STRATEGY.md) · [PROJECT.md](../../PROJECT.md)

--- a/src/app/[locale]/app/admin/layout.tsx
+++ b/src/app/[locale]/app/admin/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { isPlatformAdmin } from '@/lib/roles';
 
 type Props = {
   children: ReactNode;
@@ -12,7 +13,7 @@ type Props = {
 export default function AdminLayout({ children }: Props) {
   const profile = useOptionalAppProfile();
 
-  if (!profile || !profile.is_admin) {
+  if (!isPlatformAdmin(profile)) {
     notFound();
   }
 

--- a/src/features/profile/lib/passportPrivacy.test.ts
+++ b/src/features/profile/lib/passportPrivacy.test.ts
@@ -31,6 +31,7 @@ const baseProfile: Profile = {
   last_activity_at: null,
   avatar_url: null,
   is_admin: false,
+  role: 'athlete',
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };

--- a/src/features/submission/components/ScoreSubmissionForm.test.tsx
+++ b/src/features/submission/components/ScoreSubmissionForm.test.tsx
@@ -47,6 +47,7 @@ const profile: CompleteProfile = {
   last_activity_at: null,
   avatar_url: null,
   is_admin: false,
+  role: 'athlete',
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };

--- a/src/lib/profileSelect.ts
+++ b/src/lib/profileSelect.ts
@@ -1,3 +1,3 @@
 /** Single source for `profiles` SELECT lists (keep in sync with DB + `Profile` type). */
 export const PROFILE_COLUMNS =
-  'id,username,sex,age,weight_kg,faction,division,city,country_code,show_location_on_leaderboard,show_division_on_public,show_rating_on_public,show_score_history_on_public,show_top_scores_on_public,show_badges_on_public,show_weeklies_on_public,show_finishers_on_public,show_rival_wins_on_public,initiation_completed,creator_score,streak_days,last_activity_at,avatar_url,is_admin,created_at,updated_at';
+  'id,username,sex,age,weight_kg,faction,division,city,country_code,show_location_on_leaderboard,show_division_on_public,show_rating_on_public,show_score_history_on_public,show_top_scores_on_public,show_badges_on_public,show_weeklies_on_public,show_finishers_on_public,show_rival_wins_on_public,initiation_completed,creator_score,streak_days,last_activity_at,avatar_url,is_admin,role,created_at,updated_at';

--- a/src/lib/roles.test.ts
+++ b/src/lib/roles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { canAccessPro, isGymStaff, isPlatformAdmin, type RoleSource } from '@/lib/roles';
+
+const make = (role: RoleSource['role'], is_admin = false): RoleSource => ({ role, is_admin });
+
+describe('roles', () => {
+  it('isPlatformAdmin: true for platform_admin role or legacy is_admin flag', () => {
+    expect(isPlatformAdmin(make('platform_admin'))).toBe(true);
+    expect(isPlatformAdmin(make('athlete', true))).toBe(true); // back-compat
+    expect(isPlatformAdmin(make('athlete'))).toBe(false);
+    expect(isPlatformAdmin(make('coach'))).toBe(false);
+    expect(isPlatformAdmin(null)).toBe(false);
+  });
+
+  it('isGymStaff: true for coach and gym_admin only', () => {
+    expect(isGymStaff(make('coach'))).toBe(true);
+    expect(isGymStaff(make('gym_admin'))).toBe(true);
+    expect(isGymStaff(make('athlete'))).toBe(false);
+    expect(isGymStaff(make('platform_admin'))).toBe(false);
+    expect(isGymStaff(undefined)).toBe(false);
+  });
+
+  it('canAccessPro: gym staff or platform admin', () => {
+    expect(canAccessPro(make('coach'))).toBe(true);
+    expect(canAccessPro(make('gym_admin'))).toBe(true);
+    expect(canAccessPro(make('platform_admin'))).toBe(true);
+    expect(canAccessPro(make('athlete'))).toBe(false);
+    expect(canAccessPro(make('athlete', true))).toBe(true); // platform admin via legacy flag
+  });
+});

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,21 @@
+import type { UserRole } from '@/lib/types/database.types';
+
+/** Minimal shape needed to resolve access — a `Profile` satisfies it. */
+export type RoleSource = { role: UserRole; is_admin: boolean };
+
+/** Platform admin (the `/admin` backoffice). `is_admin` kept for back-compat with pre-V3 rows. */
+export function isPlatformAdmin(profile: RoleSource | null | undefined): boolean {
+  if (!profile) return false;
+  return profile.role === 'platform_admin' || profile.is_admin;
+}
+
+/** Gym-side staff: a coach or a gym admin. */
+export function isGymStaff(profile: RoleSource | null | undefined): boolean {
+  if (!profile) return false;
+  return profile.role === 'coach' || profile.role === 'gym_admin';
+}
+
+/** Can enter the PRO space (`/pro`): gym staff, or a platform admin overseeing it. */
+export function canAccessPro(profile: RoleSource | null | undefined): boolean {
+  return isGymStaff(profile) || isPlatformAdmin(profile);
+}

--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -4,6 +4,8 @@ export type ChallengeVariant = 'no_equipment' | 'bodyweight' | 'dumbbell' | 'sta
 export type ChallengeRatingAxis = 'engine' | 'power' | 'strength' | 'grit';
 export type Sex = 'male' | 'female' | 'other';
 export type ScoreType = 'time' | 'reps';
+/** V3-00 RBAC role. athlete (default) · coach / gym_admin (/pro) · platform_admin (/admin). */
+export type UserRole = 'athlete' | 'coach' | 'gym_admin' | 'platform_admin';
 export type ProofLevel =
   | 'honor'
   | 'video_ranked'
@@ -125,6 +127,7 @@ export interface Profile {
   last_activity_at: string | null;
   avatar_url: string | null;
   is_admin: boolean;
+  role: UserRole;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/028_user_roles.sql
+++ b/supabase/migrations/028_user_roles.sql
@@ -1,0 +1,45 @@
+-- V3-00: RBAC — user_role on profiles.
+-- Additive & non-breaking: legacy `is_admin` is KEPT (existing guards/RLS still work);
+-- `role` is the forward model. athlete (default) · coach / gym_admin (/pro) · platform_admin (/admin).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_role') THEN
+    CREATE TYPE public.user_role AS ENUM (
+      'athlete',
+      'coach',
+      'gym_admin',
+      'platform_admin'
+    );
+  END IF;
+END $$;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS role public.user_role NOT NULL DEFAULT 'athlete';
+
+COMMENT ON COLUMN public.profiles.role IS
+  'V3-00: RBAC role. athlete (default) · coach / gym_admin (PRO /pro) · platform_admin (/admin). is_admin kept for back-compat.';
+
+-- Backfill existing platform admins from the legacy is_admin flag.
+UPDATE public.profiles
+SET role = 'platform_admin'
+WHERE is_admin = true
+  AND role <> 'platform_admin';
+
+CREATE INDEX IF NOT EXISTS idx_profiles_role ON public.profiles (role);
+
+-- Reusable role check for RLS policies / RPCs (reads the caller's own role).
+CREATE OR REPLACE FUNCTION public.has_role(target_roles public.user_role[])
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles
+    WHERE id = auth.uid()
+      AND role = ANY (target_roles)
+  );
+$$;


### PR DESCRIPTION
**Phase 0 / V3-00** — foundation of the B2B2C RBAC model. Closes #109.

### Changes
- **Migration `028_user_roles.sql`**: `user_role` enum, `profiles.role` (default `athlete`), backfill `platform_admin` from legacy `is_admin`, `has_role()` SECURITY DEFINER helper. **Additive** — `is_admin` kept, nothing dropped.
- `UserRole` type + `role` on `Profile` + added to `PROFILE_COLUMNS`.
- `lib/roles.ts`: `isPlatformAdmin` / `isGymStaff` / `canAccessPro` (+ unit tests).
- `/admin` guard now role-aware (`platform_admin` OR legacy `is_admin`).

### ⚠️ Deploy order (migrations are manual — RUNBOOK)
`PROFILE_COLUMNS` now selects `role`, so **apply `028_user_roles.sql` in the Supabase SQL Editor BEFORE merging/deploying** — otherwise every profile fetch fails (column missing). Order: apply migration → merge → Vercel deploys.

typecheck + lint + 221 tests green. (`/pro` pages come in V3-04; this ships the role foundation + guard primitive.)