### PR TITLE
feat(pro): dashboard KPIs (#113)

### DIFF
--- a/src/features/pro/components/ProDashboard.tsx
+++ b/src/features/pro/components/ProDashboard.tsx
@@ -5,7 +5,36 @@ import { useLocale, useTranslations } from 'next-intl';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { PRO_NAV } from '@/features/pro/lib/proNav';
+import { fetchGymOverview } from '@/features/pro/services/dashboard';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
 import { isGymManager } from '@/lib/roles';
+
+function GymKpis() {
+  const t = useTranslations('pro.dashboard.kpi');
+  const { state } = useAsyncResource(fetchGymOverview, []);
+  const ready = state.status === 'ready' ? state.data : null;
+
+  const cards: ReadonlyArray<{ key: string; value: number | null }> = [
+    { key: 'members', value: ready?.memberCount ?? null },
+    { key: 'pending', value: ready?.pendingCount ?? null },
+    { key: 'active7d', value: ready?.active7dCount ?? null },
+  ];
+
+  return (
+    <ul className="grid grid-cols-3 gap-3">
+      {cards.map((c) => (
+        <li key={c.key} className="rounded-md border border-border bg-card p-4">
+          <p className="text-2xl font-black tabular-nums">
+            {state.status === 'error' ? '—' : (c.value ?? '·')}
+          </p>
+          <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+            {t(c.key)}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export function ProDashboard() {
   const t = useTranslations('pro');
@@ -22,6 +51,8 @@ export function ProDashboard() {
   return (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">{t('dashboard.intro')}</p>
+
+      <GymKpis />
 
       <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {cards.map((item) => {

--- a/src/features/pro/services/dashboard.ts
+++ b/src/features/pro/services/dashboard.ts
@@ -1,0 +1,26 @@
+import { supabase } from '@/lib/supabase';
+
+/** Gym KPIs scoped to the caller's gym (see `gym_overview`). */
+export type GymOverview = {
+  memberCount: number;
+  pendingCount: number;
+  active7dCount: number;
+};
+
+type Row = {
+  member_count: number;
+  pending_count: number;
+  active_7d_count: number;
+};
+
+export async function fetchGymOverview(): Promise<GymOverview> {
+  const { data, error } = await supabase.rpc('gym_overview');
+  if (error) throw new Error(error.message);
+
+  const row = ((data ?? []) as Row[])[0];
+  return {
+    memberCount: Number(row?.member_count ?? 0),
+    pendingCount: Number(row?.pending_count ?? 0),
+    active7dCount: Number(row?.active_7d_count ?? 0),
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1383,7 +1383,12 @@
       "billing": "Billing"
     },
     "dashboard": {
-      "intro": "Welcome to your PRO space. The Judge Console arrives next — the rest is on the way."
+      "intro": "Welcome to your PRO space. The Judge Console arrives next — the rest is on the way.",
+      "kpi": {
+        "members": "Members",
+        "pending": "To validate",
+        "active7d": "Active (7d)"
+      }
     },
     "judge": {
       "intro": "Validate performances you witnessed on the floor — a validated score jumps to the verified ranking.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1383,7 +1383,12 @@
       "billing": "Facturation"
     },
     "dashboard": {
-      "intro": "Bienvenue dans ton espace PRO. La Judge Console arrive juste après — le reste suit."
+      "intro": "Bienvenue dans ton espace PRO. La Judge Console arrive juste après — le reste suit.",
+      "kpi": {
+        "members": "Membres",
+        "pending": "À valider",
+        "active7d": "Actifs (7j)"
+      }
     },
     "judge": {
       "intro": "Valide les performances vues sur le floor — un score validé passe au ranking vérifié.",

--- a/supabase/migrations/032_gym_overview.sql
+++ b/supabase/migrations/032_gym_overview.sql
@@ -1,0 +1,44 @@
+-- V3 tranche 2: gym dashboard KPIs, scoped to the caller's gym.
+-- SECURITY DEFINER so a coach/gym_admin gets aggregates over their members without
+-- broad per-row read access. platform_admin sees platform-wide totals.
+
+CREATE OR REPLACE FUNCTION public.gym_overview()
+RETURNS TABLE (
+  member_count    int,
+  pending_count   int,
+  active_7d_count int
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_gym   uuid;
+  v_admin boolean;
+BEGIN
+  SELECT affiliated_gym_id, public.is_platform_admin()
+    INTO v_gym, v_admin
+  FROM public.profiles
+  WHERE id = auth.uid();
+
+  -- A coach/gym_admin with no gym set sees zeros (nothing scoped to them yet).
+  RETURN QUERY
+  SELECT
+    (SELECT count(*)::int
+       FROM public.profiles p
+       WHERE v_admin OR (v_gym IS NOT NULL AND p.affiliated_gym_id = v_gym)),
+    (SELECT count(*)::int
+       FROM public.scores s
+       JOIN public.profiles p ON p.id = s.user_id
+       WHERE s.is_hidden = false
+         AND s.proof_level <> 'judge_verified'
+         AND (v_admin OR (v_gym IS NOT NULL AND p.affiliated_gym_id = v_gym))),
+    (SELECT count(*)::int
+       FROM public.profiles p
+       WHERE (v_admin OR (v_gym IS NOT NULL AND p.affiliated_gym_id = v_gym))
+         AND p.last_activity_at >= now() - interval '7 days');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_overview() TO authenticated;


### PR DESCRIPTION
Tranche 2 — KPIs du dashboard /pro (membres / à valider / actifs 7j) via RPC `gym_overview()` (migration 032, scopée à la salle, smokée prod). Cartes au-dessus de l'aperçu des sections. i18n en+fr.