### PR TITLE
feat(pro): edit / cancel a gym event (#113)

### DIFF
--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -2,14 +2,28 @@
 
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { Leaderboard } from '@/features/challenges/components/Leaderboard';
-import { getGymEvent, type GymEvent } from '@/features/pro/services/events';
+import {
+  cancelGymEvent,
+  getGymEvent,
+  updateGymEvent,
+  type GymEvent,
+} from '@/features/pro/services/events';
 import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { isGymStaff } from '@/lib/roles';
+
+/** ISO → value for <input type="datetime-local"> (local time, no seconds). */
+function toLocalInput(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
 
 type Phase = 'upcoming' | 'live' | 'ended';
 
@@ -20,14 +34,118 @@ function phaseOf(event: GymEvent): Phase {
   return 'live';
 }
 
-function EventBody({ event }: { event: GymEvent }) {
+function EditEventForm({
+  event,
+  onSaved,
+  onClose,
+}: {
+  event: GymEvent;
+  onSaved: () => void;
+  onClose: () => void;
+}) {
+  const t = useTranslations('pro.events');
+  const [title, setTitle] = useState(event.title);
+  const [description, setDescription] = useState(event.description);
+  const [startsAt, setStartsAt] = useState(toLocalInput(event.startsAt));
+  const [endsAt, setEndsAt] = useState(toLocalInput(event.endsAt));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateGymEvent({ id: event.id, title, description, startsAt, endsAt });
+      onSaved();
+    } catch {
+      setError(t('manage.error'));
+      setBusy(false);
+    }
+  }
+
+  const inputCls =
+    'mt-1 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-card p-4">
+      <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('create.fields.title')}
+        <input value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} />
+      </label>
+      <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('create.fields.description')}
+        <textarea
+          rows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className={`${inputCls} resize-y`}
+        />
+      </label>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('create.fields.startsAt')}
+          <input
+            type="datetime-local"
+            value={startsAt}
+            onChange={(e) => setStartsAt(e.target.value)}
+            className={inputCls}
+          />
+        </label>
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('create.fields.endsAt')}
+          <input
+            type="datetime-local"
+            value={endsAt}
+            onChange={(e) => setEndsAt(e.target.value)}
+            className={inputCls}
+          />
+        </label>
+      </div>
+      {error ? <p className="text-xs font-semibold text-primary">{error}</p> : null}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={save}
+          className="rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? t('manage.saving') : t('manage.save')}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onClose}
+          className="rounded-md border border-border px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          {t('manage.cancelEdit')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => void }) {
   const t = useTranslations('pro.events');
   const locale = useLocale();
+  const router = useRouter();
   const profile = useOptionalAppProfile();
   const phase = phaseOf(event);
