### PR TITLE
feat(gyms): V3-01 — gyms table + affiliation + multi-tenant RLS

### DIFF
--- a/src/features/profile/lib/passportPrivacy.test.ts
+++ b/src/features/profile/lib/passportPrivacy.test.ts
@@ -32,6 +32,7 @@ const baseProfile: Profile = {
   avatar_url: null,
   is_admin: false,
   role: 'athlete',
+  affiliated_gym_id: null,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };

--- a/src/features/submission/components/ScoreSubmissionForm.test.tsx
+++ b/src/features/submission/components/ScoreSubmissionForm.test.tsx
@@ -48,6 +48,7 @@ const profile: CompleteProfile = {
   avatar_url: null,
   is_admin: false,
   role: 'athlete',
+  affiliated_gym_id: null,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };

--- a/src/lib/profileSelect.ts
+++ b/src/lib/profileSelect.ts
@@ -1,3 +1,3 @@
 /** Single source for `profiles` SELECT lists (keep in sync with DB + `Profile` type). */
 export const PROFILE_COLUMNS =
-  'id,username,sex,age,weight_kg,faction,division,city,country_code,show_location_on_leaderboard,show_division_on_public,show_rating_on_public,show_score_history_on_public,show_top_scores_on_public,show_badges_on_public,show_weeklies_on_public,show_finishers_on_public,show_rival_wins_on_public,initiation_completed,creator_score,streak_days,last_activity_at,avatar_url,is_admin,role,created_at,updated_at';
+  'id,username,sex,age,weight_kg,faction,division,city,country_code,show_location_on_leaderboard,show_division_on_public,show_rating_on_public,show_score_history_on_public,show_top_scores_on_public,show_badges_on_public,show_weeklies_on_public,show_finishers_on_public,show_rival_wins_on_public,initiation_completed,creator_score,streak_days,last_activity_at,avatar_url,is_admin,role,affiliated_gym_id,created_at,updated_at';

