### PR TITLE
feat(judge): V3-03 UI — Judge Console at /pro/judge (#112)

### DIFF
--- a/src/app/[locale]/app/pro/judge/page.tsx
+++ b/src/app/[locale]/app/pro/judge/page.tsx
@@ -1,0 +1,5 @@
+import { JudgeConsole } from '@/features/pro/components/JudgeConsole';
+
+export default function ProJudgePage() {
+  return <JudgeConsole />;
+}

--- a/src/features/pro/components/JudgeConsole.tsx
+++ b/src/features/pro/components/JudgeConsole.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { Check, Play } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useCallback, useMemo, useState } from 'react';
+
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import {
+  listPendingVerifications,
+  verifyScore,
+  type PendingVerification,
+} from '@/features/pro/services/judge';
+import { formatScore } from '@/lib/scoring/formatScore';
+import type { ProofLevel } from '@/lib/types/database.types';
+
+function proofBadgeClass(level: ProofLevel): string {
+  if (level === 'judge_verified') return 'bg-emerald-500/15 text-emerald-400';
+  if (level === 'video_ranked') return 'bg-sky-500/15 text-sky-400';
+  return 'bg-muted text-muted-foreground';
+}
+
+function initials(name: string | null): string {
+  if (!name) return '?';
+  return name.slice(0, 2).toUpperCase();
+}
+
+function Row({
+  item,
+  busy,
+  onVerify,
+}: {
+  item: PendingVerification;
+  busy: boolean;
+  onVerify: (id: string) => void;
+}) {
+  const t = useTranslations('pro.judge');
+  const isHorde = item.athleteFaction === 'horde';
+
+  return (
+    <li className="flex flex-wrap items-center gap-4 rounded-md border border-border bg-card p-4">
+      <div className="flex min-w-[12rem] items-center gap-3">
+        <span
+          aria-hidden
+          className={`h-2.5 w-2.5 rounded-full ${isHorde ? 'bg-[var(--faction-horde)]' : 'bg-sky-500'}`}
+        />
+        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-muted text-xs font-black">
+          {initials(item.athleteUsername)}
+        </span>
+        <div>
+          <p className="text-sm font-bold">{item.athleteUsername ?? '—'}</p>
+          <p className="text-xs text-muted-foreground">{item.athleteDivision ?? ''}</p>
+        </div>
+      </div>
+
+      <div className="flex-1">
+        <p className="flex items-center gap-2 text-sm font-bold">
+          {item.challengeTitle}
+          <span
+            className={`rounded-sm px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.1em] ${proofBadgeClass(item.proofLevel)}`}
+          >
+            {t(`proof.${item.proofLevel}`)}
+          </span>
+        </p>
+      </div>
+
+      <span className="min-w-[5rem] text-right text-base font-black tabular-nums text-accent">
+        {formatScore(item.value, item.scoreType)}
+      </span>
+
+      <div className="flex min-w-[12rem] items-center justify-end gap-2">
+        {item.videoUrl ? (
+          <a
+            href={item.videoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-sm border border-border bg-background px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-foreground hover:opacity-90"
+          >
+            <Play className="h-3.5 w-3.5" aria-hidden />
+            {t('video')}
+          </a>
+        ) : (
+          <span className="text-xs italic text-muted-foreground">{t('noProof')}</span>
+        )}
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onVerify(item.scoreId)}
+          className="inline-flex items-center gap-1.5 rounded-sm bg-emerald-600 px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-white hover:opacity-90 disabled:opacity-50"
+        >
+          <Check className="h-3.5 w-3.5" aria-hidden />
+          {busy ? t('validating') : t('validate')}
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export function JudgeConsole() {
+  const t = useTranslations('pro.judge');
+  const { state } = useAsyncResource(listPendingVerifications, []);
+  const [verifiedIds, setVerifiedIds] = useState<ReadonlySet<string>>(new Set());
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const onVerify = useCallback(async (id: string) => {
+    setBusyId(id);
+    setActionError(null);
+    try {
+      await verifyScore(id);
+      setVerifiedIds((prev) => new Set(prev).add(id));
+    } catch {
+      setActionError(id);
+    } finally {
+      setBusyId(null);
+    }
+  }, []);
+
+  const rows = useMemo(
+    () => (state.status === 'ready' ? state.data.filter((r) => !verifiedIds.has(r.scoreId)) : []),
+    [state, verifiedIds],
+  );
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error') {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t('intro')}</p>
+
+      {rows.length === 0 ? (
+        <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {t('empty')}
+        </p>
+      ) : (
+        <>
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('pendingCount', { count: rows.length })}
+          </p>
+          <ul className="space-y-3">
+            {rows.map((item) => (
+              <div key={item.scoreId} className="space-y-1">
+                <Row item={item} busy={busyId === item.scoreId} onVerify={onVerify} />
+                {actionError === item.scoreId ? (
+                  <p className="px-1 text-xs font-semibold text-primary">{t('actionError')}</p>
+                ) : null}
+              </div>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -51,7 +51,7 @@ export const PRO_NAV: readonly ProNavGroup[] = [
     id: 'competition',
     labelKey: 'competition',
     items: [
-      { id: 'judge', path: '/app/pro/judge', icon: Gavel, labelKey: 'judge', status: 'soon' },
+      { id: 'judge', path: '/app/pro/judge', icon: Gavel, labelKey: 'judge', status: 'live' },
       { id: 'events', path: '/app/pro/events', icon: Trophy, labelKey: 'events', status: 'soon' },
       { id: 'tv', path: '/app/pro/tv', icon: Tv, labelKey: 'tv', status: 'soon' },
     ],

--- a/src/features/pro/services/judge.ts
+++ b/src/features/pro/services/judge.ts
@@ -1,0 +1,64 @@
+import { supabase } from '@/lib/supabase';
+import type { ProofLevel, ScoreType } from '@/lib/types/database.types';
+
+/** A score awaiting judge validation, scoped to the caller's gym (see `pending_verifications`). */
+export type PendingVerification = {
+  scoreId: string;
+  value: number;
+  videoUrl: string | null;
+  proofLevel: ProofLevel;
+  isValidated: boolean;
+  submittedAt: string;
+  athleteId: string;
+  athleteUsername: string | null;
+  athleteDivision: string | null;
+  athleteFaction: string | null;
+  athleteAvatarUrl: string | null;
+  challengeId: string;
+  challengeTitle: string;
+  scoreType: ScoreType;
+};
+
+type Row = {
+  score_id: string;
+  value: number;
+  video_url: string | null;
+  proof_level: ProofLevel;
+  is_validated: boolean;
+  submitted_at: string;
+  athlete_id: string;
+  athlete_username: string | null;
+  athlete_division: string | null;
+  athlete_faction: string | null;
+  athlete_avatar_url: string | null;
+  challenge_id: string;
+  challenge_title: string;
+  score_type: ScoreType;
+};
+
+export async function listPendingVerifications(): Promise<PendingVerification[]> {
+  const { data, error } = await supabase.rpc('pending_verifications');
+  if (error) throw new Error(error.message);
+
+  return ((data ?? []) as Row[]).map((row) => ({
+    scoreId: row.score_id,
+    value: Number(row.value),
+    videoUrl: row.video_url,
+    proofLevel: row.proof_level,
+    isValidated: row.is_validated,
+    submittedAt: row.submitted_at,
+    athleteId: row.athlete_id,
+    athleteUsername: row.athlete_username,
+    athleteDivision: row.athlete_division,
+    athleteFaction: row.athlete_faction,
+    athleteAvatarUrl: row.athlete_avatar_url,
+    challengeId: row.challenge_id,
+    challengeTitle: row.challenge_title,
+    scoreType: row.score_type,
+  }));
+}
+
+export async function verifyScore(scoreId: string): Promise<void> {
+  const { error } = await supabase.rpc('verify_score', { p_score_id: scoreId });
+  if (error) throw new Error(error.message);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1384,6 +1384,25 @@
     },
     "dashboard": {
       "intro": "Welcome to your PRO space. The Judge Console arrives next — the rest is on the way."
+    },
+    "judge": {
+      "intro": "Validate performances you witnessed on the floor — a validated score jumps to the verified ranking.",
+      "loading": "Loading the queue…",
+      "error": "Could not load the queue.",
+      "empty": "Nothing to validate right now. 🎉",
+      "pendingCount": "{count} to validate",
+      "validate": "Validate",
+      "validating": "Validating…",
+      "video": "Video",
+      "noProof": "no video proof",
+      "actionError": "Validation failed — try again.",
+      "proof": {
+        "honor": "honor",
+        "video_ranked": "video",
+        "community_verified": "community",
+        "event_verified": "event",
+        "judge_verified": "judge"
+      }
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1384,6 +1384,25 @@
     },
     "dashboard": {
       "intro": "Bienvenue dans ton espace PRO. La Judge Console arrive juste après — le reste suit."
+    },
+    "judge": {
+      "intro": "Valide les performances vues sur le floor — un score validé passe au ranking vérifié.",
+      "loading": "Chargement de la file…",
+      "error": "Impossible de charger la file.",
+      "empty": "Rien à valider pour le moment. 🎉",
+      "pendingCount": "{count} à valider",
+      "validate": "Valider",
+      "validating": "Validation…",
+      "video": "Vidéo",
+      "noProof": "pas de preuve vidéo",
+      "actionError": "Échec de la validation — réessaie.",
+      "proof": {
+        "honor": "honor",
+        "video_ranked": "vidéo",
+        "community_verified": "communauté",
+        "event_verified": "event",
+        "judge_verified": "judge"
+      }
     }
   }
 }


### PR DESCRIPTION
## V3-03 Judge Console — UI (#112, partie 2/2)

L'écran de validation coach, branché sur les RPC backend (#126, migration 031).

- **`/pro/judge`** (`JudgeConsole`) : file des scores à valider **scopée à la salle**, athlète + challenge + proof badge + score formaté + lien vidéo conditionnel, bouton **Valider** 1-clic avec **retrait optimiste**.
- **`judge` service** : `listPendingVerifications` / `verifyScore` (wrap des RPC `pending_verifications` / `verify_score`).
- **Nav** : item `judge` passe de `soon` → `live`.
- i18n `pro.judge` (en + fr) ; réutilise `useAsyncResource` + `formatScore`.

### Vérif (QA perso)
- ✅ typecheck · lint · 222 unit · `next build`
- ✅ Authentifié (compte test), **dark + light** : la file affiche 30 scores réels (proof HONOR/VIDEO, scores formatés mm:ss / reps), clic **Valider** → score promu `judge_verified` côté DB + ligne retirée, compteur 30 → 29.

🎯 **Boucle tranche 1 complète : poster un score → coach valide → judge_verified.**