### PR TITLE
feat(pro): Stripe gym subscription — plumbing (#117)

### DIFF
--- a/src/app/[locale]/app/pro/billing/page.tsx
+++ b/src/app/[locale]/app/pro/billing/page.tsx
@@ -1,0 +1,5 @@
+import { BillingScreen } from '@/features/pro/components/BillingScreen';
+
+export default function ProBillingPage() {
+  return <BillingScreen />;
+}

--- a/src/features/pro/components/BillingScreen.tsx
+++ b/src/features/pro/components/BillingScreen.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import {
+  getBillingStatus,
+  openPortal,
+  startCheckout,
+  type BillingStatus,
+} from '@/features/pro/services/billing';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+
+function StatusBadge({ status }: { status: BillingStatus['status'] }) {
+  const t = useTranslations('pro.billing');
+  const tone =
+    status === 'active' || status === 'trialing'
+      ? 'bg-primary text-primary-foreground'
+      : status === 'past_due'
+        ? 'bg-amber-500/20 text-amber-600 dark:text-amber-400'
+        : 'bg-muted text-muted-foreground';
+  return (
+    <span
+      className={`rounded-sm px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] ${tone}`}
+    >
+      {t(`status.${status}`)}
+    </span>
+  );
+}
+
+function BillingBody({ data }: { data: BillingStatus }) {
+  const t = useTranslations('pro.billing');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function go(action: 'checkout' | 'portal') {
+    setBusy(true);
+    setError(null);
+    try {
+      const returnUrl = window.location.href;
+      const url =
+        action === 'checkout' ? await startCheckout(returnUrl) : await openPortal(returnUrl);
+      window.location.href = url;
+    } catch {
+      setError(t('error'));
+      setBusy(false);
+    }
+  }
+
+  // 'active'/'trialing' → manage; anything else → subscribe.
+  const subscribed = data.status === 'active' || data.status === 'trialing';
+
+  return (
+    <div className="max-w-md space-y-5">
+      <div className="space-y-3 rounded-md border border-border bg-card p-5">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-black uppercase tracking-[0.12em]">{data.gymName}</span>
+          <StatusBadge status={data.status} />
+        </div>
+        <p className="text-sm text-muted-foreground">{t('plan')}</p>
+        {data.currentPeriodEnd ? (
+          <p className="text-xs text-muted-foreground">
+            {t('renews', { date: new Date(data.currentPeriodEnd).toLocaleDateString() })}
+          </p>
+        ) : null}
+
+        {error ? <p className="text-sm font-semibold text-primary">{error}</p> : null}
+
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => go(subscribed ? 'portal' : 'checkout')}
+          className="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? t('loading') : subscribed ? t('manage') : t('subscribe')}
+        </button>
+      </div>
+      <p className="text-xs text-muted-foreground">{t('note')}</p>
+    </div>
+  );
+}
+
+export function BillingScreen() {
+  const t = useTranslations('pro.billing');
+  const { state } = useAsyncResource(getBillingStatus, []);
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error' || !state.data) {
+    return <p className="text-sm text-muted-foreground">{t('noGym')}</p>;
+  }
+  return <BillingBody data={state.data} />;
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -97,7 +97,7 @@ export const PRO_NAV: readonly ProNavGroup[] = [
         path: '/app/pro/billing',
         icon: CreditCard,
         labelKey: 'billing',
-        status: 'soon',
+        status: 'live',
         managerOnly: true,
       },
     ],

