### PR TITLE
feat(pro): multi-WOD gym events + cumulative standings (#136)

### DIFF
--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, Radio } from 'lucide-react';
+import { ArrowLeft, Plus, Radio } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
@@ -9,9 +9,13 @@ import { useLocale, useTranslations } from 'next-intl';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { Leaderboard } from '@/features/challenges/components/Leaderboard';
 import {
+  addEventWorkout,
   cancelGymEvent,
+  getEventStandings,
   getGymEvent,
+  listEventWorkouts,
   updateGymEvent,
+  type EventWorkout,
   type GymEvent,
 } from '@/features/pro/services/events';
 import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
@@ -33,6 +37,9 @@ function phaseOf(event: GymEvent): Phase {
   if (now > new Date(event.endsAt).getTime()) return 'ended';
   return 'live';
 }
+
+const inputCls =
+  'mt-1 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
 function EditEventForm({
   event,
@@ -62,9 +69,6 @@ function EditEventForm({
       setBusy(false);
     }
   }
-
-  const inputCls =
-    'mt-1 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
   return (
     <div className="space-y-3 rounded-md border border-border bg-card p-4">
@@ -124,6 +128,212 @@ function EditEventForm({
   );
 }
 
+function AddWorkoutForm({ eventId, onAdded }: { eventId: string; onAdded: () => void }) {
+  const t = useTranslations('pro.events');
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [workout, setWorkout] = useState('');
+  const [scoreType, setScoreType] = useState<'time' | 'reps'>('time');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function add() {
+    if (title.trim().length < 2) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await addEventWorkout({ eventId, title, workout, scoreType });
+      setOpen(false);
+      setTitle('');
+      setWorkout('');
+      onAdded();
+    } catch {
+      setError(t('manage.error'));
+      setBusy(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        {t('workouts.add')}
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-card p-4">
+      <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('create.fields.title')}
+        <input value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} />
+      </label>
+      <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('workouts.spec')}
+        <textarea
+          rows={3}
+          value={workout}
+          onChange={(e) => setWorkout(e.target.value)}
+          className={`${inputCls} resize-y`}
+        />
+      </label>
+      <div className="flex gap-2">
+        {(['time', 'reps'] as const).map((st) => (
+          <button
+            key={st}
+            type="button"
+            onClick={() => setScoreType(st)}
+            className={`rounded-sm px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] ${
+              scoreType === st
+                ? 'bg-primary text-primary-foreground'
+                : 'border border-border text-muted-foreground'
+            }`}
+          >
+            {t(`workouts.scoreType.${st}`)}
+          </button>
+        ))}
+      </div>
+      {error ? <p className="text-xs font-semibold text-primary">{error}</p> : null}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy || title.trim().length < 2}
+          onClick={add}
+          className="rounded-md bg-primary px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? t('manage.saving') : t('workouts.addSubmit')}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => setOpen(false)}
+          className="rounded-md border border-border px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          {t('manage.cancelEdit')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function StandingsTable({ eventId, reloadKey }: { eventId: string; reloadKey: number }) {
+  const t = useTranslations('pro.events');
+  const load = useCallback(() => getEventStandings(eventId), [eventId]);
+  const { state } = useAsyncResource(load, [eventId, reloadKey]);
+  const rows = state.status === 'ready' ? state.data : [];
+  if (rows.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('detail.overall')}
+      </h2>
+      <ul className="rounded-md border border-border bg-card">
+        {rows.map((r, i) => (
+          <li
+            key={r.userId}
+            className="flex items-center gap-3 border-b border-border px-3 py-2.5 last:border-b-0"
+          >
+            <span className="w-6 shrink-0 text-center text-sm font-black tabular-nums">
+              {i + 1}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-sm font-bold">{r.username ?? '—'}</span>
+            <span className="shrink-0 text-sm font-black tabular-nums">
+              {t('detail.points', { count: r.totalPoints })}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function WorkoutPanel({
+  event,
+  workout,
+  phase,
+}: {
+  event: GymEvent;
+  workout: EventWorkout;
+  phase: Phase;
+}) {
+  const t = useTranslations('pro.events');
+  const locale = useLocale();
+  const profile = useOptionalAppProfile();
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  return (
+    <div className="space-y-4">
+      {workout.rules ? (
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('detail.workout')}
+          </p>
+          <pre className="mt-2 whitespace-pre-wrap font-sans text-sm text-foreground">
+            {workout.rules}
+          </pre>
+        </div>
+      ) : null}
+
+      {phase === 'live' ? (
+        done ? (
+          <p className="rounded-md border border-border bg-card p-4 text-sm text-muted-foreground">
+            {t('detail.submitted')}
+          </p>
+        ) : submitting ? (
+          <div className="rounded-md border border-border bg-card p-4">
+            <ScoreSubmissionForm
+              challengeId={workout.challengeId}
+              scoreType={workout.scoreType}
+              availableVariants={['standard']}
+              onSubmitted={() => {
+                setSubmitting(false);
+                setDone(true);
+                setReloadKey((k) => k + 1);
+              }}
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setSubmitting(true)}
+            className="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {t('detail.submit')}
+          </button>
+        )
+      ) : null}
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('detail.standings')}
+          </h2>
+          <Link
+            href={`/${locale}/app/pro/events/${event.id}/tv`}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
+          >
+            <Radio className="h-3.5 w-3.5" />
+            {t('detail.cast')}
+          </Link>
+        </div>
+        <Leaderboard
+          key={`${workout.challengeId}-${reloadKey}-${profile?.id ?? ''}`}
+          challengeId={workout.challengeId}
+          scoreType={workout.scoreType}
+          availableVariants={['standard']}
+          mode="full"
+        />
+      </div>
+    </div>
+  );
+}
+
 function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => void }) {
   const t = useTranslations('pro.events');
   const locale = useLocale();
@@ -131,11 +341,16 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
   const profile = useOptionalAppProfile();
   const phase = phaseOf(event);
   const canManage = isGymStaff(profile);
-  const [submitting, setSubmitting] = useState(false);
-  const [reloadKey, setReloadKey] = useState(0);
-  const [done, setDone] = useState(false);
   const [editing, setEditing] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  const loadWorkouts = useCallback(() => listEventWorkouts(event.id), [event.id]);
+  const { state: workoutsState, refetch: refetchWorkouts } = useAsyncResource(loadWorkouts, [
+    event.id,
+  ]);
+  const workouts = workoutsState.status === 'ready' ? workoutsState.data : [];
+  const active = workouts[activeIdx] ?? workouts[0] ?? null;
 
   async function doCancel() {
     setCancelling(true);
@@ -209,74 +424,37 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
         <p className="text-sm text-muted-foreground">{event.description}</p>
       ) : null}
 
