### PR TITLE
feat(pro): V3 tranche 1 — /pro shell (guard + nav + dashboard) (#113)

### DIFF
--- a/src/app/[locale]/app/pro/layout.tsx
+++ b/src/app/[locale]/app/pro/layout.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { notFound } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { ProNav } from '@/features/pro/components/ProNav';
+import { canAccessPro } from '@/lib/roles';
+
+export default function ProLayout({ children }: { children: ReactNode }) {
+  const profile = useOptionalAppProfile();
+  const t = useTranslations('pro');
+
+  if (!canAccessPro(profile)) {
+    notFound();
+  }
+
+  return (
+    <section className="space-y-6 py-4">
+      <header className="space-y-1">
+        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
+          {t('badge')}
+        </p>
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <ProNav />
+
+      <div>{children}</div>
+    </section>
+  );
+}

--- a/src/app/[locale]/app/pro/page.tsx
+++ b/src/app/[locale]/app/pro/page.tsx
@@ -1,0 +1,5 @@
+import { ProDashboard } from '@/features/pro/components/ProDashboard';
+
+export default function ProHomePage() {
+  return <ProDashboard />;
+}

--- a/src/features/pro/components/ProDashboard.tsx
+++ b/src/features/pro/components/ProDashboard.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { PRO_NAV } from '@/features/pro/lib/proNav';
+import { isGymManager } from '@/lib/roles';
+
+export function ProDashboard() {
+  const t = useTranslations('pro');
+  const tNav = useTranslations('pro.nav');
+  const locale = useLocale();
+  const profile = useOptionalAppProfile();
+  const canManage = isGymManager(profile);
+
+  // Flatten every section except the dashboard itself into overview cards.
+  const cards = PRO_NAV.flatMap((group) => group.items)
+    .filter((item) => item.id !== 'dashboard')
+    .filter((item) => !item.managerOnly || canManage);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t('dashboard.intro')}</p>
+
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((item) => {
+          const Icon = item.icon;
+          const isSoon = item.status === 'soon';
+          const label = tNav(item.labelKey);
+
+          const inner = (
+            <div className="flex h-full flex-col gap-2 rounded-md border border-border bg-card p-4">
+              <div className="flex items-center justify-between">
+                <Icon className="h-5 w-5 text-primary" aria-hidden />
+                {isSoon ? (
+                  <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+                    {tNav('soon')}
+                  </span>
+                ) : null}
+              </div>
+              <span className="text-sm font-black uppercase tracking-[0.12em] text-foreground">
+                {label}
+              </span>
+            </div>
+          );
+
+          return (
+            <li key={item.id}>
+              {isSoon ? (
+                <div aria-disabled="true" className="opacity-60">
+                  {inner}
+                </div>
+              ) : (
+                <Link
+                  href={`/${locale}${item.path}`}
+                  className="block transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {inner}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/pro/components/ProNav.tsx
+++ b/src/features/pro/components/ProNav.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { PRO_NAV, isProItemActive, type ProNavItem } from '@/features/pro/lib/proNav';
+import { isGymManager } from '@/lib/roles';
+
+function itemClassName(isActive: boolean, isSoon: boolean): string {
+  return [
+    'inline-flex items-center gap-2 rounded-sm border px-3 py-2 text-xs font-black uppercase tracking-[0.14em] transition-colors',
+    isSoon
+      ? 'cursor-not-allowed border-border bg-muted/30 text-muted-foreground/60'
+      : isActive
+        ? 'border-primary bg-primary/15 text-primary'
+        : 'border-border bg-background text-muted-foreground hover:text-foreground',
+  ].join(' ');
+}
+
+export function ProNav() {
+  const t = useTranslations('pro.nav');
+  const locale = useLocale();
+  const pathname = usePathname();
+  const profile = useOptionalAppProfile();
+  const canManage = isGymManager(profile);
+
+  const visible = (item: ProNavItem) => !item.managerOnly || canManage;
+
+  return (
+    <nav aria-label={t('label')} className="space-y-3">
+      {PRO_NAV.map((group) => {
+        const items = group.items.filter(visible);
+        if (items.length === 0) return null;
+
+        return (
+          <div key={group.id} className="space-y-2">
+            {group.labelKey ? (
+              <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground/70">
+                {t(`groups.${group.labelKey}`)}
+              </p>
+            ) : null}
+            <ul className="flex flex-wrap gap-2">
+              {items.map((item) => {
+                const Icon = item.icon;
+                const isSoon = item.status === 'soon';
+                const isActive = !isSoon && isProItemActive(pathname, locale, item);
+                const label = t(item.labelKey);
+                const content = (
+                  <>
+                    <Icon className="h-3.5 w-3.5" aria-hidden />
+                    {label}
+                    {isSoon ? (
+                      <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[9px] tracking-normal">
+                        {t('soon')}
+                      </span>
+                    ) : null}
+                  </>
+                );
+
+                return (
+                  <li key={item.id}>
+                    {isSoon ? (
+                      <span
+                        className={itemClassName(false, true)}
+                        aria-disabled="true"
+                        title={t('soon')}
+                      >
+                        {content}
+                      </span>
+                    ) : (
+                      <Link
+                        href={`/${locale}${item.path}`}
+                        className={itemClassName(isActive, false)}
+                        aria-current={isActive ? 'page' : undefined}
+                      >
+                        {content}
+                      </Link>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -1,0 +1,104 @@
+import {
+  LayoutDashboard,
+  Gavel,
+  Trophy,
+  Tv,
+  CalendarDays,
+  Users,
+  Ticket,
+  Settings,
+  CreditCard,
+  type LucideIcon,
+} from 'lucide-react';
+
+/** `live` = built & navigable. `soon` = shown but disabled (vision placeholder). */
+export type ProNavStatus = 'live' | 'soon';
+
+export type ProNavItem = {
+  id: string;
+  /** Path under /{locale}, starting with `/app/pro`. Empty suffix = the PRO home. */
+  path: `/app/pro${string}`;
+  icon: LucideIcon;
+  /** i18n key under the `pro.nav` namespace. */
+  labelKey: string;
+  status: ProNavStatus;
+  /** Owner-only section (gym_admin / platform admin). Hidden for a plain coach. */
+  managerOnly?: boolean;
+};
+
+export type ProNavGroup = {
+  id: string;
+  /** i18n key under `pro.nav.groups`, or null for the top (ungrouped) item. */
+  labelKey: string | null;
+  items: readonly ProNavItem[];
+};
+
+export const PRO_NAV: readonly ProNavGroup[] = [
+  {
+    id: 'main',
+    labelKey: null,
+    items: [
+      {
+        id: 'dashboard',
+        path: '/app/pro',
+        icon: LayoutDashboard,
+        labelKey: 'dashboard',
+        status: 'live',
+      },
+    ],
+  },
+  {
+    id: 'competition',
+    labelKey: 'competition',
+    items: [
+      { id: 'judge', path: '/app/pro/judge', icon: Gavel, labelKey: 'judge', status: 'soon' },
+      { id: 'events', path: '/app/pro/events', icon: Trophy, labelKey: 'events', status: 'soon' },
+      { id: 'tv', path: '/app/pro/tv', icon: Tv, labelKey: 'tv', status: 'soon' },
+    ],
+  },
+  {
+    id: 'management',
+    labelKey: 'management',
+    items: [
+      {
+        id: 'planning',
+        path: '/app/pro/planning',
+        icon: CalendarDays,
+        labelKey: 'planning',
+        status: 'soon',
+      },
+      { id: 'members', path: '/app/pro/members', icon: Users, labelKey: 'members', status: 'soon' },
+      {
+        id: 'subscriptions',
+        path: '/app/pro/subscriptions',
+        icon: Ticket,
+        labelKey: 'subscriptions',
+        status: 'soon',
+        managerOnly: true,
+      },
+      {
+        id: 'settings',
+        path: '/app/pro/settings',
+        icon: Settings,
+        labelKey: 'settings',
+        status: 'soon',
+        managerOnly: true,
+      },
+      {
+        id: 'billing',
+        path: '/app/pro/billing',
+        icon: CreditCard,
+        labelKey: 'billing',
+        status: 'soon',
+        managerOnly: true,
+      },
+    ],
+  },
+] as const;
+
+/** Exact-match for the PRO home, prefix-match for sub-routes. */
+export function isProItemActive(pathname: string, locale: string, item: ProNavItem): boolean {
+  const localized = `/${locale}${item.path}`;
+  if (item.path === '/app/pro') return pathname === localized;
+  return pathname === localized || pathname.startsWith(`${localized}/`);
+}

--- a/src/lib/roles.test.ts
+++ b/src/lib/roles.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { canAccessPro, isGymStaff, isPlatformAdmin, type RoleSource } from '@/lib/roles';
+import {
+  canAccessPro,
+  isGymManager,
+  isGymStaff,
+  isPlatformAdmin,
+  type RoleSource,
+} from '@/lib/roles';
 
 const make = (role: RoleSource['role'], is_admin = false): RoleSource => ({ role, is_admin });
 
@@ -27,5 +33,14 @@ describe('roles', () => {
     expect(canAccessPro(make('platform_admin'))).toBe(true);
     expect(canAccessPro(make('athlete'))).toBe(false);
     expect(canAccessPro(make('athlete', true))).toBe(true); // platform admin via legacy flag
+  });
+
+  it('isGymManager: gym_admin or platform admin, but NOT a plain coach', () => {
+    expect(isGymManager(make('gym_admin'))).toBe(true);
+    expect(isGymManager(make('platform_admin'))).toBe(true);
+    expect(isGymManager(make('coach', true))).toBe(true); // platform admin via legacy flag
+    expect(isGymManager(make('coach'))).toBe(false);
+    expect(isGymManager(make('athlete'))).toBe(false);
+    expect(isGymManager(null)).toBe(false);
   });
 });

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -19,3 +19,12 @@ export function isGymStaff(profile: RoleSource | null | undefined): boolean {
 export function canAccessPro(profile: RoleSource | null | undefined): boolean {
   return isGymStaff(profile) || isPlatformAdmin(profile);
 }
+
+/**
+ * Can manage the gym itself (settings, billing, subscriptions) — a gym admin or
+ * platform admin. A plain `coach` accesses `/pro` but not these owner-only sections.
+ */
+export function isGymManager(profile: RoleSource | null | undefined): boolean {
+  if (!profile) return false;
+  return profile.role === 'gym_admin' || isPlatformAdmin(profile);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1360,5 +1360,30 @@
     "chest_to_bar": "Chest-to-Bar",
     "turkish_get_up": "Turkish Get-Up",
     "strict_ring_dip": "Strict Ring Dip"
+  },
+  "pro": {
+    "badge": "TrueGrynd PRO",
+    "title": "Gym command center",
+    "subtitle": "Validate scores, run competitions and manage your box — all in one place.",
+    "nav": {
+      "label": "PRO sections",
+      "soon": "Soon",
+      "groups": {
+        "competition": "Competition",
+        "management": "Gym management"
+      },
+      "dashboard": "Dashboard",
+      "judge": "Judge Console",
+      "events": "Events",
+      "tv": "TV Cast",
+      "planning": "Schedule",
+      "members": "Members",
+      "subscriptions": "Subscriptions",
+      "settings": "Settings",
+      "billing": "Billing"
+    },
+    "dashboard": {
+      "intro": "Welcome to your PRO space. The Judge Console arrives next — the rest is on the way."
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1360,5 +1360,30 @@
     "chest_to_bar": "Chest-to-Bar",
     "turkish_get_up": "Turkish Get-Up",
     "strict_ring_dip": "Dip strict aux anneaux"
+  },
+  "pro": {
+    "badge": "TrueGrynd PRO",
+    "title": "Espace PRO",
+    "subtitle": "Valide les scores, organise tes compétitions et gère ta box — au même endroit.",
+    "nav": {
+      "label": "Sections PRO",
+      "soon": "Bientôt",
+      "groups": {
+        "competition": "Compétition",
+        "management": "Gestion salle"
+      },
+      "dashboard": "Dashboard",
+      "judge": "Judge Console",
+      "events": "Events",
+      "tv": "TV Cast",
+      "planning": "Planning",
+      "members": "Membres",
+      "subscriptions": "Abonnements",
+      "settings": "Réglages",
+      "billing": "Facturation"
+    },
+    "dashboard": {
+      "intro": "Bienvenue dans ton espace PRO. La Judge Console arrive juste après — le reste suit."
+    }
   }
 }


### PR DESCRIPTION
## V3 tranche 1 (b) — Shell `/pro` (#113)

La coquille de l'espace PRO. Pas encore de feature métier (Judge = étape suivante #112).

### Contenu
- **Route** `src/app/[locale]/app/pro/` gardée par `canAccessPro` (miroir exact du guard `/admin`).
- **`ProNav`** : nav 2 groupes — **Compétition** (Judge / Events / TV) · **Gestion salle** (Planning / Members / Abonnements / Settings / Billing). Sections `managerOnly` (Abonnements/Settings/Billing) masquées pour un simple `coach`.
- **`ProDashboard`** : landing avec cartes d'aperçu ; sections non construites = badge **`soon`** (désactivées, pas de 404).
- **`isGymManager()`** (gym_admin ou platform admin) dans `roles.ts` + tests.
- **i18n** namespace `pro` (en + fr).

### Vérif (QA perso)
- ✅ typecheck · lint · 222 unit tests · `next build` (route `/[locale]/app/pro` enregistrée)
- ✅ Rendu authentifié vérifié en **dark ET light** (tokens de thème, aucune couleur hardcodée) — guard laisse passer platform_admin, sections owner visibles.

Prochaine étape tranche 1 : **Judge Console (#112)** → flip l'item `judge` en `live`.