### PR TITLE
feat(pro): gym-owned events — create competition + list (#113)

### DIFF
--- a/src/app/[locale]/app/pro/events/new/page.tsx
+++ b/src/app/[locale]/app/pro/events/new/page.tsx
@@ -1,0 +1,5 @@
+import { CreateGymEventScreen } from '@/features/pro/components/CreateGymEventScreen';
+
+export default function NewGymEventPage() {
+  return <CreateGymEventScreen />;
+}

--- a/src/app/[locale]/app/pro/events/page.tsx
+++ b/src/app/[locale]/app/pro/events/page.tsx
@@ -1,0 +1,5 @@
+import { EventsList } from '@/features/pro/components/EventsList';
+
+export default function ProEventsPage() {
+  return <EventsList />;
+}

--- a/src/features/pro/components/CreateGymEventScreen.tsx
+++ b/src/features/pro/components/CreateGymEventScreen.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { CreateChallengeCircuitSection } from '@/features/challenges/components/CreateChallengeCircuitSection';
+import { CreateChallengeScoringSection } from '@/features/challenges/components/CreateChallengeScoringSection';
+import { buildFullChallengeRules } from '@/features/challenges/lib/circuitBlocks';
+import {
+  buildGymEventSchema,
+  GYM_EVENT_DEFAULT_VALUES,
+  type GymEventFormValues,
+} from '@/features/pro/lib/gymEventSchema';
+import { createGymEvent } from '@/features/pro/services/events';
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return (
+    <p className="mt-1 text-xs font-semibold text-primary" role="alert">
+      {message}
+    </p>
+  );
+}
+
+export function CreateGymEventScreen() {
+  const t = useTranslations('pro.events.create');
+  const tcc = useTranslations('arena.create.validation');
+  const locale = useLocale();
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [errorKey, setErrorKey] = useState<string | null>(null);
+
+  const schema = useMemo(() => buildGymEventSchema(tcc, t), [tcc, t]);
+  const form = useForm<GymEventFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: GYM_EVENT_DEFAULT_VALUES,
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    setBusy(true);
+    setErrorKey(null);
+    try {
+      const workout = buildFullChallengeRules({
+        scoringMode: values.scoringMode,
+        amrapCap: values.amrapCap,
+        forTimeFinishCap: values.forTimeCap,
+        circuitBlocks: values.circuitBlocks,
+        rulesDetail: values.rulesDetail,
+      });
+      await createGymEvent({
+        title: values.title,
+        description: values.description,
+        workout,
+        scoreType: values.scoringMode === 'for_time' ? 'time' : 'reps',
+        startsAt: values.startsAt,
+        endsAt: values.endsAt,
+      });
+      router.push(`/${locale}/app/pro/events`);
+    } catch {
+      setErrorKey('error');
+      setBusy(false);
+    }
+  });
+
+  return (
+    <section className="space-y-6">
+      <Link
+        href={`/${locale}/app/pro/events`}
+        className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {t('back')}
+      </Link>
+
+      <header className="space-y-1">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      {errorKey ? (
+        <p className="rounded-sm border border-primary/40 bg-primary/10 px-3 py-2 text-xs font-semibold text-primary">
+          {t(errorKey)}
+        </p>
+      ) : null}
+
+      <FormProvider {...form}>
+        <form className="space-y-5" onSubmit={onSubmit} noValidate>
+          <div>
+            <label
+              htmlFor="ev-title"
+              className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
+            >
+              {t('fields.title')}
+            </label>
+            <input
+              id="ev-title"
+              type="text"
+              autoComplete="off"
+              disabled={busy}
+              className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              {...form.register('title')}
+            />
+            <FieldError message={form.formState.errors.title?.message} />
+          </div>
+
+          <div>
+            <label
+              htmlFor="ev-description"
+              className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
+            >
+              {t('fields.description')}
+            </label>
+            <textarea
+              id="ev-description"
+              rows={3}
+              disabled={busy}
+              className="mt-2 w-full resize-y rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              {...form.register('description')}
+            />
+            <FieldError message={form.formState.errors.description?.message} />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label
+                htmlFor="ev-starts"
+                className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
+              >
+                {t('fields.startsAt')}
+              </label>
+              <input
+                id="ev-starts"
+                type="datetime-local"
+                disabled={busy}
+                className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                {...form.register('startsAt')}
+              />
+              <FieldError message={form.formState.errors.startsAt?.message} />
+            </div>
+            <div>
+              <label
+                htmlFor="ev-ends"
+                className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
+              >
+                {t('fields.endsAt')}
+              </label>
+              <input
+                id="ev-ends"
+                type="datetime-local"
+                disabled={busy}
+                className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                {...form.register('endsAt')}
+              />
+              <FieldError message={form.formState.errors.endsAt?.message} />
+            </div>
+          </div>
+
+          <CreateChallengeCircuitSection disabled={busy} />
+          <CreateChallengeScoringSection disabled={busy} />
+
+          <button
+            type="submit"
+            disabled={busy}
+            className="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            {busy ? t('submitting') : t('submit')}
+          </button>
+        </form>
+      </FormProvider>
+    </section>
+  );
+}

