### PR TITLE
feat(scores): V3-02 — scores.verified_by_coach_id (#111)

### DIFF
--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -206,6 +206,8 @@ export interface Score {
   video_url: string | null;
   is_validated: boolean;
   proof_level: ProofLevel;
+  /** V3-02: coach/gym_admin who judge-verified this score (NULL = not judge-verified). */
+  verified_by_coach_id: string | null;
   variant: ChallengeVariant;
   is_hidden?: boolean;
   submitted_at: string;

--- a/supabase/migrations/030_verified_by_coach.sql
+++ b/supabase/migrations/030_verified_by_coach.sql
@@ -1,0 +1,16 @@
+-- V3-02: link a score to the coach who judge-verified it.
+-- Additive & non-breaking. Reuses the EXISTING proof_level enum (027) — does NOT recreate it.
+-- video_url (001) already covers the "proof_url" need, so no new proof column.
+-- The actual coach-validation flow (set proof_level = 'judge_verified') lands in V3-03 (Judge Console).
+
+ALTER TABLE public.scores
+  ADD COLUMN IF NOT EXISTS verified_by_coach_id UUID NULL
+    REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.scores.verified_by_coach_id IS
+  'V3-02: the coach/gym_admin who judge-verified this score (NULL = not judge-verified). Set when proof_level becomes judge_verified.';
+
+-- Lookup: a coach''s validated scores, and "who verified this".
+CREATE INDEX IF NOT EXISTS idx_scores_verified_by_coach
+  ON public.scores (verified_by_coach_id)
+  WHERE verified_by_coach_id IS NOT NULL;


### PR DESCRIPTION
## V3-02 (#111) — `scores.verified_by_coach_id`

Brique data de la Judge Console (V3-03). Migration `030` (additive, **déjà appliquée + smokée en prod** : colonne, FK, index, PostgREST OK).

- ✅ **NE recrée PAS** l'enum `proof_level` (réutilise celui de 027)
- ✅ `video_url` (001) couvre déjà le besoin `proof_url` → pas de nouvelle colonne preuve
- ✅ `verified_by_coach_id` UUID nullable → `profiles`, `ON DELETE SET NULL`, index partiel
- ⏭️ Le câblage `judge_verified` (validation coach 1-clic) arrive en **V3-03 (#112)**

Types: `Score.verified_by_coach_id`. Tranche 1 du build PRO.