### PR TITLE
feat(pro): subscription gating + harden webhook (#117)

### DIFF
--- a/src/app/[locale]/app/pro/layout.tsx
+++ b/src/app/[locale]/app/pro/layout.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { ProNav } from '@/features/pro/components/ProNav';
+import { SubscriptionGate } from '@/features/pro/components/SubscriptionGate';
 import { canAccessPro } from '@/lib/roles';
 
 export default function ProLayout({ children }: { children: ReactNode }) {
@@ -28,7 +29,7 @@ export default function ProLayout({ children }: { children: ReactNode }) {
 
       <ProNav />
 
-      <div>{children}</div>
+      <SubscriptionGate>{children}</SubscriptionGate>
     </section>
   );
 }

--- a/src/features/pro/components/SubscriptionGate.tsx
+++ b/src/features/pro/components/SubscriptionGate.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { getBillingStatus, startCheckout } from '@/features/pro/services/billing';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { isPlatformAdmin } from '@/lib/roles';
+
+/**
+ * Gates the PRO surface on an active subscription. trialing/active pass (the pilot is never
+ * locked); canceled/past_due/none get a subscribe wall. Platform admins always pass (oversight).
+ */
+export function SubscriptionGate({ children }: { children: ReactNode }) {
+  const t = useTranslations('pro.billing');
+  const profile = useOptionalAppProfile();
+  const { state } = useAsyncResource(getBillingStatus, []);
+  const [busy, setBusy] = useState(false);
+
+  // Admins oversee everything; while loading, don't flash a wall.
+  if (isPlatformAdmin(profile)) return <>{children}</>;
+  if (state.status !== 'ready' || !state.data) return <>{children}</>;
+  if (state.data.isActive) return <>{children}</>;
+
+  async function subscribe() {
+    setBusy(true);
+    try {
+      const url = await startCheckout(window.location.href);
+      window.location.href = url;
+    } catch {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-4 rounded-md border border-primary/40 bg-card p-6 text-center">
+      <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
+        {t(`status.${state.data.status}`)}
+      </p>
+      <h2 className="text-xl font-black uppercase tracking-tight">{t('gateTitle')}</h2>
+      <p className="text-sm text-muted-foreground">{t('gateBody')}</p>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={subscribe}
+        className="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+      >
+        {busy ? t('loading') : t('subscribe')}
+      </button>
+    </div>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1423,6 +1423,8 @@
       "noGym": "Create your gym first to manage billing.",
       "plan": "TrueGrynd GYM PRO — 100/mo. Validation, events, TV cast, leagues.",
       "subscribe": "Subscribe",
+      "gateTitle": "Subscription required",
+      "gateBody": "Your gym's TrueGrynd GYM PRO subscription is inactive. Subscribe to restore validation, events, TV cast and leagues.",
       "manage": "Manage subscription",
       "renews": "Renews on {date}",
       "note": "Billing is handled securely by Stripe. Cancel anytime from the portal.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1423,6 +1423,8 @@
       "noGym": "Crée d'abord ta salle pour gérer la facturation.",
       "plan": "TrueGrynd GYM PRO — 100/mois. Validation, events, TV cast, ligues.",
       "subscribe": "S'abonner",
+      "gateTitle": "Abonnement requis",
+      "gateBody": "L'abonnement TrueGrynd GYM PRO de ta salle est inactif. Abonne-toi pour rétablir la validation, les events, le TV cast et les ligues.",
       "manage": "Gérer l'abonnement",
       "renews": "Renouvellement le {date}",
       "note": "La facturation est gérée en sécurité par Stripe. Résiliable à tout moment depuis le portail.",

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -46,11 +46,17 @@ Deno.serve(async (req) => {
   async function applySubscription(sub: Stripe.Subscription) {
     const gymId = (sub.metadata?.gym_id as string | undefined) ?? null;
     const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer.id;
+    // current_period_end moved from the top-level subscription to the item in newer API
+    // versions — read whichever is present.
+    const periodEnd =
+      (sub as { current_period_end?: number }).current_period_end ??
+      sub.items?.data?.[0]?.current_period_end ??
+      null;
     const patch = {
       subscription_status: STATUS_MAP[sub.status] ?? 'none',
       stripe_subscription_id: sub.id,
       stripe_customer_id: customerId,
-      current_period_end: new Date(sub.current_period_end * 1000).toISOString(),
+      current_period_end: periodEnd ? new Date(periodEnd * 1000).toISOString() : null,
     };
     const query = admin.from('gyms').update(patch);
     if (gymId) await query.eq('id', gymId);


### PR DESCRIPTION
## Why
Completes **#117** — the gym subscription is now gated and the webhook is hardened. The full Checkout→webhook→portal flow is proven live (test mode).

## What
- **`SubscriptionGate`** in the `/pro` layout: `trialing`/`active` pass (pilot is never locked), `canceled`/`past_due`/`none` get a subscribe wall with a Checkout button to reactivate; `platform_admin` always passes (oversight).
- **stripe-webhook**: defensive `current_period_end` (top-level subscription OR `items[0]`) — avoids a null-date crash on Stripe API 2025-11.
- en/fr i18n (`pro.billing.gateTitle/gateBody`).

## Smoke — full live e2e (prod, test mode)
- `stripe-checkout` → real `checkout.stripe.com` URL ✅
- created a subscription with a test card → **webhook flipped `gyms.subscription_status` `trialing → active`** + `current_period_end` set ✅
- billing page (Playwright) shows **ACTIVE** + "Renews on 7/24/2026" + **Manage subscription** ✅
- portal → `billing.stripe.com` URL ✅
- secrets set (STRIPE_SECRET_KEY / STRIPE_PRICE_ID / STRIPE_WEBHOOK_SECRET); webhook endpoint registered. Cleaned up test data.
- `typecheck` / `lint` / 222 tests / `build` green.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)