--- a/src/features/pro/components/EventsList.tsx
+++ b/src/features/pro/components/EventsList.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { listGymEvents, type GymEvent } from '@/features/pro/services/events';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+
+type Phase = 'upcoming' | 'live' | 'ended';
+
+function phaseOf(event: GymEvent): Phase {
+  const now = Date.now();
+  if (now < new Date(event.startsAt).getTime()) return 'upcoming';
+  if (now > new Date(event.endsAt).getTime()) return 'ended';
+  return 'live';
+}
+
+function formatWindow(iso: string, locale: string): string {
+  return new Date(iso).toLocaleString(locale, {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function EventRow({ event }: { event: GymEvent }) {
+  const locale = useLocale();
+  const t = useTranslations('pro.events');
+  const phase = phaseOf(event);
+  const badgeTone =
+    phase === 'live'
+      ? 'bg-primary text-primary-foreground'
+      : phase === 'upcoming'
+        ? 'bg-sky-500/15 text-sky-600 dark:text-sky-400'
+        : 'bg-muted text-muted-foreground';
+
+  return (
+    <li className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0">
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-bold">{event.title}</span>
+        <span className="block text-xs text-muted-foreground">
+          {formatWindow(event.startsAt, locale)} → {formatWindow(event.endsAt, locale)}
+        </span>
+      </span>
+      <span
+        className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] ${badgeTone}`}
+      >
+        {t(`phase.${phase}`)}
+      </span>
+    </li>
+  );
+}
+
+export function EventsList() {
+  const t = useTranslations('pro.events');
+  const locale = useLocale();
+  const { state } = useAsyncResource(listGymEvents, []);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">{t('intro')}</p>
+        <Link
+          href={`/${locale}/app/pro/events/new`}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          {t('create.cta')}
+        </Link>
+      </div>
+
+      {state.status === 'loading' || state.status === 'idle' ? (
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
+      ) : state.status === 'error' ? (
+        <p className="text-sm font-semibold text-primary">{t('error')}</p>
+      ) : state.data.length === 0 ? (
+        <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {t('empty')}
+        </p>
+      ) : (
+        <ul className="rounded-md border border-border bg-card">
+          {state.data.map((e) => (
+            <EventRow key={e.id} event={e} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/pro/lib/gymEventSchema.ts
+++ b/src/features/pro/lib/gymEventSchema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+import {
+  buildCreateChallengeSchema,
+  type CreateChallengeFormValues,
+} from '@/features/challenges/lib/createChallengeSchema';
+
+/** Reuses the B2C challenge builder (circuit + scoring) and adds the event window. */
+export type GymEventFormValues = CreateChallengeFormValues & {
+  startsAt: string;
+  endsAt: string;
+};
+
+export const GYM_EVENT_DEFAULT_VALUES: GymEventFormValues = {
+  title: '',
+  description: '',
+  rulesDetail: '',
+  circuitBlocks: [{ label: '', kind: 'reps', amount: '', movementSlug: '' }],
+  scoringMode: 'for_time',
+  amrapCap: '',
+  forTimeCap: '',
+  equipmentTagsRaw: '',
+  variants: ['standard'],
+  startsAt: '',
+  endsAt: '',
+};
+
+export function buildGymEventSchema(t: (key: string) => string, tWindow: (key: string) => string) {
+  return z
+    .intersection(
+      buildCreateChallengeSchema(t),
+      z.object({
+        startsAt: z.string().min(1, { message: tWindow('startsRequired') }),
+        endsAt: z.string().min(1, { message: tWindow('endsRequired') }),
+      }),
+    )
+    .superRefine((data, ctx) => {
+      if (data.startsAt && data.endsAt && new Date(data.endsAt) <= new Date(data.startsAt)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: tWindow('endsAfterStart'),
+          path: ['endsAt'],
+        });
+      }
+    });
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -52,7 +52,7 @@ export const PRO_NAV: readonly ProNavGroup[] = [
     labelKey: 'competition',
     items: [
       { id: 'judge', path: '/app/pro/judge', icon: Gavel, labelKey: 'judge', status: 'live' },
-      { id: 'events', path: '/app/pro/events', icon: Trophy, labelKey: 'events', status: 'soon' },
+      { id: 'events', path: '/app/pro/events', icon: Trophy, labelKey: 'events', status: 'live' },
       { id: 'tv', path: '/app/pro/tv', icon: Tv, labelKey: 'tv', status: 'soon' },
     ],
   },

--- a/src/features/pro/services/events.ts
+++ b/src/features/pro/services/events.ts
@@ -1,0 +1,63 @@
+import { supabase } from '@/lib/supabase';
+
+/** A gym-owned competition (see `gym_events`). */
+export type GymEvent = {
+  id: string;
+  title: string;
+  description: string;
+  workout: string;
+  scoreType: 'time' | 'reps';
+  startsAt: string;
+  endsAt: string;
+};
+
+type Row = {
+  id: string;
+  title: string;
+  description: string;
+  workout: string;
+  score_type: 'time' | 'reps';
+  starts_at: string;
+  ends_at: string;
+};
+
+function toGymEvent(row: Row): GymEvent {
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    workout: row.workout,
+    scoreType: row.score_type,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+  };
+}
+
+export async function listGymEvents(): Promise<GymEvent[]> {
+  const { data, error } = await supabase.rpc('gym_events_list');
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as Row[]).map(toGymEvent);
+}
+
+export async function createGymEvent(input: {
+  title: string;
+  description: string;
+  workout: string;
+  scoreType: 'time' | 'reps';
+  startsAt: string;
+  endsAt: string;
+}): Promise<GymEvent> {
+  const { data, error } = await supabase
+    .rpc('create_gym_event', {
+      p_title: input.title,
+      p_description: input.description,
+      p_workout: input.workout,
+      p_score_type: input.scoreType,
+      p_starts_at: new Date(input.startsAt).toISOString(),
+      p_ends_at: new Date(input.endsAt).toISOString(),
+    })
+    .single<Row>();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('event_create_failed');
+  return toGymEvent(data);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1417,6 +1417,35 @@
       "count": "{count} members",
       "never": "never"
     },
+    "events": {
+      "intro": "Competitions you run for your gym.",
+      "loading": "Loading events…",
+      "error": "Could not load events.",
+      "empty": "No events yet. Create your first competition.",
+      "phase": {
+        "upcoming": "Upcoming",
+        "live": "Live",
+        "ended": "Ended"
+      },
+      "create": {
+        "cta": "New event",
+        "back": "Back to events",
+        "title": "Create an event",
+        "subtitle": "Set the window and build the workout — your members compete on it.",
+        "submit": "Create event",
+        "submitting": "Creating…",
+        "error": "Could not create the event — try again.",
+        "startsRequired": "Pick a start date.",
+        "endsRequired": "Pick an end date.",
+        "endsAfterStart": "The end must be after the start.",
+        "fields": {
+          "title": "Event name",
+          "description": "Description",
+          "startsAt": "Starts",
+          "endsAt": "Ends"
+        }
+      }
+    },
     "createGym": {
       "title": "Create your gym",
       "intro": "TrueGrynd PRO is for verified businesses. Enter your company's SIRET or SIREN — we check it against the French business registry and set up your gym.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1417,6 +1417,35 @@
       "count": "{count} membres",
       "never": "jamais"
     },
+    "events": {
+      "intro": "Les compétitions que tu organises pour ta salle.",
+      "loading": "Chargement des events…",
+      "error": "Impossible de charger les events.",
+      "empty": "Aucun event pour le moment. Crée ta première compétition.",
+      "phase": {
+        "upcoming": "À venir",
+        "live": "En cours",
+        "ended": "Terminé"
+      },
+      "create": {
+        "cta": "Nouvel event",
+        "back": "Retour aux events",
+        "title": "Créer un event",
+        "subtitle": "Définis la fenêtre et compose le WOD — tes membres s'affrontent dessus.",
+        "submit": "Créer l'event",
+        "submitting": "Création…",
+        "error": "Impossible de créer l'event — réessaie.",
+        "startsRequired": "Choisis une date de début.",
+        "endsRequired": "Choisis une date de fin.",
+        "endsAfterStart": "La fin doit être après le début.",
+        "fields": {
+          "title": "Nom de l'event",
+          "description": "Description",
+          "startsAt": "Début",
+          "endsAt": "Fin"
+        }
+      }
+    },
     "createGym": {
       "title": "Créer ta salle",
       "intro": "TrueGrynd PRO est réservé aux entreprises vérifiées. Saisis le SIRET ou le SIREN de ta box — on le vérifie auprès du registre des entreprises et on crée ta salle.",

--- a/supabase/migrations/035_gym_events.sql
+++ b/supabase/migrations/035_gym_events.sql
@@ -1,0 +1,131 @@
+-- V3-05: gym-owned competitions ("Events"). A coach/gym_admin creates an event scoped to
+-- THEIR gym: title + description + window + a workout spec built with the B2C circuit/scoring
+-- builder. Kept fully separate from the B2C `events` table (different tenant) so gym workouts
+-- never leak into the public arena or the B2C events listing. Score submission + standings
+-- are a follow-up slice. Additive & non-breaking.
+
+CREATE TABLE IF NOT EXISTS public.gym_events (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gym_id      UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  created_by  UUID        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  title       TEXT        NOT NULL CHECK (length(btrim(title)) > 0),
+  description TEXT        NOT NULL DEFAULT '',
+  workout     TEXT        NOT NULL DEFAULT '',
+  score_type  TEXT        NOT NULL CHECK (score_type IN ('time', 'reps')),
+  starts_at   TIMESTAMPTZ NOT NULL,
+  ends_at     TIMESTAMPTZ NOT NULL,
+  status      TEXT        NOT NULL DEFAULT 'scheduled'
+    CHECK (status IN ('scheduled', 'cancelled')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT gym_events_window_check CHECK (ends_at > starts_at)
+);
+
+COMMENT ON TABLE public.gym_events IS
+  'V3-05: gym-owned competitions. workout = built circuit/scoring spec. The live phase '
+  '(upcoming/live/ended) is derived from the window client-side; status only flags cancellation.';
+
+CREATE INDEX IF NOT EXISTS idx_gym_events_gym ON public.gym_events (gym_id, starts_at DESC);
+
+ALTER TABLE public.gym_events ENABLE ROW LEVEL SECURITY;
+
+-- READ: anyone affiliated to the gym (members + staff), the gym owner, or a platform admin.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gym_events'
+      AND policyname = 'Gym people can read their gym events'
+  ) THEN
+    CREATE POLICY "Gym people can read their gym events"
+      ON public.gym_events FOR SELECT
+      TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_events.gym_id
+        )
+        OR EXISTS (
+          SELECT 1 FROM public.gyms g
+          WHERE g.id = gym_events.gym_id AND g.owner_id = auth.uid()
+        )
+      );
+  END IF;
+END $$;
+
+-- Writes go exclusively through create_gym_event (SECURITY DEFINER) — no INSERT/UPDATE policy.
+
+-- Create an event for the caller's own gym. Staff-only; the gym is the caller's affiliation.
+CREATE OR REPLACE FUNCTION public.create_gym_event(
+  p_title       text,
+  p_description text,
+  p_workout     text,
+  p_score_type  text,
+  p_starts_at   timestamptz,
+  p_ends_at     timestamptz
+)
+RETURNS public.gym_events
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller uuid := auth.uid();
+  v_gym    uuid;
+  v_staff  boolean;
+  v_event  public.gym_events;
+BEGIN
+  SELECT affiliated_gym_id, (role IN ('coach', 'gym_admin'))
+    INTO v_gym, v_staff
+  FROM public.profiles WHERE id = v_caller;
+
+  IF NOT (COALESCE(v_staff, false) OR public.is_platform_admin()) THEN
+    RAISE EXCEPTION 'not_gym_staff';
+  END IF;
+  IF v_gym IS NULL THEN
+    RAISE EXCEPTION 'no_gym';
+  END IF;
+  IF p_score_type NOT IN ('time', 'reps') THEN
+    RAISE EXCEPTION 'bad_score_type';
+  END IF;
+  IF p_ends_at <= p_starts_at THEN
+    RAISE EXCEPTION 'bad_window';
+  END IF;
+
+  INSERT INTO public.gym_events (gym_id, created_by, title, description, workout, score_type, starts_at, ends_at)
+  VALUES (v_gym, v_caller, btrim(p_title), coalesce(p_description, ''), coalesce(p_workout, ''),
+          p_score_type, p_starts_at, p_ends_at)
+  RETURNING * INTO v_event;
+
+  RETURN v_event;
+END;
+$$;
+
+COMMENT ON FUNCTION public.create_gym_event IS
+  'V3-05: create a competition for the caller''s gym (coach/gym_admin/platform_admin).';
+
+-- List the caller's gym events (most recent window first).
+CREATE OR REPLACE FUNCTION public.gym_events_list()
+RETURNS SETOF public.gym_events
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT e.*
+  FROM public.gym_events e
+  WHERE e.status <> 'cancelled'
+    AND (
+      public.is_platform_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = auth.uid() AND p.affiliated_gym_id = e.gym_id
+      )
+    )
+  ORDER BY e.starts_at DESC
+  LIMIT 200;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_gym_event(text, text, text, text, timestamptz, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.gym_events_list() TO authenticated;


### PR DESCRIPTION
## Why
First slice of **Events** (gym competitions). A coach/gym_admin creates a competition scoped to **their** gym, reusing the proven B2C challenge builder so there's no second WOD editor to maintain.

## What
- **Migration 035** — dedicated `gym_events` table (title, description, workout spec, score_type, window). Deliberately **separate from the B2C `events` table**: different tenant, so gym workouts never leak into the public arena or the B2C events listing. Gym-scoped RLS read (members/owner/platform_admin). Writes via `create_gym_event` (SECURITY DEFINER, staff-only, attaches to the caller's gym) + `gym_events_list` RPC.
- **UI** — `/app/pro/events` list with upcoming/live/ended phase derived from the window; `/app/pro/events/new` full-page builder reusing `CreateChallengeCircuitSection` + `CreateChallengeScoringSection`. Nav `events` `soon → live`.
- Events service, gym-event form schema (challenge schema ∩ window), en/fr i18n.

## Smoke (prod, end-to-end)
Bootstrapped a test gym, then:
- `create_gym_event` → event created, scoped to the gym ✅
- `gym_events_list` → returns only the caller's gym events ✅
- guardrails: `bad_window` (end ≤ start) and `bad_score_type` rejected ✅
- cleanup: deleting the gym cascade-removed the event + reset affiliation → DB pristine ✅
- `typecheck` / `lint` / 222 tests / `build` green (both new routes present).

## Scope / next slice
This slice is **create + list**. **Score submission + standings** (reusing the existing `event_scores` machinery) and event detail/edit/cancel are the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)