-      {event.workout ? (
-        <div className="rounded-md border border-border bg-card p-4">
-          <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {t('detail.workout')}
-          </p>
-          <pre className="mt-2 whitespace-pre-wrap font-sans text-sm text-foreground">
-            {event.workout}
-          </pre>
-        </div>
-      ) : null}
+      {/* Overall standings across all workouts (only meaningful with 2+ WODs). */}
+      {workouts.length > 1 ? <StandingsTable eventId={event.id} reloadKey={activeIdx} /> : null}
 
-      {/* Score submission flows through the same core pipeline as the B2C arena. */}
-      {phase === 'live' && event.challengeId ? (
-        done ? (
-          <p className="rounded-md border border-border bg-card p-4 text-sm text-muted-foreground">
-            {t('detail.submitted')}
-          </p>
-        ) : submitting ? (
-          <div className="rounded-md border border-border bg-card p-4">
-            <ScoreSubmissionForm
-              challengeId={event.challengeId}
-              scoreType={event.scoreType}
-              availableVariants={['standard']}
-              onSubmitted={() => {
-                setSubmitting(false);
-                setDone(true);
-                setReloadKey((k) => k + 1);
-              }}
-            />
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => setSubmitting(true)}
-            className="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {t('detail.submit')}
-          </button>
-        )
-      ) : null}
-
-      <div className="space-y-2">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {t('detail.standings')}
-          </h2>
-          {event.challengeId ? (
-            <Link
-              href={`/${locale}/app/pro/events/${event.id}/tv`}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
-            >
-              <Radio className="h-3.5 w-3.5" />
-              {t('detail.cast')}
-            </Link>
+      {/* Workout selector + active workout panel. */}
+      {workouts.length > 0 ? (
+        <div className="space-y-3">
+          {workouts.length > 1 ? (
+            <div className="flex flex-wrap gap-2">
+              {workouts.map((w, i) => (
+                <button
+                  key={w.challengeId}
+                  type="button"
+                  onClick={() => setActiveIdx(i)}
+                  className={`rounded-sm px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] ${
+                    i === activeIdx
+                      ? 'bg-primary text-primary-foreground'
+                      : 'border border-border text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {t('workouts.label', { n: w.sortOrder })} · {w.title}
+                </button>
+              ))}
+            </div>
           ) : null}
+          {active ? <WorkoutPanel event={event} workout={active} phase={phase} /> : null}
         </div>
-        {event.challengeId ? (
-          <Leaderboard
-            key={`${event.challengeId}-${reloadKey}-${profile?.id ?? ''}`}
-            challengeId={event.challengeId}
-            scoreType={event.scoreType}
-            availableVariants={['standard']}
-            mode="full"
-          />
-        ) : (
-          <p className="text-sm text-muted-foreground">{t('detail.noStandings')}</p>
-        )}
-      </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">{t('detail.noStandings')}</p>
+      )}
+
+      {canManage ? <AddWorkoutForm eventId={event.id} onAdded={refetchWorkouts} /> : null}
     </section>
   );
 }

--- a/src/features/pro/services/events.ts
+++ b/src/features/pro/services/events.ts
@@ -102,3 +102,76 @@ export async function cancelGymEvent(id: string): Promise<void> {
   const { error } = await supabase.rpc('cancel_gym_event', { p_event_id: id });
   if (error) throw new Error(error.message);
 }
+
+/** A workout within a (possibly multi-WOD) gym event. */
+export type EventWorkout = {
+  challengeId: string;
+  title: string;
+  scoreType: 'time' | 'reps';
+  rules: string;
+  sortOrder: number;
+};
+
+export async function listEventWorkouts(eventId: string): Promise<EventWorkout[]> {
+  const { data, error } = await supabase.rpc('gym_event_workouts_list', { p_event_id: eventId });
+  if (error) throw new Error(error.message);
+  return (
+    (data ?? []) as Array<{
+      challenge_id: string;
+      title: string;
+      score_type: 'time' | 'reps';
+      rules: string;
+      sort_order: number;
+    }>
+  ).map((r) => ({
+    challengeId: r.challenge_id,
+    title: r.title,
+    scoreType: r.score_type,
+    rules: r.rules,
+    sortOrder: r.sort_order,
+  }));
+}
+
+export async function addEventWorkout(input: {
+  eventId: string;
+  title: string;
+  workout: string;
+  scoreType: 'time' | 'reps';
+}): Promise<void> {
+  const { error } = await supabase.rpc('add_gym_event_workout', {
+    p_event_id: input.eventId,
+    p_title: input.title,
+    p_workout: input.workout,
+    p_score_type: input.scoreType,
+  });
+  if (error) throw new Error(error.message);
+}
+
+/** A row in the cumulative event standings. */
+export type EventStanding = {
+  userId: string;
+  username: string | null;
+  avatarUrl: string | null;
+  faction: string | null;
+  totalPoints: number;
+};
+
+export async function getEventStandings(eventId: string): Promise<EventStanding[]> {
+  const { data, error } = await supabase.rpc('gym_event_standings', { p_event_id: eventId });
+  if (error) throw new Error(error.message);
+  return (
+    (data ?? []) as Array<{
+      user_id: string;
+      username: string | null;
+      avatar_url: string | null;
+      faction: string | null;
+      total_points: number;
+    }>
+  ).map((r) => ({
+    userId: r.user_id,
+    username: r.username,
+    avatarUrl: r.avatar_url,
+    faction: r.faction,
+    totalPoints: Number(r.total_points ?? 0),
+  }));
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1483,7 +1483,19 @@
         "noStandings": "Standings will appear once the event is set up.",
         "submit": "Submit my score",
         "submitted": "Score submitted — it's in the standings and the Judge queue.",
-        "cast": "Cast to TV"
+        "cast": "Cast to TV",
+        "overall": "Overall standings",
+        "points": "{count, plural, =1 {1 pt} other {# pts}}"
+      },
+      "workouts": {
+        "label": "WOD {n}",
+        "add": "Add workout",
+        "addSubmit": "Add workout",
+        "spec": "Workout",
+        "scoreType": {
+          "time": "For time",
+          "reps": "Reps / AMRAP"
+        }
       },
       "tv": {
         "badge": "Live broadcast",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1483,7 +1483,19 @@
         "noStandings": "Le classement apparaîtra une fois l'event configuré.",
         "submit": "Soumettre mon score",
         "submitted": "Score soumis — il est dans le classement et la file Judge.",
-        "cast": "Caster sur la TV"
+        "cast": "Caster sur la TV",
+        "overall": "Classement général",
+        "points": "{count, plural, =1 {1 pt} other {# pts}}"
+      },
+      "workouts": {
+        "label": "WOD {n}",
+        "add": "Ajouter un WOD",
+        "addSubmit": "Ajouter le WOD",
+        "spec": "WOD",
+        "scoreType": {
+          "time": "For time",
+          "reps": "Reps / AMRAP"
+        }
       },
       "tv": {
         "badge": "Diffusion live",

--- a/supabase/migrations/041_gym_event_multi_wod.sql
+++ b/supabase/migrations/041_gym_event_multi_wod.sql
@@ -1,0 +1,214 @@
+-- V3-05 follow-up (#136): multi-WOD gym events + cumulative standings. An event can hold
+-- 1..N workouts; the existing single workout (gym_events.challenge_id) is backfilled as WOD #1.
+-- Standings = CrossFit-Open style: per workout points = (participants - rank + 1), summed across
+-- workouts (a missed workout scores 0). Additive & non-breaking.
+
+CREATE TABLE IF NOT EXISTS public.gym_event_workouts (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id     UUID        NOT NULL REFERENCES public.gym_events(id) ON DELETE CASCADE,
+  challenge_id UUID        NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  sort_order   INT         NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (event_id, sort_order),
+  UNIQUE (event_id, challenge_id)
+);
+
+COMMENT ON TABLE public.gym_event_workouts IS
+  'V3-05 #136: ordered workouts (gym-scoped challenges) of a gym event.';
+
+ALTER TABLE public.gym_event_workouts ENABLE ROW LEVEL SECURITY;
+
+-- READ: same audience as the parent event (gym members / owner / platform admin).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'gym_event_workouts'
+                 AND policyname = 'Gym people read their event workouts') THEN
+    CREATE POLICY "Gym people read their event workouts"
+      ON public.gym_event_workouts FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1 FROM public.gym_events e
+        WHERE e.id = gym_event_workouts.event_id
+          AND (
+            public.is_platform_admin()
+            OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = e.gym_id)
+            OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = e.gym_id AND g.owner_id = auth.uid())
+          )
+      ));
+  END IF;
+END $$;
+
+-- Backfill the existing single workout as WOD #1.
+INSERT INTO public.gym_event_workouts (event_id, challenge_id, sort_order)
+SELECT id, challenge_id, 1 FROM public.gym_events WHERE challenge_id IS NOT NULL
+ON CONFLICT (event_id, challenge_id) DO NOTHING;
+
+-- Append a workout to an event (staff of its gym). Creates the gym-scoped challenge like
+-- create_gym_event does, then links it at the next sort_order.
+CREATE OR REPLACE FUNCTION public.add_gym_event_workout(
+  p_event_id   uuid,
+  p_title      text,
+  p_workout    text,
+  p_score_type text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller    uuid := auth.uid();
+  v_gym       uuid;
+  v_ends      timestamptz;
+  v_challenge uuid;
+  v_next      int;
+BEGIN
+  PERFORM public.assert_can_manage_gym_event(p_event_id);
+  IF p_score_type NOT IN ('time', 'reps') THEN
+    RAISE EXCEPTION 'bad_score_type';
+  END IF;
+
+  SELECT gym_id, ends_at INTO v_gym, v_ends FROM public.gym_events WHERE id = p_event_id;
+
+  INSERT INTO public.challenges (title, description, rules, score_type, gym_id, creator_id,
+                                 is_official, status, ends_at)
+  VALUES (btrim(p_title), btrim(p_title),
+          coalesce(nullif(btrim(p_workout), ''), btrim(p_title)), p_score_type, v_gym, v_caller,
+          false, 'approved', v_ends)
+  RETURNING id INTO v_challenge;
+
+  INSERT INTO public.challenge_variants (challenge_id, variant)
+  VALUES (v_challenge, 'standard') ON CONFLICT (challenge_id, variant) DO NOTHING;
+
+  SELECT coalesce(max(sort_order), 0) + 1 INTO v_next
+  FROM public.gym_event_workouts WHERE event_id = p_event_id;
+
+  INSERT INTO public.gym_event_workouts (event_id, challenge_id, sort_order)
+  VALUES (p_event_id, v_challenge, v_next);
+
+  RETURN v_challenge;
+END;
+$$;
+
+-- Workouts of an event (ordered).
+CREATE OR REPLACE FUNCTION public.gym_event_workouts_list(p_event_id uuid)
+RETURNS TABLE (challenge_id uuid, title text, score_type text, rules text, sort_order int)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT w.challenge_id, c.title, c.score_type, c.rules, w.sort_order
+  FROM public.gym_event_workouts w
+  JOIN public.challenges c ON c.id = w.challenge_id
+  WHERE w.event_id = p_event_id
+  ORDER BY w.sort_order;
+$$;
+
+-- Cumulative standings across all workouts (Open-style points; missed workout = 0).
+CREATE OR REPLACE FUNCTION public.gym_event_standings(p_event_id uuid)
+RETURNS TABLE (
+  user_id      uuid,
+  username     text,
+  avatar_url   text,
+  faction      text,
+  total_points bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  WITH workouts AS (
+    SELECT w.challenge_id, c.score_type
+    FROM public.gym_event_workouts w
+    JOIN public.challenges c ON c.id = w.challenge_id
+    WHERE w.event_id = p_event_id
+  ),
+  best AS (
+    SELECT s.challenge_id, s.user_id, wo.score_type,
+           CASE WHEN wo.score_type = 'time' THEN min(s.value) ELSE max(s.value) END AS val
+    FROM public.scores s
+    JOIN workouts wo ON wo.challenge_id = s.challenge_id
+    WHERE s.is_validated = true
+    GROUP BY s.challenge_id, s.user_id, wo.score_type
+  ),
+  ranked AS (
+    SELECT b.challenge_id, b.user_id,
+           rank() OVER (
+             PARTITION BY b.challenge_id
+             ORDER BY (CASE WHEN b.score_type = 'time' THEN b.val END) ASC NULLS LAST,
+                      (CASE WHEN b.score_type = 'reps' THEN b.val END) DESC NULLS LAST
+           ) AS rnk,
+           count(*) OVER (PARTITION BY b.challenge_id) AS n
+    FROM best b
+  )
+  SELECT r.user_id, p.username, p.avatar_url, p.faction,
+         sum(r.n - r.rnk + 1)::bigint AS total_points
+  FROM ranked r
+  JOIN public.profiles p ON p.id = r.user_id
+  GROUP BY r.user_id, p.username, p.avatar_url, p.faction
+  ORDER BY total_points DESC
+  LIMIT 200;
+$$;
+
+-- Redefine create_gym_event so newly created events also register their primary workout as
+-- WOD #1 in gym_event_workouts (the migration backfill only covered pre-existing events).
+CREATE OR REPLACE FUNCTION public.create_gym_event(
+  p_title       text,
+  p_description text,
+  p_workout     text,
+  p_score_type  text,
+  p_starts_at   timestamptz,
+  p_ends_at     timestamptz
+)
+RETURNS public.gym_events
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller    uuid := auth.uid();
+  v_gym       uuid;
+  v_staff     boolean;
+  v_challenge uuid;
+  v_event     public.gym_events;
+BEGIN
+  SELECT affiliated_gym_id, (role IN ('coach', 'gym_admin'))
+    INTO v_gym, v_staff
+  FROM public.profiles WHERE id = v_caller;
+
+  IF NOT (COALESCE(v_staff, false) OR public.is_platform_admin()) THEN
+    RAISE EXCEPTION 'not_gym_staff';
+  END IF;
+  IF v_gym IS NULL THEN
+    RAISE EXCEPTION 'no_gym';
+  END IF;
+  IF p_score_type NOT IN ('time', 'reps') THEN
+    RAISE EXCEPTION 'bad_score_type';
+  END IF;
+  IF p_ends_at <= p_starts_at THEN
+    RAISE EXCEPTION 'bad_window';
+  END IF;
+
+  INSERT INTO public.challenges (title, description, rules, score_type, gym_id, creator_id,
+                                 is_official, status, ends_at)
+  VALUES (btrim(p_title), coalesce(nullif(btrim(p_description), ''), btrim(p_title)),
+          coalesce(nullif(btrim(p_workout), ''), btrim(p_title)), p_score_type, v_gym, v_caller,
+          false, 'approved', p_ends_at)
+  RETURNING id INTO v_challenge;
+
+  INSERT INTO public.challenge_variants (challenge_id, variant)
+  VALUES (v_challenge, 'standard')
+  ON CONFLICT (challenge_id, variant) DO NOTHING;
+
+  INSERT INTO public.gym_events (gym_id, created_by, title, description, workout, score_type,
+                                 starts_at, ends_at, challenge_id)
+  VALUES (v_gym, v_caller, btrim(p_title), coalesce(p_description, ''), coalesce(p_workout, ''),
+          p_score_type, p_starts_at, p_ends_at, v_challenge)
+  RETURNING * INTO v_event;
+
+  INSERT INTO public.gym_event_workouts (event_id, challenge_id, sort_order)
+  VALUES (v_event.id, v_challenge, 1)
+  ON CONFLICT (event_id, challenge_id) DO NOTHING;
+
+  RETURN v_event;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.add_gym_event_workout(uuid, text, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.gym_event_workouts_list(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.gym_event_standings(uuid) TO authenticated;


### PR DESCRIPTION
## What
An event can hold **1..N workouts** with an Open-style **cumulative ranking**.

- **Migration 041** — `gym_event_workouts` (ordered WODs); backfills the existing single WOD as #1; `create_gym_event` now registers WOD #1; `add_gym_event_workout` (staff); `gym_event_workouts_list`; `gym_event_standings` (per WOD points = participants − rank + 1, summed; missed WOD = 0).
- **EventDetail rework** — WOD selector, per-WOD submit + leaderboard, **overall standings** table (shown with 2+ WODs), staff "Add workout"; service helpers; en/fr i18n.

## Smoke (API + Playwright)
- 2-WOD event, `add_gym_event_workout` → WOD2; validated scores on both → **overall standings "2 pts"** ✅
- Playwright: detail shows OVERALL STANDINGS + WOD 1/WOD 2 selector + per-WOD panel ✅
- `typecheck` / `lint` / 222 tests / `build` green.

> Note: the per-WOD leaderboard reuses the B2C `Leaderboard` whose default filter preset (faction/local) can hide rows — pre-existing behavior; an events-specific "all" default is a small follow-up.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)