### PR TITLE
feat(pro): members roster at /pro/members (#113)

### DIFF
--- a/src/app/[locale]/app/pro/members/page.tsx
+++ b/src/app/[locale]/app/pro/members/page.tsx
@@ -1,0 +1,5 @@
+import { MembersList } from '@/features/pro/components/MembersList';
+
+export default function ProMembersPage() {
+  return <MembersList />;
+}

--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useLocale, useTranslations } from 'next-intl';
+
+import { listGymMembers, type GymMember } from '@/features/pro/services/members';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+
+function initials(name: string | null): string {
+  return name ? name.slice(0, 2).toUpperCase() : '?';
+}
+
+function lastActiveLabel(iso: string | null, locale: string, never: string): string {
+  if (!iso) return never;
+  return new Date(iso).toLocaleDateString(locale, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function MemberRow({ member }: { member: GymMember }) {
+  const locale = useLocale();
+  const t = useTranslations('pro.members');
+  const isHorde = member.faction === 'horde';
+
+  return (
+    <li className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0">
+      <span
+        aria-hidden
+        className={`h-2 w-2 shrink-0 rounded-full ${isHorde ? 'bg-[var(--faction-horde)]' : 'bg-sky-500'}`}
+      />
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-black">
+        {initials(member.username)}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm font-bold">{member.username ?? '—'}</span>
+      {member.division ? (
+        <span className="shrink-0 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+          {member.division}
+        </span>
+      ) : null}
+      <span className="w-28 shrink-0 text-right text-xs text-muted-foreground">
+        {lastActiveLabel(member.lastActivityAt, locale, t('never'))}
+      </span>
+    </li>
+  );
+}
+
+export function MembersList() {
+  const t = useTranslations('pro.members');
+  const { state } = useAsyncResource(listGymMembers, []);
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error') {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+
+  const members = state.data;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t('intro')}</p>
+      {members.length === 0 ? (
+        <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {t('empty')}
+        </p>
+      ) : (
+        <>
+          <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('count', { count: members.length })}
+          </p>
+          <ul className="rounded-md border border-border bg-card">
+            {members.map((m) => (
+              <MemberRow key={m.id} member={m} />
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -67,7 +67,7 @@ export const PRO_NAV: readonly ProNavGroup[] = [
         labelKey: 'planning',
         status: 'soon',
       },
-      { id: 'members', path: '/app/pro/members', icon: Users, labelKey: 'members', status: 'soon' },
+      { id: 'members', path: '/app/pro/members', icon: Users, labelKey: 'members', status: 'live' },
       {
         id: 'subscriptions',
         path: '/app/pro/subscriptions',

--- a/src/features/pro/services/members.ts
+++ b/src/features/pro/services/members.ts
@@ -1,0 +1,34 @@
+import { supabase } from '@/lib/supabase';
+
+/** An athlete affiliated to the caller's gym (see `gym_members`). */
+export type GymMember = {
+  id: string;
+  username: string | null;
+  division: string | null;
+  faction: string | null;
+  avatarUrl: string | null;
+  lastActivityAt: string | null;
+};
+
+type Row = {
+  id: string;
+  username: string | null;
+  division: string | null;
+  faction: string | null;
+  avatar_url: string | null;
+  last_activity_at: string | null;
+};
+
+export async function listGymMembers(): Promise<GymMember[]> {
+  const { data, error } = await supabase.rpc('gym_members');
+  if (error) throw new Error(error.message);
+
+  return ((data ?? []) as Row[]).map((row) => ({
+    id: row.id,
+    username: row.username,
+    division: row.division,
+    faction: row.faction,
+    avatarUrl: row.avatar_url,
+    lastActivityAt: row.last_activity_at,
+  }));
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1408,6 +1408,14 @@
         "event_verified": "event",
         "judge_verified": "judge"
       }
+    },
+    "members": {
+      "intro": "Athletes affiliated to your gym.",
+      "loading": "Loading members…",
+      "error": "Could not load members.",
+      "empty": "No members affiliated yet.",
+      "count": "{count} members",
+      "never": "never"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1408,6 +1408,14 @@
         "event_verified": "event",
         "judge_verified": "judge"
       }
+    },
+    "members": {
+      "intro": "Les athlètes affiliés à ta salle.",
+      "loading": "Chargement des membres…",
+      "error": "Impossible de charger les membres.",
+      "empty": "Aucun membre affilié pour le moment.",
+      "count": "{count} membres",
+      "never": "jamais"
     }
   }
 }

--- a/supabase/migrations/033_gym_members.sql
+++ b/supabase/migrations/033_gym_members.sql
@@ -1,0 +1,34 @@
+-- V3 tranche 2: roster of athletes affiliated to the caller's gym.
+-- SECURITY DEFINER so a coach/gym_admin lists their members without broad profile read access.
+-- platform_admin sees all profiles. LANGUAGE sql (no OUT-param shadowing of column names).
+
+CREATE OR REPLACE FUNCTION public.gym_members()
+RETURNS TABLE (
+  id               uuid,
+  username         text,
+  division         text,
+  faction          text,
+  avatar_url       text,
+  last_activity_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT p.id, p.username, p.division, p.faction, p.avatar_url, p.last_activity_at
+  FROM public.profiles p
+  WHERE EXISTS (
+    SELECT 1
+    FROM public.profiles caller
+    WHERE caller.id = auth.uid()
+      AND (
+        public.is_platform_admin()
+        OR (caller.affiliated_gym_id IS NOT NULL AND p.affiliated_gym_id = caller.affiliated_gym_id)
+      )
+  )
+  ORDER BY p.last_activity_at DESC NULLS LAST
+  LIMIT 500;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_members() TO authenticated;


### PR DESCRIPTION
Tranche 2 — roster des athlètes affiliés à la salle. RPC `gym_members()` (migration 033, SQL, scopée gym, smokée prod), liste avec faction/division/dernière activité, nav `members` → live, i18n en+fr. Vérifié visuellement (10 membres).