### PR TITLE
feat(pro): TV Broadcaster — realtime live leaderboard (#114)

### DIFF
--- a/src/app/[locale]/app/pro/events/[eventId]/tv/page.tsx
+++ b/src/app/[locale]/app/pro/events/[eventId]/tv/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { use } from 'react';
+
+import { EventBroadcast } from '@/features/pro/components/EventBroadcast';
+
+type Params = { eventId: string; locale: string };
+
+export default function EventTvPage({ params }: { params: Promise<Params> }) {
+  const { eventId } = use(params);
+  return <EventBroadcast eventId={eventId} />;
+}

--- a/src/app/[locale]/app/pro/tv/page.tsx
+++ b/src/app/[locale]/app/pro/tv/page.tsx
@@ -1,0 +1,5 @@
+import { TvList } from '@/features/pro/components/TvList';
+
+export default function ProTvPage() {
+  return <TvList />;
+}

--- a/src/features/pro/components/EventBroadcast.tsx
+++ b/src/features/pro/components/EventBroadcast.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { Radio, X } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useEffect } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { listLeaderboardScores } from '@/features/challenges/services/leaderboard';
+import { formatScore } from '@/features/challenges/lib/scoreFormat';
+import { getGymEvent, type GymEvent } from '@/features/pro/services/events';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { supabase } from '@/lib/supabase';
+
+const FACTION_COLOR: Record<string, string> = {
+  horde: 'var(--faction-horde)',
+  nomads: 'var(--faction-nomads)',
+  iron: 'var(--faction-iron)',
+};
+
+const RANK_MEDAL = ['#f5c518', '#c0c0c0', '#cd7f32'];
+
+function Board({ event }: { event: GymEvent }) {
+  const t = useTranslations('pro.events.tv');
+  const challengeId = event.challengeId as string;
+
+  const load = useCallback(
+    () => listLeaderboardScores({ challengeId, scoreType: event.scoreType, limit: 30 }),
+    [challengeId, event.scoreType],
+  );
+  const { state, refetch } = useAsyncResource(load, [challengeId]);
+
+  // Realtime: any score change for this event's challenge re-pulls the board.
+  // A slow poll is kept as a safety net if a realtime event is ever missed.
+  useEffect(() => {
+    const channel = supabase
+      .channel(`event-tv-${challengeId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'scores', filter: `challenge_id=eq.${challengeId}` },
+        () => refetch(),
+      )
+      .subscribe();
+    const poll = setInterval(() => refetch(), 20000);
+    return () => {
+      clearInterval(poll);
+      void supabase.removeChannel(channel);
+    };
+  }, [challengeId, refetch]);
+
+  const rows = state.status === 'ready' ? state.data : [];
+
+  return (
+    <div className="flex h-full flex-col">
+      {rows.length === 0 ? (
+        <p className="flex flex-1 items-center justify-center text-center text-2xl font-bold text-muted-foreground">
+          {state.status === 'error' ? t('error') : t('waiting')}
+        </p>
+      ) : (
+        <ol className="flex-1 space-y-2 overflow-hidden">
+          {rows.map((entry, i) => {
+            const faction = entry.profile?.faction ?? '';
+            const color = FACTION_COLOR[faction] ?? 'var(--primary)';
+            return (
+              <li
+                key={entry.id}
+                className="flex items-center gap-4 rounded-lg border border-border bg-card px-5 py-3"
+                style={{ borderLeft: `6px solid ${color}` }}
+              >
+                <span
+                  className="w-12 shrink-0 text-center text-3xl font-black tabular-nums md:text-4xl"
+                  style={{ color: RANK_MEDAL[i] ?? 'inherit' }}
+                >
+                  {i + 1}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-2xl font-black uppercase tracking-tight md:text-4xl">
+                  {entry.profile?.username ?? '—'}
+                </span>
+                {entry.proof_level === 'judge_verified' ? (
+                  <span className="shrink-0 rounded-sm bg-primary px-2 py-1 text-xs font-black uppercase tracking-[0.14em] text-primary-foreground">
+                    {t('verified')}
+                  </span>
+                ) : null}
+                <span className="shrink-0 text-3xl font-black tabular-nums md:text-5xl">
+                  {formatScore(entry.value, event.scoreType)}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+export function EventBroadcast({ eventId }: { eventId: string }) {
+  const t = useTranslations('pro.events.tv');
+  const locale = useLocale();
+  const load = useCallback(() => getGymEvent(eventId), [eventId]);
+  const { state } = useAsyncResource(load, [eventId]);
+  const event = state.status === 'ready' ? state.data : null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-background p-6 md:p-10">
+      <header className="mb-6 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Radio className="h-6 w-6 animate-pulse text-primary" aria-hidden />
+          <div>
+            <p className="text-[11px] font-black uppercase tracking-[0.28em] text-primary">
+              {t('badge')}
+            </p>
+            <h1 className="text-3xl font-black uppercase tracking-tight md:text-5xl">
+              {event?.title ?? '…'}
+            </h1>
+          </div>
+        </div>
+        <Link
+          href={`/${locale}/app/pro/events/${eventId}`}
+          className="shrink-0 rounded-md border border-border p-2 text-muted-foreground hover:text-foreground"
+          aria-label={t('exit')}
+        >
+          <X className="h-6 w-6" />
+        </Link>
+      </header>
+
+      {event?.challengeId ? (
+        <Board event={event} />
+      ) : (
+        <p className="flex flex-1 items-center justify-center text-2xl font-bold text-muted-foreground">
+          {state.status === 'error' ? t('error') : t('waiting')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Radio } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
@@ -251,9 +251,20 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
       ) : null}
 
       <div className="space-y-2">
-        <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-          {t('detail.standings')}
-        </h2>
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('detail.standings')}
+          </h2>
+          {event.challengeId ? (
+            <Link
+              href={`/${locale}/app/pro/events/${event.id}/tv`}
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
+            >
+              <Radio className="h-3.5 w-3.5" />
+              {t('detail.cast')}
+            </Link>
+          ) : null}
+        </div>
         {event.challengeId ? (
           <Leaderboard
             key={`${event.challengeId}-${reloadKey}-${profile?.id ?? ''}`}

--- a/src/features/pro/components/TvList.tsx
+++ b/src/features/pro/components/TvList.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Radio } from 'lucide-react';
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { listGymEvents, type GymEvent } from '@/features/pro/services/events';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+
+function isCastable(event: GymEvent): boolean {
+  // Live or upcoming — no point casting a finished event.
+  return Date.now() <= new Date(event.endsAt).getTime();
+}
+
+export function TvList() {
+  const t = useTranslations('pro.events.tv');
+  const locale = useLocale();
+  const { state } = useAsyncResource(listGymEvents, []);
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error') {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+
+  const castable = state.data.filter(isCastable);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t('listIntro')}</p>
+      {castable.length === 0 ? (
+        <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {t('listEmpty')}
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {castable.map((event) => (
+            <li key={event.id}>
+              <Link
+                href={`/${locale}/app/pro/events/${event.id}/tv`}
+                className="flex items-center gap-3 rounded-md border border-border bg-card p-4 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Radio className="h-5 w-5 shrink-0 text-primary" aria-hidden />
+                <span className="min-w-0 flex-1 truncate text-sm font-black uppercase tracking-[0.12em]">
+                  {event.title}
+                </span>
+                <span className="shrink-0 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+                  {t('cast')}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -53,7 +53,7 @@ export const PRO_NAV: readonly ProNavGroup[] = [
     items: [
       { id: 'judge', path: '/app/pro/judge', icon: Gavel, labelKey: 'judge', status: 'live' },
       { id: 'events', path: '/app/pro/events', icon: Trophy, labelKey: 'events', status: 'live' },
-      { id: 'tv', path: '/app/pro/tv', icon: Tv, labelKey: 'tv', status: 'soon' },
+      { id: 'tv', path: '/app/pro/tv', icon: Tv, labelKey: 'tv', status: 'live' },
     ],
   },
   {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1433,7 +1433,19 @@
         "standings": "Standings",
         "noStandings": "Standings will appear once the event is set up.",
         "submit": "Submit my score",
-        "submitted": "Score submitted — it's in the standings and the Judge queue."
+        "submitted": "Score submitted — it's in the standings and the Judge queue.",
+        "cast": "Cast to TV"
+      },
+      "tv": {
+        "badge": "Live broadcast",
+        "exit": "Exit",
+        "verified": "Verified",
+        "waiting": "Waiting for the first scores…",
+        "error": "Could not load the board.",
+        "loading": "Loading…",
+        "cast": "Cast",
+        "listIntro": "Cast a live leaderboard on your gym's screen.",
+        "listEmpty": "No live or upcoming events to cast."
       },
       "manage": {
         "edit": "Edit",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1433,7 +1433,19 @@
         "standings": "Classement",
         "noStandings": "Le classement apparaîtra une fois l'event configuré.",
         "submit": "Soumettre mon score",
-        "submitted": "Score soumis — il est dans le classement et la file Judge."
+        "submitted": "Score soumis — il est dans le classement et la file Judge.",
+        "cast": "Caster sur la TV"
+      },
+      "tv": {
+        "badge": "Diffusion live",
+        "exit": "Quitter",
+        "verified": "Vérifié",
+        "waiting": "En attente des premiers scores…",
+        "error": "Impossible de charger le tableau.",
+        "loading": "Chargement…",
+        "cast": "Caster",
+        "listIntro": "Caste un classement live sur l'écran de ta salle.",
+        "listEmpty": "Aucun event live ou à venir à caster."
       },
       "manage": {
         "edit": "Modifier",


### PR DESCRIPTION
## Why
The demo magnet for selling to gyms: cast an event's leaderboard full-screen on the box's wall, updating **live** as members post.

## What
- **`EventBroadcast`** — full-screen read-only board (faction-coloured rows, medal ranks, big score typography, `verified` badge) subscribed to **Supabase Realtime** `postgres_changes` on `scores` filtered by the event's challenge. Any score insert/update re-pulls the board; a 20s poll is kept as a safety net. Reuses `listLeaderboardScores` + `formatScore` — no new ranking logic. `scores` is already in the realtime publication (migration 003), so **no migration**.
- **`/app/pro/events/[eventId]/tv`** route + a "Cast to TV" link on the event detail.
- **`/app/pro/tv`** page listing live/upcoming events to cast; nav `tv` `soon → live`.
- en/fr i18n (`pro.events.tv`).

## Smoke (in-browser, Playwright)
- Injected the test session, opened the TV route → board renders the standings (rank, athlete, `05:00`, faction border) ✅
- Inserted a better score via API → **board updated to `04:00` live with no reload** (realtime verified) ✅
- Seed cleaned up. `typecheck` / `lint` / 222 tests / `build` green.

![TV board](https://github.com/igorms-pro/truegrynd/assets/placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)