### PR TITLE
feat(pro): league standings — box vs box by avg member rating (#139)

### DIFF
--- a/src/app/[locale]/app/pro/leagues/[leagueId]/page.tsx
+++ b/src/app/[locale]/app/pro/leagues/[leagueId]/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { use } from 'react';
+
+import { LeagueDetail } from '@/features/pro/components/LeagueDetail';
+
+type Params = { leagueId: string; locale: string };
+
+export default function ProLeagueDetailPage({ params }: { params: Promise<Params> }) {
+  const { leagueId } = use(params);
+  return <LeagueDetail leagueId={leagueId} />;
+}

--- a/src/features/pro/components/LeagueDetail.tsx
+++ b/src/features/pro/components/LeagueDetail.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { getLeagueStandings, listLeagues } from '@/features/pro/services/leagues';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+
+const RANK_MEDAL = ['#f5c518', '#c0c0c0', '#cd7f32'];
+
+export function LeagueDetail({ leagueId }: { leagueId: string }) {
+  const t = useTranslations('pro.leagues');
+  const locale = useLocale();
+  const loadStandings = useCallback(() => getLeagueStandings(leagueId), [leagueId]);
+  const { state } = useAsyncResource(loadStandings, [leagueId]);
+  const { state: leaguesState } = useAsyncResource(listLeagues, []);
+  const league =
+    leaguesState.status === 'ready' ? leaguesState.data.find((l) => l.id === leagueId) : null;
+
+  return (
+    <section className="space-y-5">
+      <Link
+        href={`/${locale}/app/pro/leagues`}
+        className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {t('detail.back')}
+      </Link>
+
+      <header className="space-y-1">
+        <span className="inline-flex items-center rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+          {league ? t(`scope.${league.scope}`) : '—'}
+        </span>
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">
+          {league?.name ?? '…'}
+        </h1>
+        <p className="text-sm text-muted-foreground">{t('detail.intro')}</p>
+      </header>
+
+      {state.status === 'loading' || state.status === 'idle' ? (
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
+      ) : state.status === 'error' ? (
+        <p className="text-sm font-semibold text-primary">{t('error')}</p>
+      ) : state.data.length === 0 ? (
+        <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          {t('detail.empty')}
+        </p>
+      ) : (
+        <ul className="rounded-md border border-border bg-card">
+          {state.data.map((row, i) => (
+            <li
+              key={row.gymId}
+              className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0"
+            >
+              <span
+                className="w-6 shrink-0 text-center text-base font-black tabular-nums"
+                style={{ color: RANK_MEDAL[i] ?? 'inherit' }}
+              >
+                {i + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-bold">{row.gymName}</span>
+                <span className="block text-xs text-muted-foreground">
+                  {t('detail.members', { count: row.memberCount })}
+                </span>
+              </span>
+              <span className="shrink-0 text-right">
+                <span className="block text-lg font-black tabular-nums">{row.avgRating}</span>
+                <span className="block text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+                  {t('detail.avgRating')}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="text-xs text-muted-foreground">{t('detail.note')}</p>
+    </section>
+  );
+}

--- a/src/features/pro/components/LeaguesList.tsx
+++ b/src/features/pro/components/LeaguesList.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { joinLeague, leaveLeague, listLeagues, type League } from '@/features/pro/services/leagues';
@@ -18,6 +19,7 @@ function LeagueRow({
   onChanged: () => void;
 }) {
   const t = useTranslations('pro.leagues');
+  const locale = useLocale();
   const [busy, setBusy] = useState(false);
 
   async function toggle() {
@@ -33,12 +35,15 @@ function LeagueRow({
 
   return (
     <li className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0">
-      <span className="min-w-0 flex-1">
+      <Link
+        href={`/${locale}/app/pro/leagues/${league.id}`}
+        className="min-w-0 flex-1 hover:opacity-80"
+      >
         <span className="block truncate text-sm font-bold">{league.name}</span>
         <span className="text-xs text-muted-foreground">
           {t('members', { count: league.memberCount })}
         </span>
-      </span>
+      </Link>
       <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
         {t(`scope.${league.scope}`)}
       </span>

--- a/src/features/pro/services/leagues.ts
+++ b/src/features/pro/services/leagues.ts
@@ -34,6 +34,35 @@ export async function listLeagues(): Promise<League[]> {
   }));
 }
 
+/** A member gym's row in the league standings. */
+export type LeagueStanding = {
+  gymId: string;
+  gymName: string;
+  memberCount: number;
+  ratedCount: number;
+  avgRating: number;
+};
+
+export async function getLeagueStandings(leagueId: string): Promise<LeagueStanding[]> {
+  const { data, error } = await supabase.rpc('league_standings', { p_league_id: leagueId });
+  if (error) throw new Error(error.message);
+  return (
+    (data ?? []) as Array<{
+      gym_id: string;
+      gym_name: string;
+      member_count: number;
+      rated_count: number;
+      avg_rating: number;
+    }>
+  ).map((r) => ({
+    gymId: r.gym_id,
+    gymName: r.gym_name,
+    memberCount: Number(r.member_count ?? 0),
+    ratedCount: Number(r.rated_count ?? 0),
+    avgRating: Number(r.avg_rating ?? 0),
+  }));
+}
+
 export async function joinLeague(leagueId: string): Promise<void> {
   const { error } = await supabase.rpc('join_league', { p_league_id: leagueId });
   if (error) throw new Error(error.message);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1464,6 +1464,14 @@
         "local": "Local",
         "regional": "Regional",
         "national": "National"
+      },
+      "detail": {
+        "back": "Back to leagues",
+        "intro": "Member boxes ranked by their athletes' average rating.",
+        "empty": "No member gyms yet.",
+        "members": "{count, plural, =0 {no members} =1 {1 member} other {# members}}",
+        "avgRating": "Avg rating",
+        "note": "Score = average of each box's members' global rating. Shared-WOD matches are coming next."
       }
     },
     "events": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1464,6 +1464,14 @@
         "local": "Locale",
         "regional": "Régionale",
         "national": "Nationale"
+      },
+      "detail": {
+        "back": "Retour aux ligues",
+        "intro": "Les box membres classées par le rating moyen de leurs athlètes.",
+        "empty": "Aucune salle membre pour le moment.",
+        "members": "{count, plural, =0 {aucun membre} =1 {1 membre} other {# membres}}",
+        "avgRating": "Rating moyen",
+        "note": "Score = moyenne du rating global des membres de chaque box. Les matchs sur WOD partagé arrivent ensuite."
       }
     },
     "events": {

--- a/supabase/migrations/042_league_standings.sql
+++ b/supabase/migrations/042_league_standings.sql
@@ -1,0 +1,36 @@
+-- V3-06 follow-up (#139): box-vs-box league standings. Each member gym's score = the average
+-- of its members' global rating (rating_global is already normalized 0-100 across challenges /
+-- scaling, so it's a fair cross-box metric — "moyenne des membres par scaling"). Gyms ranked by
+-- that average. Shared-WOD league matches are a deeper follow-up. Additive & read-only.
+
+CREATE OR REPLACE FUNCTION public.league_standings(p_league_id uuid)
+RETURNS TABLE (
+  gym_id       uuid,
+  gym_name     text,
+  member_count bigint,
+  rated_count  bigint,
+  avg_rating   numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT g.id,
+         g.name,
+         count(p.id)                              AS member_count,
+         count(pr.user_id)                        AS rated_count,
+         COALESCE(round(avg(pr.rating_global), 1), 0) AS avg_rating
+  FROM public.league_gyms lg
+  JOIN public.gyms g ON g.id = lg.gym_id
+  LEFT JOIN public.profiles p ON p.affiliated_gym_id = g.id
+  LEFT JOIN public.profile_ratings pr ON pr.user_id = p.id
+  WHERE lg.league_id = p_league_id
+  GROUP BY g.id, g.name
+  ORDER BY COALESCE(avg(pr.rating_global), 0) DESC, count(p.id) DESC;
+$$;
+
+COMMENT ON FUNCTION public.league_standings IS
+  'V3-06 #139: member gyms of a league ranked by average member global rating.';
+
+GRANT EXECUTE ON FUNCTION public.league_standings(uuid) TO authenticated;


### PR DESCRIPTION
## What
A league detail page ranks member gyms by their athletes' **average global rating** (`rating_global` is normalized 0–100 across challenges/scaling → a fair cross-box score = "moyenne des membres par scaling").

- **Migration 042** — `league_standings(league_id)` RPC (avg member rating + member/rated counts).
- **`/app/pro/leagues/[leagueId]`** — medal-ranked standings; league rows in the list now link to it; service helper; en/fr i18n.

## Smoke (API + Playwright)
- Joined the National league → standings show **"CROSSFIT MADEC · 1 member · 68.6 avg"** ✅
- `typecheck` / `lint` / 222 tests / `build` green.

## Follow-up
Shared-WOD league matches (synchronized benchmark workouts across boxes) remain a deeper follow-up; this ships the box-vs-box standing on existing rating data.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)