+  const canManage = isGymStaff(profile);
   const [submitting, setSubmitting] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const [done, setDone] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  async function doCancel() {
+    setCancelling(true);
+    try {
+      await cancelGymEvent(event.id);
+      router.push(`/${locale}/app/pro/events`);
+    } catch {
+      setCancelling(false);
+    }
+  }
 
   const formatWindow = (iso: string) =>
     new Date(iso).toLocaleString(locale, {
@@ -55,9 +173,39 @@ function EventBody({ event }: { event: GymEvent }) {
         <p className="text-sm text-muted-foreground">
           {formatWindow(event.startsAt)} → {formatWindow(event.endsAt)}
         </p>
+        {canManage && !editing ? (
+          <div className="flex gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
+            >
+              {t('manage.edit')}
+            </button>
+            <button
+              type="button"
+              disabled={cancelling}
+              onClick={doCancel}
+              className="rounded-sm border border-primary/40 px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] text-primary hover:opacity-80 disabled:opacity-50"
+            >
+              {cancelling ? t('manage.cancelling') : t('manage.cancel')}
+            </button>
+          </div>
+        ) : null}
       </header>
 
-      {event.description ? (
+      {editing ? (
+        <EditEventForm
+          event={event}
+          onSaved={() => {
+            setEditing(false);
+            onChanged();
+          }}
+          onClose={() => setEditing(false)}
+        />
+      ) : null}
+
+      {!editing && event.description ? (
         <p className="text-sm text-muted-foreground">{event.description}</p>
       ) : null}
 
@@ -125,7 +273,7 @@ function EventBody({ event }: { event: GymEvent }) {
 export function EventDetail({ eventId }: { eventId: string }) {
   const t = useTranslations('pro.events');
   const load = useCallback(() => getGymEvent(eventId), [eventId]);
-  const { state } = useAsyncResource(load, [eventId]);
+  const { state, refetch } = useAsyncResource(load, [eventId]);
 
   if (state.status === 'loading' || state.status === 'idle') {
     return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
@@ -133,5 +281,5 @@ export function EventDetail({ eventId }: { eventId: string }) {
   if (state.status === 'error' || !state.data) {
     return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
   }
-  return <EventBody event={state.data} />;
+  return <EventBody event={state.data} onChanged={refetch} />;
 }

--- a/src/features/pro/services/events.ts
+++ b/src/features/pro/services/events.ts
@@ -76,3 +76,29 @@ export async function createGymEvent(input: {
   if (!data) throw new Error('event_create_failed');
   return toGymEvent(data);
 }
+
+export async function updateGymEvent(input: {
+  id: string;
+  title: string;
+  description: string;
+  startsAt: string;
+  endsAt: string;
+}): Promise<GymEvent> {
+  const { data, error } = await supabase
+    .rpc('update_gym_event', {
+      p_event_id: input.id,
+      p_title: input.title,
+      p_description: input.description,
+      p_starts_at: new Date(input.startsAt).toISOString(),
+      p_ends_at: new Date(input.endsAt).toISOString(),
+    })
+    .single<Row>();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('event_update_failed');
+  return toGymEvent(data);
+}
+
+export async function cancelGymEvent(id: string): Promise<void> {
+  const { error } = await supabase.rpc('cancel_gym_event', { p_event_id: id });
+  if (error) throw new Error(error.message);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1435,6 +1435,15 @@
         "submit": "Submit my score",
         "submitted": "Score submitted — it's in the standings and the Judge queue."
       },
+      "manage": {
+        "edit": "Edit",
+        "cancel": "Cancel event",
+        "cancelling": "Cancelling…",
+        "save": "Save",
+        "saving": "Saving…",
+        "cancelEdit": "Discard",
+        "error": "Could not save — try again."
+      },
       "create": {
         "cta": "New event",
         "back": "Back to events",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1435,6 +1435,15 @@
         "submit": "Soumettre mon score",
         "submitted": "Score soumis — il est dans le classement et la file Judge."
       },
+      "manage": {
+        "edit": "Modifier",
+        "cancel": "Annuler l'event",
+        "cancelling": "Annulation…",
+        "save": "Enregistrer",
+        "saving": "Enregistrement…",
+        "cancelEdit": "Abandonner",
+        "error": "Impossible d'enregistrer — réessaie."
+      },
       "create": {
         "cta": "Nouvel event",
         "back": "Retour aux events",

--- a/supabase/migrations/037_gym_event_manage.sql
+++ b/supabase/migrations/037_gym_event_manage.sql
@@ -1,0 +1,110 @@
+-- V3-05 slice 3: edit / cancel a gym event. Staff of the event's gym only (platform_admin
+-- oversees all). Edit covers metadata + window (the WOD itself is immutable — cancel & recreate
+-- to change movements). Window edits propagate to the backing challenge; cancel closes it so no
+-- further scores land. Additive & non-breaking.
+
+-- Shared guard: is the caller allowed to manage this event? Returns the backing challenge id.
+CREATE OR REPLACE FUNCTION public.assert_can_manage_gym_event(p_event_id uuid)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller    uuid := auth.uid();
+  v_gym       uuid;
+  v_challenge uuid;
+  v_ok        boolean;
+BEGIN
+  SELECT gym_id, challenge_id INTO v_gym, v_challenge
+  FROM public.gym_events WHERE id = p_event_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event_not_found';
+  END IF;
+
+  SELECT public.is_platform_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = v_caller
+          AND p.role IN ('coach', 'gym_admin')
+          AND p.affiliated_gym_id = v_gym
+      )
+      OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = v_gym AND g.owner_id = v_caller)
+    INTO v_ok;
+
+  IF NOT v_ok THEN
+    RAISE EXCEPTION 'not_allowed';
+  END IF;
+
+  RETURN v_challenge;
+END;
+$$;
+
+-- Edit event metadata + window.
+CREATE OR REPLACE FUNCTION public.update_gym_event(
+  p_event_id    uuid,
+  p_title       text,
+  p_description text,
+  p_starts_at   timestamptz,
+  p_ends_at     timestamptz
+)
+RETURNS public.gym_events
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_challenge uuid;
+  v_event     public.gym_events;
+BEGIN
+  v_challenge := public.assert_can_manage_gym_event(p_event_id);
+
+  IF p_ends_at <= p_starts_at THEN
+    RAISE EXCEPTION 'bad_window';
+  END IF;
+
+  UPDATE public.gym_events
+  SET title = btrim(p_title),
+      description = coalesce(p_description, ''),
+      starts_at = p_starts_at,
+      ends_at = p_ends_at,
+      updated_at = NOW()
+  WHERE id = p_event_id
+  RETURNING * INTO v_event;
+
+  -- Keep the backing challenge title + close date in sync.
+  IF v_challenge IS NOT NULL THEN
+    UPDATE public.challenges
+    SET title = btrim(p_title), ends_at = p_ends_at
+    WHERE id = v_challenge;
+  END IF;
+
+  RETURN v_event;
+END;
+$$;
+
+-- Cancel an event (soft): drops it from listings and closes the backing challenge to scores.
+CREATE OR REPLACE FUNCTION public.cancel_gym_event(p_event_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_challenge uuid;
+BEGIN
+  v_challenge := public.assert_can_manage_gym_event(p_event_id);
+
+  UPDATE public.gym_events
+  SET status = 'cancelled', updated_at = NOW()
+  WHERE id = p_event_id;
+
+  IF v_challenge IS NOT NULL THEN
+    UPDATE public.challenges SET ends_at = NOW() WHERE id = v_challenge;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.assert_can_manage_gym_event(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_gym_event(uuid, text, text, timestamptz, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_gym_event(uuid) TO authenticated;


### PR DESCRIPTION
## Why
Rounds out the Events CRUD — a coach must be able to fix a typo or drop a duplicate/mistaken event.

## What
- **Migration 037** — `update_gym_event` + `cancel_gym_event` RPCs, gated by a shared `assert_can_manage_gym_event` guard (staff of the event's gym / gym owner / platform_admin). Window edits sync to the backing challenge; **cancel** soft-drops the event (status `cancelled`, hidden from listings) and closes its challenge so no further scores land.
- **EventDetail** — staff-only **Edit** (title / description / window) and **Cancel** actions; refetches on save. en/fr i18n (`pro.events.manage`).

The WOD itself stays immutable (cancel & recreate to change movements) — the built workout text isn't cleanly reversible into the builder.

## Smoke (prod)
- Update → backing challenge title + `ends_at` synced ✅
- `bad_window` (end ≤ start) rejected ✅
- Cancel → status `cancelled`, dropped from `gym_events_list`, backing challenge closed ✅
- Cleaned up. `typecheck` / `lint` / 222 tests / `build` green.

## Events
CRUD complete: create / list / detail / submit / standings / validate / **edit / cancel**. Next big piece: TV Broadcaster (#114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)