### PR TITLE
feat(pro): KYB-gated gym creation — verified SIREN/SIRET onboarding (#113)

### DIFF
--- a/src/app/[locale]/app/pro/gyms/new/page.tsx
+++ b/src/app/[locale]/app/pro/gyms/new/page.tsx
@@ -1,0 +1,5 @@
+import { CreateGymScreen } from '@/features/pro/components/CreateGymScreen';
+
+export default function NewGymPage() {
+  return <CreateGymScreen />;
+}

--- a/src/features/pro/components/CreateGymScreen.tsx
+++ b/src/features/pro/components/CreateGymScreen.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { createGym } from '@/features/pro/services/gym';
+
+/** Server `code`s that map to a dedicated message; anything else falls back to `error.generic`. */
+const KNOWN_ERRORS = new Set([
+  'invalid_siret',
+  'company_not_found',
+  'company_closed',
+  'gym_already_claimed',
+  'registry_unreachable',
+  'registry_error',
+]);
+
+export function CreateGymScreen() {
+  const t = useTranslations('pro.createGym');
+  const locale = useLocale();
+  const [siret, setSiret] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+
+  const digits = siret.replace(/\D/g, '');
+  const canSubmit = !submitting && (digits.length === 9 || digits.length === 14);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setErrorCode(null);
+    try {
+      await createGym({ siret: digits });
+      // Full reload so the server-provided profile (now gym_admin + affiliated) refreshes.
+      window.location.href = `/${locale}/app/pro`;
+    } catch (err) {
+      const code = err instanceof Error ? err.message : 'generic';
+      setErrorCode(KNOWN_ERRORS.has(code) ? code : 'generic');
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-5">
+      <div className="space-y-2">
+        <h2 className="text-xl font-black uppercase tracking-tight">{t('title')}</h2>
+        <p className="text-sm text-muted-foreground">{t('intro')}</p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4 rounded-md border border-border bg-card p-5"
+      >
+        <label className="block space-y-1.5">
+          <span className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('siretLabel')}
+          </span>
+          <input
+            type="text"
+            inputMode="numeric"
+            autoComplete="off"
+            value={siret}
+            onChange={(e) => setSiret(e.target.value)}
+            placeholder="848 359 154 00020"
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <span className="text-xs text-muted-foreground">{t('siretHint')}</span>
+        </label>
+
+        {errorCode ? (
+          <p role="alert" className="text-sm font-semibold text-primary">
+            {t(`error.${errorCode}`)}
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-black uppercase tracking-[0.12em] text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {submitting ? t('submitting') : t('submit')}
+        </button>
+      </form>
+
+      <p className="text-xs text-muted-foreground">{t('moat')}</p>
+    </div>
+  );
+}

--- a/src/features/pro/components/ProDashboard.tsx
+++ b/src/features/pro/components/ProDashboard.tsx
@@ -36,12 +36,30 @@ function GymKpis() {
   );
 }
 
+function NoGymCta() {
+  const t = useTranslations('pro.createGym');
+  const locale = useLocale();
+  return (
+    <Link
+      href={`/${locale}/app/pro/gyms/new`}
+      className="block rounded-md border border-primary/40 bg-card p-5 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <p className="text-[10px] font-black uppercase tracking-[0.18em] text-primary">
+        {t('ctaBadge')}
+      </p>
+      <p className="mt-1 text-base font-black uppercase tracking-tight">{t('title')}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{t('ctaBody')}</p>
+    </Link>
+  );
+}
+
 export function ProDashboard() {
   const t = useTranslations('pro');
   const tNav = useTranslations('pro.nav');
   const locale = useLocale();
   const profile = useOptionalAppProfile();
   const canManage = isGymManager(profile);
+  const hasGym = Boolean(profile?.affiliated_gym_id);
 
   // Flatten every section except the dashboard itself into overview cards.
   const cards = PRO_NAV.flatMap((group) => group.items)
@@ -52,7 +70,7 @@ export function ProDashboard() {
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">{t('dashboard.intro')}</p>
 
-      <GymKpis />
+      {hasGym ? <GymKpis /> : <NoGymCta />}
 
       <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {cards.map((item) => {

--- a/src/features/pro/services/gym.ts
+++ b/src/features/pro/services/gym.ts
@@ -1,0 +1,47 @@
+import { supabase } from '@/lib/supabase';
+
+/** A gym just created via KYB verification. */
+export type CreatedGym = {
+  id: string;
+  name: string;
+  slug: string;
+  siren: string | null;
+  legal_name: string | null;
+  city: string | null;
+};
+
+/**
+ * Claim/create a gym from a SIREN/SIRET. The `create-gym` Edge Function verifies the legal
+ * entity against the public business registry, then provisions the gym and promotes the
+ * caller to gym_admin. Throws with the server `code` (e.g. `company_not_found`) on failure.
+ */
+export async function createGym(input: { siret: string }): Promise<CreatedGym> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    throw new Error('no_session');
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '') ?? '';
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+  if (!baseUrl || !anonKey) {
+    throw new Error('server_misconfigured');
+  }
+
+  const res = await fetch(`${baseUrl}/functions/v1/create-gym`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`,
+      apikey: anonKey,
+    },
+    body: JSON.stringify({ siret: input.siret }),
+  });
+
+  const parsed = (await res.json().catch(() => ({}))) as { code?: string; gym?: CreatedGym };
+  if (!res.ok || !parsed.gym) {
+    throw new Error(parsed.code ?? `http_${res.status}`);
+  }
+  return parsed.gym;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1416,6 +1416,26 @@
       "empty": "No members affiliated yet.",
       "count": "{count} members",
       "never": "never"
+    },
+    "createGym": {
+      "title": "Create your gym",
+      "intro": "TrueGrynd PRO is for verified businesses. Enter your company's SIRET or SIREN — we check it against the French business registry and set up your gym.",
+      "siretLabel": "SIRET or SIREN",
+      "siretHint": "14 digits (SIRET) or 9 (SIREN) — found on your Kbis or any invoice.",
+      "submit": "Verify & create my gym",
+      "submitting": "Verifying…",
+      "moat": "Every gym on TrueGrynd maps to a real, verified company — that's what keeps the ranking credible.",
+      "ctaBadge": "Get started",
+      "ctaBody": "You don't have a gym yet. Create yours to unlock judging, events and member management.",
+      "error": {
+        "generic": "Something went wrong — try again.",
+        "invalid_siret": "Enter a valid SIRET (14 digits) or SIREN (9 digits).",
+        "company_not_found": "No company found for this number. Check the digits.",
+        "company_closed": "This company is registered as closed.",
+        "gym_already_claimed": "A gym already exists for this company.",
+        "registry_unreachable": "The business registry is unreachable right now — try again shortly.",
+        "registry_error": "The business registry returned an error — try again shortly."
+      }
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1416,6 +1416,26 @@
       "empty": "Aucun membre affilié pour le moment.",
       "count": "{count} membres",
       "never": "jamais"
+    },
+    "createGym": {
+      "title": "Créer ta salle",
+      "intro": "TrueGrynd PRO est réservé aux entreprises vérifiées. Saisis le SIRET ou le SIREN de ta box — on le vérifie auprès du registre des entreprises et on crée ta salle.",
+      "siretLabel": "SIRET ou SIREN",
+      "siretHint": "14 chiffres (SIRET) ou 9 (SIREN) — sur ton Kbis ou n'importe quelle facture.",
+      "submit": "Vérifier & créer ma salle",
+      "submitting": "Vérification…",
+      "moat": "Chaque salle sur TrueGrynd correspond à une entreprise réelle et vérifiée — c'est ce qui rend le classement crédible.",
+      "ctaBadge": "Démarrer",
+      "ctaBody": "Tu n'as pas encore de salle. Crée la tienne pour débloquer la validation, les events et la gestion des membres.",
+      "error": {
+        "generic": "Une erreur est survenue — réessaie.",
+        "invalid_siret": "Saisis un SIRET (14 chiffres) ou un SIREN (9 chiffres) valide.",
+        "company_not_found": "Aucune entreprise trouvée pour ce numéro. Vérifie les chiffres.",
+        "company_closed": "Cette entreprise est enregistrée comme fermée.",
+        "gym_already_claimed": "Une salle existe déjà pour cette entreprise.",
+        "registry_unreachable": "Le registre des entreprises est injoignable pour le moment — réessaie bientôt.",
+        "registry_error": "Le registre des entreprises a renvoyé une erreur — réessaie bientôt."
+      }
     }
   }
 }

--- a/supabase/functions/create-gym/cors.ts
+++ b/supabase/functions/create-gym/cors.ts
@@ -1,0 +1,4 @@
+export const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};

--- a/supabase/functions/create-gym/index.ts
+++ b/supabase/functions/create-gym/index.ts
@@ -1,0 +1,160 @@
+// V3-04: KYB-gated gym creation.
+// Verifies a French SIREN/SIRET against the public business registry
+// (recherche-entreprises.api.gouv.fr — free, no key), then provisions the gym and promotes
+// the caller to gym_admin via the service-role-only RPC `create_verified_gym`.
+// This Edge Function is the ONLY path that can persist a gym, so every gym is verified.
+
+import { createClient } from 'npm:@supabase/supabase-js@2';
+
+import { corsHeaders } from './cors.ts';
+
+const REGISTRY_URL = 'https://recherche-entreprises.api.gouv.fr/search';
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+type RegistrySiege = {
+  siret?: string;
+  etat_administratif?: string;
+  activite_principale?: string;
+  libelle_commune?: string;
+};
+type RegistryResult = {
+  siren?: string;
+  nom_complet?: string;
+  nom_raison_sociale?: string;
+  siege?: RegistrySiege;
+};
+
+/** Verified company identity, ready to persist. */
+type VerifiedCompany = {
+  siren: string;
+  siret: string;
+  legalName: string;
+  naf: string | null;
+  city: string | null;
+};
+
+/** Look up a company by SIREN (9) / SIRET (14) and confirm it is active. */
+async function verifyCompany(
+  digits: string,
+): Promise<{ ok: true; company: VerifiedCompany } | { ok: false; code: string; status: number }> {
+  const siren = digits.length === 14 ? digits.slice(0, 9) : digits;
+
+  const url = `${REGISTRY_URL}?q=${encodeURIComponent(digits)}&page=1&per_page=1`;
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Accept: 'application/json' } });
+  } catch {
+    return { ok: false, code: 'registry_unreachable', status: 502 };
+  }
+  if (!res.ok) {
+    return { ok: false, code: 'registry_error', status: 502 };
+  }
+
+  const body = (await res.json().catch(() => null)) as { results?: RegistryResult[] } | null;
+  const result = body?.results?.[0];
+  if (!result || result.siren !== siren) {
+    return { ok: false, code: 'company_not_found', status: 404 };
+  }
+  if (result.siege?.etat_administratif === 'C') {
+    return { ok: false, code: 'company_closed', status: 422 };
+  }
+
+  const legalName = (result.nom_complet ?? result.nom_raison_sociale ?? '').trim();
+  if (!legalName) {
+    return { ok: false, code: 'company_not_found', status: 404 };
+  }
+
+  return {
+    ok: true,
+    company: {
+      siren,
+      siret: digits.length === 14 ? digits : (result.siege?.siret ?? ''),
+      legalName,
+      naf: result.siege?.activite_principale ?? null,
+      city: result.siege?.libelle_commune ?? null,
+    },
+  };
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ code: 'method_not_allowed' }, 405);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !anonKey || !serviceKey) {
+    return jsonResponse({ code: 'server_misconfigured' }, 500);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return jsonResponse({ code: 'unauthorized' }, 401);
+  }
+
+  let body: { siret?: string; siren?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return jsonResponse({ code: 'bad_request' }, 400);
+  }
+
+  // Accept either a SIRET (14 digits) or a SIREN (9); strip spaces/dots the user may type.
+  const digits = (body.siret ?? body.siren ?? '').replace(/\D/g, '');
+  if (digits.length !== 9 && digits.length !== 14) {
+    return jsonResponse({ code: 'invalid_siret' }, 400);
+  }
+
+  // Identify the caller from their JWT (they become the gym owner).
+  const authed = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+  const {
+    data: { user },
+    error: userErr,
+  } = await authed.auth.getUser();
+  if (userErr || !user) {
+    return jsonResponse({ code: 'unauthorized' }, 401);
+  }
+
+  const verified = await verifyCompany(digits);
+  if (!verified.ok) {
+    return jsonResponse({ code: verified.code }, verified.status);
+  }
+  const { company } = verified;
+
+  // Service role: the RPC is service-role-only, so an unverified SIREN can never reach the DB.
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+  const { data: gym, error: rpcErr } = await admin.rpc('create_verified_gym', {
+    p_owner: user.id,
+    p_name: company.legalName,
+    p_siren: company.siren,
+    p_siret: company.siret,
+    p_legal_name: company.legalName,
+    p_naf: company.naf,
+    p_city: company.city,
+    p_country: 'FR',
+  });
+
+  if (rpcErr) {
+    const code = rpcErr.message.includes('gym_already_claimed')
+      ? 'gym_already_claimed'
+      : 'create_failed';
+    return jsonResponse({ code }, code === 'gym_already_claimed' ? 409 : 500);
+  }
+
+  return jsonResponse({ gym }, 201);
+});

--- a/supabase/migrations/034_gym_kyb.sql
+++ b/supabase/migrations/034_gym_kyb.sql
@@ -1,0 +1,90 @@
+-- V3-04: KYB — a gym is a VERIFIED legal entity (SIREN/SIRET), not a free-form record.
+-- Self-serve gym creation is gated behind business verification (recherche-entreprises API,
+-- done server-side in the `create-gym` Edge Function). This keeps the verified-ranking moat
+-- credible: every gym maps to a real company. Additive & non-breaking.
+
+-- 1. Legal-identity columns on gyms (all NULL for pre-V3-04 rows).
+ALTER TABLE public.gyms
+  ADD COLUMN IF NOT EXISTS siren       TEXT        NULL,
+  ADD COLUMN IF NOT EXISTS siret       TEXT        NULL,
+  ADD COLUMN IF NOT EXISTS legal_name  TEXT        NULL,
+  ADD COLUMN IF NOT EXISTS naf_code    TEXT        NULL,
+  ADD COLUMN IF NOT EXISTS verified_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.gyms.siren IS
+  'V3-04: 9-digit SIREN of the owning legal entity (KYB). Unique — one gym per company.';
+COMMENT ON COLUMN public.gyms.verified_at IS
+  'V3-04: when the SIREN/SIRET was verified against the public business registry.';
+
+-- One gym per legal entity (partial: legacy rows with NULL siren are unaffected).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gyms_siren_unique
+  ON public.gyms (siren) WHERE siren IS NOT NULL;
+
+-- 2. Trusted creation path. SECURITY DEFINER so it can insert the gym AND promote the
+-- caller to gym_admin in one transaction. Granted to service_role ONLY: the sole caller is
+-- the `create-gym` Edge Function, which has already verified the SIREN against the registry.
+-- A client cannot reach this directly, so an unverified SIREN can never be persisted.
+CREATE OR REPLACE FUNCTION public.create_verified_gym(
+  p_owner      uuid,
+  p_name       text,
+  p_siren      text,
+  p_siret      text,
+  p_legal_name text,
+  p_naf        text,
+  p_city       text,
+  p_country    text DEFAULT 'FR'
+)
+RETURNS public.gyms
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_gym  public.gyms;
+  v_base text;
+  v_slug text;
+  v_n    int := 1;
+BEGIN
+  IF p_owner IS NULL THEN
+    RAISE EXCEPTION 'no_owner';
+  END IF;
+  IF p_siren IS NULL OR p_siren !~ '^\d{9}$' THEN
+    RAISE EXCEPTION 'invalid_siren';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.gyms WHERE siren = p_siren) THEN
+    RAISE EXCEPTION 'gym_already_claimed';
+  END IF;
+
+  -- Build a unique URL slug from the (legal) name.
+  v_base := btrim(regexp_replace(lower(coalesce(nullif(btrim(p_name), ''), 'gym')), '[^a-z0-9]+', '-', 'g'), '-');
+  IF v_base = '' THEN
+    v_base := 'gym';
+  END IF;
+  v_slug := v_base;
+  WHILE EXISTS (SELECT 1 FROM public.gyms WHERE slug = v_slug) LOOP
+    v_n := v_n + 1;
+    v_slug := v_base || '-' || v_n;
+  END LOOP;
+
+  INSERT INTO public.gyms (name, slug, owner_id, city, country_code,
+                           siren, siret, legal_name, naf_code, verified_at)
+  VALUES (coalesce(nullif(btrim(p_name), ''), p_legal_name), v_slug, p_owner, p_city, p_country,
+          p_siren, p_siret, p_legal_name, p_naf, NOW())
+  RETURNING * INTO v_gym;
+
+  -- Promote the claimer to gym_admin (never downgrade a platform_admin) and affiliate them.
+  UPDATE public.profiles
+  SET role = CASE WHEN role IN ('athlete', 'coach') THEN 'gym_admin'::public.user_role ELSE role END,
+      affiliated_gym_id = v_gym.id
+  WHERE id = p_owner;
+
+  RETURN v_gym;
+END;
+$$;
+
+COMMENT ON FUNCTION public.create_verified_gym IS
+  'V3-04: create a KYB-verified gym + promote the owner to gym_admin. Service-role only; '
+  'the create-gym Edge Function verifies the SIREN before calling this.';
+
+REVOKE ALL ON FUNCTION public.create_verified_gym(uuid, text, text, text, text, text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.create_verified_gym(uuid, text, text, text, text, text, text, text) TO service_role;


### PR DESCRIPTION
## Why
A gym must be a **verified legal entity**, not a free-form record. This gates self-serve gym creation behind business verification (KYB) — the same pattern Stripe/Qonto use — so every gym maps to a real company. That's what keeps the **verified-ranking moat** credible and blocks fake/spam gyms.

## What
- **Migration 034** — `gyms` KYB columns (`siren`, `siret`, `legal_name`, `naf_code`, `verified_at`), unique partial index on `siren` (one gym per company), and `create_verified_gym` RPC (SECURITY DEFINER, **service-role only**): inserts the gym + promotes the caller to `gym_admin` + affiliates them, in one transaction. Never downgrades a `platform_admin`.
- **Edge Function `create-gym`** — verifies the SIREN/SIRET against the public business registry (`recherche-entreprises.api.gouv.fr`, free, no key), confirms the entity is active, then calls the RPC via service role. It's the **only** write path, so an unverified SIREN can never be persisted.
- **UI** — `/app/pro/gyms/new` claim/create screen (SIRET or SIREN input) + a dashboard CTA shown when the caller has no gym yet. en/fr i18n.

## Smoke (prod, end-to-end)
- Real SIRET `84835915400020` → gym created with legal name / NAF / city, owner promoted, affiliation set ✅
- Duplicate SIRET → `409 gym_already_claimed` · unknown → `404 company_not_found` · malformed → `400 invalid_siret` ✅
- `platform_admin` role preserved (not downgraded) ✅
- Test gym deleted afterwards; FK `ON DELETE SET NULL` auto-cleared the affiliation → DB pristine ✅
- `typecheck` / `lint` / 222 tests / `build` all green.

## Scope note
This is the **admin-provisionable / self-serve creation** primitive (one path for both). Member **invitations** and **Stripe billing** gating remain follow-ups (#117/#118). Opening the entry point to plain athletes (outside the `/pro` guard) is the PLG follow-up; the pilot box is bootstrapped via `platform_admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)