### PR TITLE
feat(pro): back gym events with a gym-scoped challenge (#113)

### DIFF
--- a/src/features/pro/services/events.ts
+++ b/src/features/pro/services/events.ts
@@ -9,6 +9,7 @@ export type GymEvent = {
   scoreType: 'time' | 'reps';
   startsAt: string;
   endsAt: string;
+  challengeId: string | null;
 };
 
 type Row = {
@@ -19,6 +20,7 @@ type Row = {
   score_type: 'time' | 'reps';
   starts_at: string;
   ends_at: string;
+  challenge_id: string | null;
 };
 
 function toGymEvent(row: Row): GymEvent {
@@ -30,6 +32,7 @@ function toGymEvent(row: Row): GymEvent {
     scoreType: row.score_type,
     startsAt: row.starts_at,
     endsAt: row.ends_at,
+    challengeId: row.challenge_id ?? null,
   };
 }
 

--- a/src/lib/challenges/listApprovedChallenges.ts
+++ b/src/lib/challenges/listApprovedChallenges.ts
@@ -2,13 +2,17 @@ import { CHALLENGE_SELECT } from '@/lib/challenges/constants';
 import { supabase } from '@/lib/supabase';
 import type { Challenge } from '@/lib/types/database.types';
 
-/** Approved challenges still open in Arena (excludes admin-closed UGC with past ends_at). */
+/**
+ * Approved challenges still open in Arena (excludes admin-closed UGC with past ends_at).
+ * Gym-scoped challenges (those backing a gym event) are kept out of the public B2C arena.
+ */
 export async function listApprovedChallenges(): Promise<Challenge[]> {
   const nowIso = new Date().toISOString();
   const { data, error } = await supabase
     .from('challenges')
     .select(CHALLENGE_SELECT)
     .eq('status', 'approved')
+    .is('gym_id', null)
     .or(`ends_at.is.null,ends_at.gt.${nowIso}`)
     .order('created_at', { ascending: false });
   if (error) throw new Error(error.message);

--- a/supabase/migrations/036_gym_event_scoring.sql
+++ b/supabase/migrations/036_gym_event_scoring.sql
@@ -1,0 +1,84 @@
+-- V3-05 slice 2a: route gym-event scoring through the EXISTING scoring core.
+-- "Big tech" unification: instead of a parallel score silo, a gym event is backed by a
+-- gym-scoped challenge (challenges.gym_id). Member scores flow through the normal `scores`
+-- pipeline → proof levels → Judge Console validation → leaderboard, all reused. The only
+-- new rule: gym-scoped challenges are hidden from the public B2C arena (one query filter).
+-- Additive & non-breaking.
+
+-- 1. Scope dimension on challenges. NULL = public B2C challenge; set = belongs to a gym.
+ALTER TABLE public.challenges
+  ADD COLUMN IF NOT EXISTS gym_id UUID NULL REFERENCES public.gyms(id) ON DELETE CASCADE;
+
+COMMENT ON COLUMN public.challenges.gym_id IS
+  'V3-05: when set, this challenge backs a gym event and is hidden from the public arena.';
+
+CREATE INDEX IF NOT EXISTS idx_challenges_gym ON public.challenges (gym_id) WHERE gym_id IS NOT NULL;
+
+-- 2. Link a gym event to its backing workout challenge.
+ALTER TABLE public.gym_events
+  ADD COLUMN IF NOT EXISTS challenge_id UUID NULL REFERENCES public.challenges(id) ON DELETE SET NULL;
+
+-- 3. create_gym_event now also materialises the gym-scoped challenge and links it, so members
+-- can submit scores against it immediately (same path as any other challenge).
+CREATE OR REPLACE FUNCTION public.create_gym_event(
+  p_title       text,
+  p_description text,
+  p_workout     text,
+  p_score_type  text,
+  p_starts_at   timestamptz,
+  p_ends_at     timestamptz
+)
+RETURNS public.gym_events
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller    uuid := auth.uid();
+  v_gym       uuid;
+  v_staff     boolean;
+  v_challenge uuid;
+  v_event     public.gym_events;
+BEGIN
+  SELECT affiliated_gym_id, (role IN ('coach', 'gym_admin'))
+    INTO v_gym, v_staff
+  FROM public.profiles WHERE id = v_caller;
+
+  IF NOT (COALESCE(v_staff, false) OR public.is_platform_admin()) THEN
+    RAISE EXCEPTION 'not_gym_staff';
+  END IF;
+  IF v_gym IS NULL THEN
+    RAISE EXCEPTION 'no_gym';
+  END IF;
+  IF p_score_type NOT IN ('time', 'reps') THEN
+    RAISE EXCEPTION 'bad_score_type';
+  END IF;
+  IF p_ends_at <= p_starts_at THEN
+    RAISE EXCEPTION 'bad_window';
+  END IF;
+
+  -- Backing gym-scoped challenge (approved, hidden from arena via gym_id). Closes with the event.
+  INSERT INTO public.challenges (title, description, rules, score_type, gym_id, creator_id,
+                                 is_official, status, ends_at)
+  VALUES (btrim(p_title), coalesce(nullif(btrim(p_description), ''), btrim(p_title)),
+          coalesce(nullif(btrim(p_workout), ''), btrim(p_title)), p_score_type, v_gym, v_caller,
+          false, 'approved', p_ends_at)
+  RETURNING id INTO v_challenge;
+
+  -- The scores pipeline requires a matching challenge_variants row (composite FK
+  -- scores.(challenge_id, variant) → challenge_variants). Gym events use the standard lane.
+  INSERT INTO public.challenge_variants (challenge_id, variant)
+  VALUES (v_challenge, 'standard')
+  ON CONFLICT (challenge_id, variant) DO NOTHING;
+
+  INSERT INTO public.gym_events (gym_id, created_by, title, description, workout, score_type,
+                                 starts_at, ends_at, challenge_id)
+  VALUES (v_gym, v_caller, btrim(p_title), coalesce(p_description, ''), coalesce(p_workout, ''),
+          p_score_type, p_starts_at, p_ends_at, v_challenge)
+  RETURNING * INTO v_event;
+
+  RETURN v_event;
+END;
+$$;
+
+-- gym_events_list already returns whole rows via SETOF gym_events, so challenge_id is included.


### PR DESCRIPTION
## Why
Slice 2a of **Events**. The "big tech" call: **one scoring core, not two.** Instead of a parallel `gym_event_scores` silo, a gym event is backed by a **gym-scoped challenge** so member scores flow through the existing `scores` → proof level → **Judge Console** → leaderboard pipeline. Zero new scoring/verification code; the verified-ranking moat is reused, not reimplemented.

## What
- **Migration 036** — `challenges.gym_id` (NULL = public B2C; set = gym-scoped). `gym_events.challenge_id`. `create_gym_event` now also materialises the backing challenge (approved, gym-scoped, `ends_at` = event end) **and** its `standard` `challenge_variants` row — required by the `scores (challenge_id, variant)` composite FK.
- **Arena isolation** — `listApprovedChallenges` filters `gym_id IS NULL`, so gym workouts never leak into the public arena.
- Events service exposes `challengeId` for the standings UI (slice 2b).

## Smoke (prod, end-to-end)
- Create event → backing challenge + `standard` variant created, **hidden from arena** ✅
- Member submits a score → core pipeline accepts it (`proof_level: honor`) ✅
- The **existing Judge Console queue** (`pending_verifications`) picks it up automatically; `verify_score` promotes it to `judge_verified` + records `verified_by_coach_id` ✅
- Cleanup via cascade; DB pristine. `typecheck` / `lint` / 222 tests / `build` green.

## Next slice
2b: event detail page + member score-submission UI + standings (reusing the existing `Leaderboard` component on the backing challenge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)