### PR TITLE
feat(pro): event detail — score submission + standings (#113)

### DIFF
--- a/src/app/[locale]/app/pro/events/[eventId]/page.tsx
+++ b/src/app/[locale]/app/pro/events/[eventId]/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { use } from 'react';
+
+import { EventDetail } from '@/features/pro/components/EventDetail';
+
+type Params = { eventId: string; locale: string };
+
+export default function ProEventDetailPage({ params }: { params: Promise<Params> }) {
+  const { eventId } = use(params);
+  return <EventDetail eventId={eventId} />;
+}

--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { Leaderboard } from '@/features/challenges/components/Leaderboard';
+import { getGymEvent, type GymEvent } from '@/features/pro/services/events';
+import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+
+type Phase = 'upcoming' | 'live' | 'ended';
+
+function phaseOf(event: GymEvent): Phase {
+  const now = Date.now();
+  if (now < new Date(event.startsAt).getTime()) return 'upcoming';
+  if (now > new Date(event.endsAt).getTime()) return 'ended';
+  return 'live';
+}
+
+function EventBody({ event }: { event: GymEvent }) {
+  const t = useTranslations('pro.events');
+  const locale = useLocale();
+  const profile = useOptionalAppProfile();
+  const phase = phaseOf(event);
+  const [submitting, setSubmitting] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [done, setDone] = useState(false);
+
+  const formatWindow = (iso: string) =>
+    new Date(iso).toLocaleString(locale, {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+  return (
+    <section className="space-y-6">
+      <Link
+        href={`/${locale}/app/pro/events`}
+        className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {t('detail.back')}
+      </Link>
+
+      <header className="space-y-2">
+        <span className="inline-flex items-center rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t(`phase.${phase}`)}
+        </span>
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{event.title}</h1>
+        <p className="text-sm text-muted-foreground">
+          {formatWindow(event.startsAt)} → {formatWindow(event.endsAt)}
+        </p>
+      </header>
+
+      {event.description ? (
+        <p className="text-sm text-muted-foreground">{event.description}</p>
+      ) : null}
+
+      {event.workout ? (
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('detail.workout')}
+          </p>
+          <pre className="mt-2 whitespace-pre-wrap font-sans text-sm text-foreground">
+            {event.workout}
+          </pre>
+        </div>
+      ) : null}
+
+      {/* Score submission flows through the same core pipeline as the B2C arena. */}
+      {phase === 'live' && event.challengeId ? (
+        done ? (
+          <p className="rounded-md border border-border bg-card p-4 text-sm text-muted-foreground">
+            {t('detail.submitted')}
+          </p>
+        ) : submitting ? (
+          <div className="rounded-md border border-border bg-card p-4">
+            <ScoreSubmissionForm
+              challengeId={event.challengeId}
+              scoreType={event.scoreType}
+              availableVariants={['standard']}
+              onSubmitted={() => {
+                setSubmitting(false);
+                setDone(true);
+                setReloadKey((k) => k + 1);
+              }}
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setSubmitting(true)}
+            className="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('detail.submit')}
+          </button>
+        )
+      ) : null}
+
+      <div className="space-y-2">
+        <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('detail.standings')}
+        </h2>
+        {event.challengeId ? (
+          <Leaderboard
+            key={`${event.challengeId}-${reloadKey}-${profile?.id ?? ''}`}
+            challengeId={event.challengeId}
+            scoreType={event.scoreType}
+            availableVariants={['standard']}
+            mode="full"
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground">{t('detail.noStandings')}</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function EventDetail({ eventId }: { eventId: string }) {
+  const t = useTranslations('pro.events');
+  const load = useCallback(() => getGymEvent(eventId), [eventId]);
+  const { state } = useAsyncResource(load, [eventId]);
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error' || !state.data) {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+  return <EventBody event={state.data} />;
+}

--- a/src/features/pro/components/EventsList.tsx
+++ b/src/features/pro/components/EventsList.tsx
@@ -37,18 +37,23 @@ function EventRow({ event }: { event: GymEvent }) {
         : 'bg-muted text-muted-foreground';
 
   return (
-    <li className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0">
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-bold">{event.title}</span>
-        <span className="block text-xs text-muted-foreground">
-          {formatWindow(event.startsAt, locale)} → {formatWindow(event.endsAt, locale)}
-        </span>
-      </span>
-      <span
-        className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] ${badgeTone}`}
+    <li className="border-b border-border last:border-b-0">
+      <Link
+        href={`/${locale}/app/pro/events/${event.id}`}
+        className="flex items-center gap-3 px-3 py-3 transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        {t(`phase.${phase}`)}
-      </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-bold">{event.title}</span>
+          <span className="block text-xs text-muted-foreground">
+            {formatWindow(event.startsAt, locale)} → {formatWindow(event.endsAt, locale)}
+          </span>
+        </span>
+        <span
+          className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] ${badgeTone}`}
+        >
+          {t(`phase.${phase}`)}
+        </span>
+      </Link>
     </li>
   );
 }

--- a/src/features/pro/services/events.ts
+++ b/src/features/pro/services/events.ts
@@ -42,6 +42,18 @@ export async function listGymEvents(): Promise<GymEvent[]> {
   return ((data ?? []) as Row[]).map(toGymEvent);
 }
 
+const GYM_EVENT_SELECT = 'id,title,description,workout,score_type,starts_at,ends_at,challenge_id';
+
+export async function getGymEvent(id: string): Promise<GymEvent | null> {
+  const { data, error } = await supabase
+    .from('gym_events')
+    .select(GYM_EVENT_SELECT)
+    .eq('id', id)
+    .maybeSingle<Row>();
+  if (error) throw new Error(error.message);
+  return data ? toGymEvent(data) : null;
+}
+
 export async function createGymEvent(input: {
   title: string;
   description: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1427,6 +1427,14 @@
         "live": "Live",
         "ended": "Ended"
       },
+      "detail": {
+        "back": "Back to events",
+        "workout": "Workout",
+        "standings": "Standings",
+        "noStandings": "Standings will appear once the event is set up.",
+        "submit": "Submit my score",
+        "submitted": "Score submitted — it's in the standings and the Judge queue."
+      },
       "create": {
         "cta": "New event",
         "back": "Back to events",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1427,6 +1427,14 @@
         "live": "En cours",
         "ended": "Terminé"
       },
+      "detail": {
+        "back": "Retour aux events",
+        "workout": "WOD",
+        "standings": "Classement",
+        "noStandings": "Le classement apparaîtra une fois l'event configuré.",
+        "submit": "Soumettre mon score",
+        "submitted": "Score soumis — il est dans le classement et la file Judge."
+      },
       "create": {
         "cta": "Nouvel event",
         "back": "Retour aux events",


### PR DESCRIPTION
## Why
Slice 2b of **Events** — completes the loop. The detail page reuses the B2C primitives end-to-end, so there's no second submission flow or leaderboard to maintain.

## What
- **`/app/pro/events/[eventId]`** — header + phase (upcoming/live/ended) + window + workout; a **live-only "Submit my score"** that reuses `ScoreSubmissionForm`, and **standings** that reuse the existing `Leaderboard` on the event's backing challenge (proof badges + judge-verified ranking included).
- `getGymEvent(id)` service (RLS-scoped read); event list rows now link to the detail page.
- en/fr i18n (`pro.events.detail`).

## Smoke (prod)
- Read event by id under RLS ✅ · submit score → standings reflect it ✅ · cleanup ✅
- `typecheck` / `lint` / 222 tests / `build` green. **No migration** (pure reuse of the slice-2a backing challenge).

## Events status
Create → list → detail → **member submits → standings → coach validates (Judge Console)** is now a complete loop, all on the unified scoring core. Follow-ups: event edit/cancel, multi-workout events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)