--- a/src/features/pro/services/billing.ts
+++ b/src/features/pro/services/billing.ts
@@ -1,0 +1,63 @@
+import { supabase } from '@/lib/supabase';
+
+export type BillingStatus = {
+  gymId: string;
+  gymName: string;
+  status: 'trialing' | 'active' | 'past_due' | 'canceled' | 'incomplete' | 'none';
+  currentPeriodEnd: string | null;
+  isActive: boolean;
+};
+
+type Row = {
+  gym_id: string;
+  gym_name: string;
+  subscription_status: BillingStatus['status'];
+  current_period_end: string | null;
+  is_active: boolean;
+};
+
+export async function getBillingStatus(): Promise<BillingStatus | null> {
+  const { data, error } = await supabase.rpc('gym_billing_status').maybeSingle<Row>();
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+  return {
+    gymId: data.gym_id,
+    gymName: data.gym_name,
+    status: data.subscription_status,
+    currentPeriodEnd: data.current_period_end,
+    isActive: data.is_active,
+  };
+}
+
+/** Opens Stripe Checkout (subscribe) or the Billing Portal (manage); returns the hosted URL. */
+async function stripeSession(action: 'checkout' | 'portal', returnUrl: string): Promise<string> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) throw new Error('no_session');
+
+  const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '') ?? '';
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+  if (!baseUrl || !anonKey) throw new Error('server_misconfigured');
+
+  const res = await fetch(`${baseUrl}/functions/v1/stripe-checkout`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`,
+      apikey: anonKey,
+    },
+    body: JSON.stringify({ action, returnUrl }),
+  });
+  const parsed = (await res.json().catch(() => ({}))) as { url?: string; code?: string };
+  if (!res.ok || !parsed.url) throw new Error(parsed.code ?? `http_${res.status}`);
+  return parsed.url;
+}
+
+export async function startCheckout(returnUrl: string): Promise<string> {
+  return stripeSession('checkout', returnUrl);
+}
+
+export async function openPortal(returnUrl: string): Promise<string> {
+  return stripeSession('portal', returnUrl);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1418,6 +1418,24 @@
       "count": "{count} members",
       "never": "never"
     },
+    "billing": {
+      "loading": "Loading…",
+      "noGym": "Create your gym first to manage billing.",
+      "plan": "TrueGrynd PRO — 100/mo. Validation, events, TV cast, leagues.",
+      "subscribe": "Subscribe",
+      "manage": "Manage subscription",
+      "renews": "Renews on {date}",
+      "note": "Billing is handled securely by Stripe. Cancel anytime from the portal.",
+      "error": "Something went wrong — try again.",
+      "status": {
+        "trialing": "Trial",
+        "active": "Active",
+        "past_due": "Past due",
+        "canceled": "Canceled",
+        "incomplete": "Incomplete",
+        "none": "Inactive"
+      }
+    },
     "leagues": {
       "intro": "Opt your gym into leagues to compete against other boxes.",
       "loading": "Loading leagues…",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1418,6 +1418,24 @@
       "count": "{count} membres",
       "never": "jamais"
     },
+    "billing": {
+      "loading": "Chargement…",
+      "noGym": "Crée d'abord ta salle pour gérer la facturation.",
+      "plan": "TrueGrynd PRO — 100/mois. Validation, events, TV cast, ligues.",
+      "subscribe": "S'abonner",
+      "manage": "Gérer l'abonnement",
+      "renews": "Renouvellement le {date}",
+      "note": "La facturation est gérée en sécurité par Stripe. Résiliable à tout moment depuis le portail.",
+      "error": "Une erreur est survenue — réessaie.",
+      "status": {
+        "trialing": "Essai",
+        "active": "Actif",
+        "past_due": "Impayé",
+        "canceled": "Résilié",
+        "incomplete": "Incomplet",
+        "none": "Inactif"
+      }
+    },
     "leagues": {
       "intro": "Inscris ta salle à des ligues pour affronter d'autres box.",
       "loading": "Chargement des ligues…",

--- a/supabase/functions/stripe-checkout/cors.ts
+++ b/supabase/functions/stripe-checkout/cors.ts
@@ -1,0 +1,4 @@
+export const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};

--- a/supabase/functions/stripe-checkout/index.ts
+++ b/supabase/functions/stripe-checkout/index.ts
@@ -1,0 +1,109 @@
+// V3-08: Stripe Checkout + Billing Portal for the gym subscription (100/mo).
+// action 'checkout' → returns a hosted Checkout Session URL to start/resume the subscription.
+// action 'portal'   → returns a Billing Portal URL to manage/cancel an existing subscription.
+// The caller must be a gym_admin (or platform_admin) with a gym. The webhook flips the gym's
+// subscription_status; this function only opens the hosted pages.
+
+import Stripe from 'npm:stripe@17';
+import { createClient } from 'npm:@supabase/supabase-js@2';
+
+import { corsHeaders } from './cors.ts';
+
+function json(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return json({ code: 'method_not_allowed' }, 405);
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY');
+  const priceId = Deno.env.get('STRIPE_PRICE_ID');
+  if (!supabaseUrl || !anonKey || !serviceKey || !stripeKey || !priceId) {
+    return json({ code: 'server_misconfigured' }, 500);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) return json({ code: 'unauthorized' }, 401);
+
+  let body: { action?: string; returnUrl?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return json({ code: 'bad_request' }, 400);
+  }
+  const action = body.action === 'portal' ? 'portal' : 'checkout';
+  const returnUrl = (body.returnUrl ?? '').trim();
+  if (!returnUrl.startsWith('http')) return json({ code: 'bad_return_url' }, 400);
+
+  // Identify the caller's gym (must be its manager).
+  const authed = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+  const {
+    data: { user },
+  } = await authed.auth.getUser();
+  if (!user) return json({ code: 'unauthorized' }, 401);
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('role, is_admin, affiliated_gym_id')
+    .eq('id', user.id)
+    .maybeSingle();
+  const isManager =
+    profile?.role === 'gym_admin' || profile?.role === 'platform_admin' || profile?.is_admin;
+  if (!isManager || !profile?.affiliated_gym_id) return json({ code: 'not_gym_admin' }, 403);
+
+  const { data: gym } = await admin
+    .from('gyms')
+    .select('id, name, stripe_customer_id')
+    .eq('id', profile.affiliated_gym_id)
+    .maybeSingle();
+  if (!gym) return json({ code: 'no_gym' }, 403);
+
+  const stripe = new Stripe(stripeKey, { apiVersion: '2025-09-30.clover' });
+
+  // Ensure a Stripe customer exists for this gym.
+  let customerId = gym.stripe_customer_id as string | null;
+  if (!customerId) {
+    const customer = await stripe.customers.create({
+      email: user.email ?? undefined,
+      name: gym.name as string,
+      metadata: { gym_id: gym.id as string },
+    });
+    customerId = customer.id;
+    await admin.from('gyms').update({ stripe_customer_id: customerId }).eq('id', gym.id);
+  }
+
+  try {
+    if (action === 'portal') {
+      const portal = await stripe.billingPortal.sessions.create({
+        customer: customerId,
+        return_url: returnUrl,
+      });
+      return json({ url: portal.url });
+    }
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: returnUrl,
+      cancel_url: returnUrl,
+      client_reference_id: gym.id as string,
+      subscription_data: { metadata: { gym_id: gym.id as string } },
+    });
+    return json({ url: session.url ?? '' });
+  } catch (e) {
+    return json({ code: 'stripe_error', message: e instanceof Error ? e.message : 'unknown' }, 502);
+  }
+});

--- a/supabase/functions/stripe-webhook/cors.ts
+++ b/supabase/functions/stripe-webhook/cors.ts
@@ -1,0 +1,4 @@
+export const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,86 @@
+// V3-08: Stripe webhook → mirror the gym subscription state into gyms.
+// Verifies the signature, then on subscription/checkout events updates the gym (matched by
+// subscription metadata.gym_id, else by stripe_customer_id). Service role: bypasses RLS.
+
+import Stripe from 'npm:stripe@17';
+import { createClient } from 'npm:@supabase/supabase-js@2';
+
+const STATUS_MAP: Record<string, string> = {
+  trialing: 'trialing',
+  active: 'active',
+  past_due: 'past_due',
+  unpaid: 'past_due',
+  canceled: 'canceled',
+  incomplete: 'incomplete',
+  incomplete_expired: 'canceled',
+};
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') return new Response('method_not_allowed', { status: 405 });
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY');
+  const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+  if (!supabaseUrl || !serviceKey || !stripeKey || !webhookSecret) {
+    return new Response('server_misconfigured', { status: 500 });
+  }
+
+  const sig = req.headers.get('stripe-signature');
+  if (!sig) return new Response('no_signature', { status: 400 });
+
+  const stripe = new Stripe(stripeKey, { apiVersion: '2025-09-30.clover' });
+  const payload = await req.text();
+
+  let event: Stripe.Event;
+  try {
+    event = await stripe.webhooks.constructEventAsync(payload, sig, webhookSecret);
+  } catch (e) {
+    return new Response(`bad_signature: ${e instanceof Error ? e.message : ''}`, { status: 400 });
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+
+  async function applySubscription(sub: Stripe.Subscription) {
+    const gymId = (sub.metadata?.gym_id as string | undefined) ?? null;
+    const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer.id;
+    const patch = {
+      subscription_status: STATUS_MAP[sub.status] ?? 'none',
+      stripe_subscription_id: sub.id,
+      stripe_customer_id: customerId,
+      current_period_end: new Date(sub.current_period_end * 1000).toISOString(),
+    };
+    const query = admin.from('gyms').update(patch);
+    if (gymId) await query.eq('id', gymId);
+    else await query.eq('stripe_customer_id', customerId);
+  }
+
+  try {
+    switch (event.type) {
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted':
+        await applySubscription(event.data.object as Stripe.Subscription);
+        break;
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        if (session.subscription) {
+          const sub = await stripe.subscriptions.retrieve(session.subscription as string);
+          await applySubscription(sub);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  } catch (e) {
+    return new Response(`handler_error: ${e instanceof Error ? e.message : ''}`, { status: 500 });
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});

--- a/supabase/migrations/039_gym_subscription.sql
+++ b/supabase/migrations/039_gym_subscription.sql
@@ -1,0 +1,40 @@
+-- V3-08 slice 1: gym subscription state (Stripe). The webhook (service role) writes these
+-- columns; the app reads them for billing status + soft gating. Default 'trialing' so existing
+-- gyms are never locked out during the pilot. Additive & non-breaking.
+
+ALTER TABLE public.gyms
+  ADD COLUMN IF NOT EXISTS stripe_customer_id     TEXT        NULL,
+  ADD COLUMN IF NOT EXISTS stripe_subscription_id TEXT        NULL,
+  ADD COLUMN IF NOT EXISTS subscription_status    TEXT        NOT NULL DEFAULT 'trialing'
+    CHECK (subscription_status IN ('trialing', 'active', 'past_due', 'canceled', 'incomplete', 'none')),
+  ADD COLUMN IF NOT EXISTS current_period_end     TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.gyms.subscription_status IS
+  'V3-08: Stripe subscription state. trialing/active = PRO features unlocked. Webhook-managed.';
+
+CREATE INDEX IF NOT EXISTS idx_gyms_stripe_customer
+  ON public.gyms (stripe_customer_id) WHERE stripe_customer_id IS NOT NULL;
+
+-- Billing status for the caller's gym (owner or affiliated staff).
+CREATE OR REPLACE FUNCTION public.gym_billing_status()
+RETURNS TABLE (
+  gym_id              uuid,
+  gym_name            text,
+  subscription_status text,
+  current_period_end  timestamptz,
+  is_active           boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT g.id, g.name, g.subscription_status, g.current_period_end,
+         (g.subscription_status IN ('trialing', 'active'))
+  FROM public.gyms g
+  JOIN public.profiles p ON p.id = auth.uid()
+  WHERE g.id = p.affiliated_gym_id OR g.owner_id = auth.uid()
+  LIMIT 1;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_billing_status() TO authenticated;


### PR DESCRIPTION
## Why
Monetize the PRO surface: a gym pays **100/mo** to keep PRO features. This PR is the **plumbing** — the live Checkout→webhook smoke is pending Stripe **test keys** (Igor sets them up).

## What
- **Migration 039** — `gyms` subscription columns (`stripe_customer_id`, `stripe_subscription_id`, `subscription_status` default `trialing`, `current_period_end`) + `gym_billing_status` RPC. Default `trialing` → **soft gating**, the pilot is never locked out.
- **Edge fn `stripe-checkout`** — hosted **Checkout** (subscribe) + **Billing Portal** (manage), gym_admin only, creates/reuses one Stripe customer per gym. Hosted redirect → **no client publishable key needed**.
- **Edge fn `stripe-webhook`** (`--no-verify-jwt`) — signature-verified, mirrors subscription state into `gyms` (by `metadata.gym_id` / customer) on `customer.subscription.*` + `checkout.session.completed`.
- billing service + `/app/pro/billing` screen (status badge, subscribe/manage); nav `billing` `soon → live`; en/fr i18n.

## Smoke (no keys yet)
- `gym_billing_status` → `trialing` / `is_active: true` (grace works) ✅
- `stripe-checkout` deployed → `server_misconfigured` (awaiting secrets) ✅
- `typecheck` / `lint` / 222 tests / `build` green. Functions deployed to prod.

## ⏭️ To finish #117 (needs Igor)
1. Set secrets: `supabase secrets set STRIPE_SECRET_KEY=sk_test_… STRIPE_PRICE_ID=price_… STRIPE_WEBHOOK_SECRET=whsec_…`
2. Register webhook in Stripe → `https://hfgpefxvjwhwzsanhtjv.supabase.co/functions/v1/stripe-webhook` (events: `customer.subscription.*`, `checkout.session.completed`).
3. Then full Checkout→webhook smoke (test card 4242) + hard gating enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)