--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -128,6 +128,21 @@ export interface Profile {
   avatar_url: string | null;
   is_admin: boolean;
   role: UserRole;
+  /** V3-01: gym this profile trains at (NULL = unaffiliated / B2C default). */
+  affiliated_gym_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Mirrors the `gyms` table (V3-01). A B2B2C facility owned by a gym_admin. */
+export interface Gym {
+  id: string;
+  name: string;
+  slug: string;
+  /** The gym_admin who manages this gym (NULL if the owner profile was deleted). */
+  owner_id: string | null;
+  city: string | null;
+  country_code: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/029_gyms.sql
+++ b/supabase/migrations/029_gyms.sql
@@ -1,0 +1,112 @@
+-- V3-01: gyms (multi-tenant facilities) + athlete affiliation + RLS.
+-- Additive & non-breaking. Depends on V3-00 (user_role / has_role).
+-- A gym is owned by a gym_admin (owner_id); athletes/coaches affiliate via profiles.affiliated_gym_id.
+
+CREATE TABLE IF NOT EXISTS public.gyms (
+  id           UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         TEXT         NOT NULL CHECK (length(btrim(name)) > 0),
+  slug         TEXT         NOT NULL UNIQUE CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
+  owner_id     UUID         NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  city         TEXT         NULL,
+  country_code TEXT         NULL,
+  created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.gyms IS
+  'V3-01: B2B2C facilities. owner_id = the gym_admin who manages it; members affiliate via profiles.affiliated_gym_id.';
+
+CREATE INDEX IF NOT EXISTS idx_gyms_owner ON public.gyms (owner_id);
+
+-- Athlete/coach affiliation to a gym. NULL = unaffiliated (the B2C default).
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS affiliated_gym_id UUID NULL REFERENCES public.gyms(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.profiles.affiliated_gym_id IS
+  'V3-01: gym this profile trains at (NULL = unaffiliated). Coaches/gym_admins of that gym can see the member.';
+
+CREATE INDEX IF NOT EXISTS idx_profiles_affiliated_gym ON public.profiles (affiliated_gym_id);
+
+ALTER TABLE public.gyms ENABLE ROW LEVEL SECURITY;
+
+-- Reusable platform-admin check that honours BOTH the V3 role and the legacy is_admin flag.
+CREATE OR REPLACE FUNCTION public.is_platform_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE id = auth.uid()
+      AND (role = 'platform_admin' OR is_admin = true)
+  );
+$$;
+
+COMMENT ON FUNCTION public.is_platform_admin IS
+  'V3-01: true if caller is a platform admin (role platform_admin OR legacy is_admin).';
+
+-- READ: gyms are a public directory for any authenticated user.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gyms'
+      AND policyname = 'Authenticated users can read gyms'
+  ) THEN
+    CREATE POLICY "Authenticated users can read gyms"
+      ON public.gyms FOR SELECT
+      TO authenticated
+      USING (true);
+  END IF;
+END $$;
+
+-- INSERT: a gym_admin can create a gym they own; platform admins unrestricted.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gyms'
+      AND policyname = 'Gym admins can create own gym'
+  ) THEN
+    CREATE POLICY "Gym admins can create own gym"
+      ON public.gyms FOR INSERT
+      TO authenticated
+      WITH CHECK (
+        public.is_platform_admin()
+        OR (owner_id = auth.uid() AND public.has_role(ARRAY['gym_admin']::public.user_role[]))
+      );
+  END IF;
+END $$;
+
+-- UPDATE: only the owner (or a platform admin) can edit a gym.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gyms'
+      AND policyname = 'Gym owners can update own gym'
+  ) THEN
+    CREATE POLICY "Gym owners can update own gym"
+      ON public.gyms FOR UPDATE
+      TO authenticated
+      USING (public.is_platform_admin() OR owner_id = auth.uid())
+      WITH CHECK (public.is_platform_admin() OR owner_id = auth.uid());
+  END IF;
+END $$;
+
+-- DELETE: only the owner (or a platform admin) can delete a gym.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gyms'
+      AND policyname = 'Gym owners can delete own gym'
+  ) THEN
+    CREATE POLICY "Gym owners can delete own gym"
+      ON public.gyms FOR DELETE
+      TO authenticated
+      USING (public.is_platform_admin() OR owner_id = auth.uid());
+  END IF;
+END $$;


### PR DESCRIPTION
## V3-01 (#110) — Fondation multi-tenant `gyms`

Couche **données only** (pas d'UI). Pose la table des salles + l'affiliation athlète, prérequis du shell `/pro` (#113) et de la Judge Console (#112).

### Contenu
- **`supabase/migrations/029_gyms.sql`** (additive, idempotente) :
  - table `public.gyms` (`name`, `slug` unique+CHECK, `owner_id` → profil gym_admin, `city`, `country_code`)
  - `profiles.affiliated_gym_id` (FK → gyms, `ON DELETE SET NULL`, NULL = non affilié / défaut B2C)
  - RLS `gyms` : lecture = tout authentifié (annuaire) ; insert/update/delete = owner **ou** platform admin
  - helper `public.is_platform_admin()` (role `platform_admin` **ou** legacy `is_admin`)
- **Types** : interface `Gym` + `Profile.affiliated_gym_id` ; `PROFILE_COLUMNS` en sync

### ⚠️ Migration déjà appliquée en prod
`029` a été poussée via `supabase db push --linked` et vérifiée (table, RLS, 4 policies, FK, CHECK, anon ne lit pas). **Pas besoin de la rejouer** avant merge.

### Décisions prises (data layer)
- Nom colonne : `affiliated_gym_id` (conforme à `V3_STRATEGY.md`)
- RLS « coach voit les scores de ses membres » **hors scope** → V3-02/03 (touche `scores`)
- Le SQL brouillon du doc stratégie (RLS référençant `role` sur `gyms`) était bugué → réécrit proprement

### Hors scope (suite)
Design/UX de `/pro` → voir issue de design dédiée. Modèle `scores`/coach → #111/#112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)