### PR TITLE
feat(pro): inter-box leagues — foundation + gym opt-in (#115)

### DIFF
--- a/src/app/[locale]/app/pro/leagues/page.tsx
+++ b/src/app/[locale]/app/pro/leagues/page.tsx
@@ -1,0 +1,5 @@
+import { LeaguesList } from '@/features/pro/components/LeaguesList';
+
+export default function ProLeaguesPage() {
+  return <LeaguesList />;
+}

--- a/src/features/pro/components/LeaguesList.tsx
+++ b/src/features/pro/components/LeaguesList.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { joinLeague, leaveLeague, listLeagues, type League } from '@/features/pro/services/leagues';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { isGymManager } from '@/lib/roles';
+
+function LeagueRow({
+  league,
+  canManage,
+  onChanged,
+}: {
+  league: League;
+  canManage: boolean;
+  onChanged: () => void;
+}) {
+  const t = useTranslations('pro.leagues');
+  const [busy, setBusy] = useState(false);
+
+  async function toggle() {
+    setBusy(true);
+    try {
+      if (league.isMember) await leaveLeague(league.id);
+      else await joinLeague(league.id);
+      onChanged();
+    } catch {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <li className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0">
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-bold">{league.name}</span>
+        <span className="text-xs text-muted-foreground">
+          {t('members', { count: league.memberCount })}
+        </span>
+      </span>
+      <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+        {t(`scope.${league.scope}`)}
+      </span>
+      {canManage ? (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={toggle}
+          className={`shrink-0 rounded-md px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] disabled:opacity-50 ${
+            league.isMember
+              ? 'border border-border text-muted-foreground hover:text-foreground'
+              : 'bg-primary text-primary-foreground hover:opacity-90'
+          }`}
+        >
+          {league.isMember ? t('leave') : t('join')}
+        </button>
+      ) : league.isMember ? (
+        <span className="shrink-0 text-[10px] font-black uppercase tracking-[0.14em] text-primary">
+          {t('joined')}
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+export function LeaguesList() {
+  const t = useTranslations('pro.leagues');
+  const profile = useOptionalAppProfile();
+  const canManage = isGymManager(profile);
+  const { state, refetch } = useAsyncResource(listLeagues, []);
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error') {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">{t('intro')}</p>
+      {state.data.length === 0 ? (
+        <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {t('empty')}
+        </p>
+      ) : (
+        <ul className="rounded-md border border-border bg-card">
+          {state.data.map((l) => (
+            <LeagueRow key={l.id} league={l} canManage={canManage} onChanged={refetch} />
+          ))}
+        </ul>
+      )}
+      <p className="text-xs text-muted-foreground">{t('standingsSoon')}</p>
+    </div>
+  );
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -3,6 +3,7 @@ import {
   Gavel,
   Trophy,
   Tv,
+  Swords,
   CalendarDays,
   Users,
   Ticket,
@@ -54,6 +55,13 @@ export const PRO_NAV: readonly ProNavGroup[] = [
       { id: 'judge', path: '/app/pro/judge', icon: Gavel, labelKey: 'judge', status: 'live' },
       { id: 'events', path: '/app/pro/events', icon: Trophy, labelKey: 'events', status: 'live' },
       { id: 'tv', path: '/app/pro/tv', icon: Tv, labelKey: 'tv', status: 'live' },
+      {
+        id: 'leagues',
+        path: '/app/pro/leagues',
+        icon: Swords,
+        labelKey: 'leagues',
+        status: 'live',
+      },
     ],
   },
   {

--- a/src/features/pro/services/leagues.ts
+++ b/src/features/pro/services/leagues.ts
@@ -1,0 +1,45 @@
+import { supabase } from '@/lib/supabase';
+
+export type LeagueScope = 'local' | 'regional' | 'national';
+
+/** A league in the directory, with the caller's gym membership state. */
+export type League = {
+  id: string;
+  name: string;
+  scope: LeagueScope;
+  regionCode: string | null;
+  memberCount: number;
+  isMember: boolean;
+};
+
+type Row = {
+  id: string;
+  name: string;
+  scope: LeagueScope;
+  region_code: string | null;
+  member_count: number;
+  is_member: boolean;
+};
+
+export async function listLeagues(): Promise<League[]> {
+  const { data, error } = await supabase.rpc('league_directory');
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as Row[]).map((row) => ({
+    id: row.id,
+    name: row.name,
+    scope: row.scope,
+    regionCode: row.region_code,
+    memberCount: Number(row.member_count ?? 0),
+    isMember: row.is_member,
+  }));
+}
+
+export async function joinLeague(leagueId: string): Promise<void> {
+  const { error } = await supabase.rpc('join_league', { p_league_id: leagueId });
+  if (error) throw new Error(error.message);
+}
+
+export async function leaveLeague(leagueId: string): Promise<void> {
+  const { error } = await supabase.rpc('leave_league', { p_league_id: leagueId });
+  if (error) throw new Error(error.message);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1376,6 +1376,7 @@
       "judge": "Judge Console",
       "events": "Events",
       "tv": "TV Cast",
+      "leagues": "Leagues",
       "planning": "Schedule",
       "members": "Members",
       "subscriptions": "Subscriptions",
@@ -1416,6 +1417,22 @@
       "empty": "No members affiliated yet.",
       "count": "{count} members",
       "never": "never"
+    },
+    "leagues": {
+      "intro": "Opt your gym into leagues to compete against other boxes.",
+      "loading": "Loading leagues…",
+      "error": "Could not load leagues.",
+      "empty": "No leagues available yet.",
+      "members": "{count, plural, =0 {no gyms} =1 {1 gym} other {# gyms}}",
+      "join": "Join",
+      "leave": "Leave",
+      "joined": "Member",
+      "standingsSoon": "Box-vs-box matches and standings are coming next.",
+      "scope": {
+        "local": "Local",
+        "regional": "Regional",
+        "national": "National"
+      }
     },
     "events": {
       "intro": "Competitions you run for your gym.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1376,6 +1376,7 @@
       "judge": "Judge Console",
       "events": "Events",
       "tv": "TV Cast",
+      "leagues": "Ligues",
       "planning": "Planning",
       "members": "Membres",
       "subscriptions": "Abonnements",
@@ -1416,6 +1417,22 @@
       "empty": "Aucun membre affilié pour le moment.",
       "count": "{count} membres",
       "never": "jamais"
+    },
+    "leagues": {
+      "intro": "Inscris ta salle à des ligues pour affronter d'autres box.",
+      "loading": "Chargement des ligues…",
+      "error": "Impossible de charger les ligues.",
+      "empty": "Aucune ligue disponible pour le moment.",
+      "members": "{count, plural, =0 {aucune salle} =1 {1 salle} other {# salles}}",
+      "join": "Rejoindre",
+      "leave": "Quitter",
+      "joined": "Membre",
+      "standingsSoon": "Les matchs box-vs-box et le classement arrivent ensuite.",
+      "scope": {
+        "local": "Locale",
+        "regional": "Régionale",
+        "national": "Nationale"
+      }
     },
     "events": {
       "intro": "Les compétitions que tu organises pour ta salle.",

--- a/supabase/migrations/038_leagues.sql
+++ b/supabase/migrations/038_leagues.sql
@@ -1,0 +1,134 @@
+-- V3-06 slice 1: inter-box leagues — foundation + gym opt-in. A league groups gyms by scope
+-- (local / regional / national). A gym_admin opts their gym in/out. Box-vs-box matches and
+-- standings are a follow-up slice. Additive & non-breaking.
+
+CREATE TABLE IF NOT EXISTS public.leagues (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        TEXT        NOT NULL CHECK (length(btrim(name)) > 0),
+  slug        TEXT        NOT NULL UNIQUE CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
+  scope       TEXT        NOT NULL CHECK (scope IN ('local', 'regional', 'national')),
+  region_code TEXT        NULL,
+  status      TEXT        NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.leagues IS
+  'V3-06: inter-box leagues. Platform-managed; gyms opt in via league_gyms.';
+
+CREATE TABLE IF NOT EXISTS public.league_gyms (
+  league_id UUID        NOT NULL REFERENCES public.leagues(id) ON DELETE CASCADE,
+  gym_id    UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (league_id, gym_id)
+);
+
+COMMENT ON TABLE public.league_gyms IS 'V3-06: which gyms have opted into which leagues.';
+
+CREATE INDEX IF NOT EXISTS idx_league_gyms_gym ON public.league_gyms (gym_id);
+
+ALTER TABLE public.leagues ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.league_gyms ENABLE ROW LEVEL SECURITY;
+
+-- READ: leagues + membership are a public directory for any authenticated user.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'leagues'
+                 AND policyname = 'Authenticated can read leagues') THEN
+    CREATE POLICY "Authenticated can read leagues" ON public.leagues
+      FOR SELECT TO authenticated USING (status = 'active');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'league_gyms'
+                 AND policyname = 'Authenticated can read league memberships') THEN
+    CREATE POLICY "Authenticated can read league memberships" ON public.league_gyms
+      FOR SELECT TO authenticated USING (true);
+  END IF;
+END $$;
+
+-- Opt-in / opt-out go through RPCs (SECURITY DEFINER) — no direct write policy.
+
+-- Directory: every active league + member count + whether the caller's gym is in it.
+CREATE OR REPLACE FUNCTION public.league_directory()
+RETURNS TABLE (
+  id           uuid,
+  name         text,
+  slug         text,
+  scope        text,
+  region_code  text,
+  member_count bigint,
+  is_member    boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT l.id, l.name, l.slug, l.scope, l.region_code,
+         (SELECT count(*) FROM public.league_gyms lg WHERE lg.league_id = l.id),
+         EXISTS (
+           SELECT 1 FROM public.league_gyms lg
+           JOIN public.profiles p ON p.id = auth.uid()
+           WHERE lg.league_id = l.id AND lg.gym_id = p.affiliated_gym_id
+         )
+  FROM public.leagues l
+  WHERE l.status = 'active'
+  ORDER BY l.scope, l.name;
+$$;
+
+-- Opt the caller's gym in. gym_admin (or platform_admin) only.
+CREATE OR REPLACE FUNCTION public.join_league(p_league_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_gym uuid;
+  v_mgr boolean;
+BEGIN
+  SELECT affiliated_gym_id, (role = 'gym_admin') INTO v_gym, v_mgr
+  FROM public.profiles WHERE id = auth.uid();
+
+  IF NOT (COALESCE(v_mgr, false) OR public.is_platform_admin()) THEN
+    RAISE EXCEPTION 'not_gym_admin';
+  END IF;
+  IF v_gym IS NULL THEN
+    RAISE EXCEPTION 'no_gym';
+  END IF;
+
+  INSERT INTO public.league_gyms (league_id, gym_id)
+  VALUES (p_league_id, v_gym)
+  ON CONFLICT (league_id, gym_id) DO NOTHING;
+END;
+$$;
+
+-- Opt the caller's gym out.
+CREATE OR REPLACE FUNCTION public.leave_league(p_league_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_gym uuid;
+  v_mgr boolean;
+BEGIN
+  SELECT affiliated_gym_id, (role = 'gym_admin') INTO v_gym, v_mgr
+  FROM public.profiles WHERE id = auth.uid();
+
+  IF NOT (COALESCE(v_mgr, false) OR public.is_platform_admin()) THEN
+    RAISE EXCEPTION 'not_gym_admin';
+  END IF;
+
+  DELETE FROM public.league_gyms WHERE league_id = p_league_id AND gym_id = v_gym;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.league_directory() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.join_league(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.leave_league(uuid) TO authenticated;
+
+-- Seed a couple of leagues so the opt-in flow is usable out of the box.
+INSERT INTO public.leagues (name, slug, scope, region_code) VALUES
+  ('TrueGrynd National', 'truegrynd-national', 'national', NULL),
+  ('Île-de-France', 'ile-de-france', 'regional', 'IDF')
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Why
First slice of **inter-box leagues** (#115): gyms opt into leagues to compete against other boxes. Box-vs-box matches and standings are the follow-up slice.

## What
- **Migration 038** — `leagues` + `league_gyms` tables (scope local/regional/national), public-read RLS, `league_directory` / `join_league` / `leave_league` RPCs (a gym_admin opts their **own** gym in/out). Seeds a National + a regional (Île-de-France) league so the flow is usable out of the box.
- **`/app/pro/leagues`** — directory with scope badge, member count, join/leave (gym managers only). Nav `leagues` `soon → live`.
- leagues service + en/fr i18n.

## Smoke
- **API**: directory lists seeded leagues; join → `is_member=true` + count 1; leave → false + 0 ✅
- **In-browser (Playwright)**: page renders, clicked **Join** → "1 gym" + button flips to **Leave** ✅. The Playwright pass caught an i18n block mistakenly nested under `pro.events` instead of `pro` (raw keys showing) — fixed.
- `typecheck` / `lint` / 222 tests / `build` green.

## Scope / follow-up
Opt-in foundation only. **Box-vs-box matches + league standings** (shared league WODs, gym score = member average per scaling) tracked separately.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)