### PR TITLE
chore(pro): Stripe env docs + name plan "TrueGrynd GYM PRO" (#117)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -25,6 +25,15 @@ E2E_TEST_PASSWORD=testpassword123
 #   OPENAI_API_KEY=sk-...
 #   OPENAI_MODEL=gpt-4o-mini   # optional; default in function is gpt-4o-mini
 
+# --- Stripe gym subscription (Supabase Edge Functions, not Vercel) ---
+# Deploy: supabase functions deploy stripe-checkout && supabase functions deploy stripe-webhook --no-verify-jwt
+# Secrets (supabase secrets set ... --project-ref <ref>):
+#   STRIPE_SECRET_KEY=sk_test_...        # secret — DO NOT commit
+#   STRIPE_PRICE_ID=price_...            # the "TrueGrynd GYM PRO" 100/mo recurring price (not secret)
+#   STRIPE_WEBHOOK_SECRET=whsec_...      # from the Stripe webhook endpoint (secret)
+# Webhook endpoint URL: https://<ref>.supabase.co/functions/v1/stripe-webhook
+# No client-side key needed — Checkout is hosted (server returns the redirect URL).
+
 # --- Supabase CLI (optional; multi-account / no browser login) ---
 # Do NOT put a real token in this file — copy to .env.supabase.local (gitignored).
 # Create token: https://supabase.com/dashboard/account/tokens

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1421,7 +1421,7 @@
     "billing": {
       "loading": "Loading…",
       "noGym": "Create your gym first to manage billing.",
-      "plan": "TrueGrynd PRO — 100/mo. Validation, events, TV cast, leagues.",
+      "plan": "TrueGrynd GYM PRO — 100/mo. Validation, events, TV cast, leagues.",
       "subscribe": "Subscribe",
       "manage": "Manage subscription",
       "renews": "Renews on {date}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1421,7 +1421,7 @@
     "billing": {
       "loading": "Chargement…",
       "noGym": "Crée d'abord ta salle pour gérer la facturation.",
-      "plan": "TrueGrynd PRO — 100/mois. Validation, events, TV cast, ligues.",
+      "plan": "TrueGrynd GYM PRO — 100/mois. Validation, events, TV cast, ligues.",
       "subscribe": "S'abonner",
       "manage": "Gérer l'abonnement",
       "renews": "Renouvellement le {date}",


### PR DESCRIPTION
Docs + naming for the gym subscription:
- .env.local.example: Stripe Edge Function secrets section + webhook URL (no client key needed)
- billing plan copy → "TrueGrynd GYM PRO" (distinguishes B2B from future B2C premium)

STRIPE_PRICE_ID already set as a Supabase secret (non-sensitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)