### PR TITLE
feat(pro): pacing assistant — personalized event splits (#116)

### DIFF
--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -18,6 +18,7 @@ import {
   type EventWorkout,
   type GymEvent,
 } from '@/features/pro/services/events';
+import { PacingCard } from '@/features/pro/components/PacingCard';
 import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
 import { isGymStaff } from '@/lib/roles';
@@ -423,6 +424,8 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
       {!editing && event.description ? (
         <p className="text-sm text-muted-foreground">{event.description}</p>
       ) : null}
+
+      {!editing ? <PacingCard eventId={event.id} canManage={canManage} /> : null}
 
       {/* Overall standings across all workouts (only meaningful with 2+ WODs). */}
       {workouts.length > 1 ? <StandingsTable eventId={event.id} reloadKey={activeIdx} /> : null}

--- a/src/features/pro/components/PacingCard.tsx
+++ b/src/features/pro/components/PacingCard.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { Gauge } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { getEventPacing, setEventPacing } from '@/features/pro/services/events';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { formatTime } from '@/lib/scoring';
+
+/** "12:30" / "90" → seconds (null if unparseable). */
+function parseMmSs(raw: string): number | null {
+  const v = raw.trim();
+  if (/^\d+$/.test(v)) return parseInt(v, 10);
+  const m = v.match(/^(\d+):([0-5]?\d)$/);
+  if (!m) return null;
+  return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
+}
+
+function SetPacingForm({
+  eventId,
+  onSaved,
+  initial,
+}: {
+  eventId: string;
+  onSaved: () => void;
+  initial: { benchmark: string; segments: number } | null;
+}) {
+  const t = useTranslations('pro.events.pacing');
+  const [benchmark, setBenchmark] = useState(initial?.benchmark ?? '');
+  const [segments, setSegments] = useState(String(initial?.segments ?? 3));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save() {
+    const secs = parseMmSs(benchmark);
+    const seg = parseInt(segments, 10);
+    if (!secs || secs <= 0 || !seg || seg < 1) {
+      setError(t('invalid'));
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await setEventPacing({ eventId, benchmarkSeconds: secs, segments: seg });
+      onSaved();
+    } catch {
+      setError(t('error'));
+      setBusy(false);
+    }
+  }
+
+  const inputCls =
+    'mt-1 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+  return (
+    <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto] sm:items-end">
+      <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('benchmark')}
+        <input
+          value={benchmark}
+          onChange={(e) => setBenchmark(e.target.value)}
+          placeholder="12:00"
+          className={inputCls}
+        />
+      </label>
+      <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('segments')}
+        <input
+          type="number"
+          min={1}
+          max={20}
+          value={segments}
+          onChange={(e) => setSegments(e.target.value)}
+          className={inputCls}
+        />
+      </label>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={save}
+        className="rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+      >
+        {busy ? t('saving') : t('save')}
+      </button>
+      {error ? <p className="text-xs font-semibold text-primary sm:col-span-3">{error}</p> : null}
+    </div>
+  );
+}
+
+export function PacingCard({ eventId, canManage }: { eventId: string; canManage: boolean }) {
+  const t = useTranslations('pro.events.pacing');
+  const load = useCallback(() => getEventPacing(eventId), [eventId]);
+  const { state, refetch } = useAsyncResource(load, [eventId]);
+  const [editing, setEditing] = useState(false);
+
+  if (state.status !== 'ready') return null;
+  const pacing = state.data;
+
+  // No plan: only staff sees the "set it up" affordance.
+  if (!pacing && !canManage) return null;
+
+  return (
+    <div className="rounded-md border border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-[0.18em] text-accent">
+          <Gauge className="h-3.5 w-3.5" />
+          {t('title')}
+        </p>
+        {canManage && pacing && !editing ? (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded-sm border border-border px-2 py-1 text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
+          >
+            {t('edit')}
+          </button>
+        ) : null}
+      </div>
+
+      {pacing && !editing ? (
+        <div className="mt-3 space-y-1">
+          <p className="text-sm">
+            {t('yourTarget')}{' '}
+            <span className="text-2xl font-black tabular-nums">
+              {formatTime(pacing.personalTargetSeconds)}
+            </span>
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {t('splits', { time: formatTime(pacing.splitSeconds), count: pacing.segments })}
+          </p>
+          <p className="text-[11px] text-muted-foreground">
+            {t('basis', { engine: pacing.engine, benchmark: formatTime(pacing.benchmarkSeconds) })}
+          </p>
+        </div>
+      ) : null}
+
+      {!pacing && canManage && !editing ? (
+        <p className="mt-2 text-sm text-muted-foreground">{t('emptyStaff')}</p>
+      ) : null}
+
+      {canManage && (editing || !pacing) ? (
+        <SetPacingForm
+          eventId={eventId}
+          initial={
+            pacing
+              ? { benchmark: formatTime(pacing.benchmarkSeconds), segments: pacing.segments }
+              : null
+          }
+          onSaved={() => {
+            setEditing(false);
+            refetch();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/pro/services/events.ts
+++ b/src/features/pro/services/events.ts
@@ -147,6 +147,52 @@ export async function addEventWorkout(input: {
   if (error) throw new Error(error.message);
 }
 
+/** The caller's personalized pacing for an event (null = no plan set). */
+export type EventPacing = {
+  benchmarkSeconds: number;
+  segments: number;
+  engine: number;
+  factor: number;
+  personalTargetSeconds: number;
+  splitSeconds: number;
+};
+
+export async function getEventPacing(eventId: string): Promise<EventPacing | null> {
+  const { data, error } = await supabase
+    .rpc('my_event_pacing', { p_event_id: eventId })
+    .maybeSingle<{
+      benchmark_seconds: number;
+      segments: number;
+      engine: number;
+      factor: number;
+      personal_target_seconds: number;
+      split_seconds: number;
+    }>();
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+  return {
+    benchmarkSeconds: data.benchmark_seconds,
+    segments: data.segments,
+    engine: Number(data.engine),
+    factor: Number(data.factor),
+    personalTargetSeconds: data.personal_target_seconds,
+    splitSeconds: data.split_seconds,
+  };
+}
+
+export async function setEventPacing(input: {
+  eventId: string;
+  benchmarkSeconds: number;
+  segments: number;
+}): Promise<void> {
+  const { error } = await supabase.rpc('set_event_pacing', {
+    p_event_id: input.eventId,
+    p_benchmark_seconds: input.benchmarkSeconds,
+    p_segments: input.segments,
+  });
+  if (error) throw new Error(error.message);
+}
+
 /** A row in the cumulative event standings. */
 export type EventStanding = {
   userId: string;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1505,6 +1505,20 @@
           "reps": "Reps / AMRAP"
         }
       },
+      "pacing": {
+        "title": "Pacing assistant",
+        "yourTarget": "Your target",
+        "splits": "{time} per segment × {count}",
+        "basis": "Based on your Engine {engine} vs a {benchmark} benchmark — a guide, not a limit.",
+        "edit": "Edit",
+        "emptyStaff": "Set a benchmark finish + segments to give each athlete a personalized pace.",
+        "benchmark": "Benchmark (mm:ss)",
+        "segments": "Segments",
+        "save": "Save",
+        "saving": "Saving…",
+        "invalid": "Enter a valid time (mm:ss) and segment count.",
+        "error": "Could not save — try again."
+      },
       "tv": {
         "badge": "Live broadcast",
         "exit": "Exit",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1505,6 +1505,20 @@
           "reps": "Reps / AMRAP"
         }
       },
+      "pacing": {
+        "title": "Assistant de pacing",
+        "yourTarget": "Ton objectif",
+        "splits": "{time} par segment × {count}",
+        "basis": "Basé sur ton Engine {engine} vs un benchmark de {benchmark} — un repère, pas une limite.",
+        "edit": "Modifier",
+        "emptyStaff": "Définis un temps benchmark + des segments pour donner à chaque athlète un pacing personnalisé.",
+        "benchmark": "Benchmark (mm:ss)",
+        "segments": "Segments",
+        "save": "Enregistrer",
+        "saving": "Enregistrement…",
+        "invalid": "Saisis un temps valide (mm:ss) et un nombre de segments.",
+        "error": "Impossible d'enregistrer — réessaie."
+      },
       "tv": {
         "badge": "Diffusion live",
         "exit": "Quitter",

--- a/supabase/migrations/043_event_pacing.sql
+++ b/supabase/migrations/043_event_pacing.sql
@@ -1,0 +1,103 @@
+-- V3-07 (#116): Pacing Assistant. A coach sets a benchmark target time + segment count on an
+-- event; each athlete gets a personalized target + even splits, scaled by their Engine rating.
+-- Transparent heuristic (a guide, not a prediction): factor = clamp(50 / engine, 0.75, 1.4) so
+-- the median athlete (rating 50) gets the benchmark, elites ~25% faster, beginners ~40% slower.
+-- Additive & non-breaking.
+
+CREATE TABLE IF NOT EXISTS public.gym_event_pacing (
+  event_id          UUID        PRIMARY KEY REFERENCES public.gym_events(id) ON DELETE CASCADE,
+  benchmark_seconds INT         NOT NULL CHECK (benchmark_seconds > 0 AND benchmark_seconds <= 36000),
+  segments          INT         NOT NULL CHECK (segments BETWEEN 1 AND 20),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.gym_event_pacing IS
+  'V3-07: per-event pacing plan (benchmark finish + segments). Athlete target derived from Engine rating.';
+
+ALTER TABLE public.gym_event_pacing ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'gym_event_pacing'
+                 AND policyname = 'Gym people read their event pacing') THEN
+    CREATE POLICY "Gym people read their event pacing"
+      ON public.gym_event_pacing FOR SELECT TO authenticated
+      USING (EXISTS (
+        SELECT 1 FROM public.gym_events e
+        WHERE e.id = gym_event_pacing.event_id
+          AND (
+            public.is_platform_admin()
+            OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = e.gym_id)
+            OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = e.gym_id AND g.owner_id = auth.uid())
+          )
+      ));
+  END IF;
+END $$;
+
+-- Coach sets/updates the pacing plan (staff of the event's gym).
+CREATE OR REPLACE FUNCTION public.set_event_pacing(
+  p_event_id          uuid,
+  p_benchmark_seconds int,
+  p_segments          int
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM public.assert_can_manage_gym_event(p_event_id);
+  IF p_benchmark_seconds <= 0 OR p_benchmark_seconds > 36000 THEN
+    RAISE EXCEPTION 'bad_benchmark';
+  END IF;
+  IF p_segments < 1 OR p_segments > 20 THEN
+    RAISE EXCEPTION 'bad_segments';
+  END IF;
+
+  INSERT INTO public.gym_event_pacing (event_id, benchmark_seconds, segments, updated_at)
+  VALUES (p_event_id, p_benchmark_seconds, p_segments, NOW())
+  ON CONFLICT (event_id) DO UPDATE
+    SET benchmark_seconds = EXCLUDED.benchmark_seconds,
+        segments = EXCLUDED.segments,
+        updated_at = NOW();
+END;
+$$;
+
+-- The caller's personalized pacing for an event (scaled by their Engine rating).
+CREATE OR REPLACE FUNCTION public.my_event_pacing(p_event_id uuid)
+RETURNS TABLE (
+  benchmark_seconds       int,
+  segments                int,
+  engine                  numeric,
+  factor                  numeric,
+  personal_target_seconds int,
+  split_seconds           int
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH plan AS (
+    SELECT pc.benchmark_seconds, pc.segments
+    FROM public.gym_event_pacing pc WHERE pc.event_id = p_event_id
+  ),
+  eng AS (
+    SELECT COALESCE((SELECT rating_engine FROM public.profile_ratings WHERE user_id = auth.uid()), 50)::numeric AS engine
+  ),
+  calc AS (
+    SELECT p.benchmark_seconds, p.segments, e.engine,
+           greatest(0.75, least(1.4, 50.0 / greatest(e.engine, 1))) AS factor
+    FROM plan p CROSS JOIN eng e
+  )
+  SELECT benchmark_seconds,
+         segments,
+         round(engine, 1),
+         round(factor, 2),
+         round(benchmark_seconds * factor)::int AS personal_target_seconds,
+         round(benchmark_seconds * factor / segments)::int AS split_seconds
+  FROM calc;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_event_pacing(uuid, int, int) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.my_event_pacing(uuid) TO authenticated;


### PR DESCRIPTION
## What
The last V3 feature. A coach sets a **benchmark finish + segment count** on an event; each athlete sees a **personalized target + even splits**, scaled by their Engine rating.

- **Migration 043** — `gym_event_pacing` + `set_event_pacing` (staff) + `my_event_pacing` (per-caller). Transparent heuristic: `factor = clamp(50/engine, 0.75, 1.4)` → median athlete (rating 50) gets the benchmark, elites ~25% faster, beginners ~40% slower.
- **PacingCard** on the event detail: athlete sees target + splits + the basis; staff sets/edits the benchmark. service helpers + en/fr i18n.

## Smoke (API + Playwright)
- benchmark 12:00 / 3 segments, Engine 97 → **target 09:00, 03:00 × 3**, "a guide, not a limit" ✅
- `typecheck` / `lint` / 222 tests / `build` green.

## Honest scope note
This is a **v1 guide** (clearly labeled as such), not a physiology model. The issue flagged it "hardest, validate last" — recommend validating usefulness with the pilot box before deepening (segment-aware WOD specs, per-axis scaling, AMRAP rep targets).

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)