### PR TITLE
docs(v4,v5): draft V4 (gym management) + V5 (B2C premium) strategies

### DIFF
--- a/docs/V4_STRATEGY.md
+++ b/docs/V4_STRATEGY.md
@@ -22,9 +22,31 @@ This is the moment Truegrynd stops being an add-on and becomes the **system of r
 - None unify **management + competition + hybrid athletic identity** in one place. Truegrynd already owns the hard, differentiated half (verified ranking, judge, events, leagues, TV). Adding management is comparatively commoditized — but bundling it with the moat is what no incumbent can copy quickly.
 - The data flywheel: the schedule knows who trained, the WOD knows what they did, the passport knows how they progressed — **one graph**, not three exports.
 
-## 3. Scope — the "Gym management" nav group
+## 3. Innovation — what no incumbent can do
 
-V3 already shipped the PRO shell with a **"Gestion salle"** nav group whose items are placeholders (`soon`). V4 fills them in.
+Resawod / Peppy / Wodify are **cashier + booking** tools. Truegrynd holds three assets they don't: the **engagement graph** (streaks, activity, passport), **verified performance data** (judge/proof), and a **network of athletes across gyms**. That turns booking from a cold transaction into a retention + community engine. The headline:
+
+> **V4 is not "a booking tool with community bolted on" — it's a retention + community engine that also handles booking.**
+
+The differentiators (each = a real _"dommage que Resawod ne fasse pas ça"_):
+
+1. **🚨 Retention / churn-risk engine** _(owners' #1 pain; our structural edge)._ Incumbents tell you who paid; never _"these 8 members' attendance dropped 40% — they're about to churn."_ We already have the streak/activity/passport graph → surface an **at-risk dashboard** + auto re-engagement nudges. Gyms don't want a cashier, they want **retention**. This is the lead sales argument.
+2. **🔗 Booking ⇄ WOD ⇄ leaderboard loop.** Book the 18h → **see the day's WOD while booking** → attend → post your score → it lands on the **class leaderboard, validated by the coach on the floor**. One app, one chain; impossible when programming and booking are separate tools.
+3. **👥 Social booking (kills no-shows).** No-shows are the plague. We have rivals/factions: _"your rival booked 18h — join?"_, _"6 in, 2 from your faction."_ Attendance becomes social → accountability → fewer no-shows. Plus a **reputation-based waitlist** (chronic no-shows lose priority; reliable members auto-promoted).
+4. **🌍 Cross-gym drop-in network** _(the network effect no single-gym tool can copy)._ Every Truegrynd athlete has a passport and gyms live on the platform → a traveling athlete can **drop in at any Truegrynd gym**: discover, book, pay, and the host gym sees their **verified level**. Revenue for gyms + an acquisition loop. Resawod can't — each gym is a silo.
+5. **🎯 Coach class-prep view.** Resawod gives a list of names. We give the coach, per booked athlete: **level / scaling / recent scores / flagged injury** → he preps and scales the class intelligently.
+6. **🏠 The member home is a destination, not a chore.** Peppy is opened only to book (cold). Truegrynd is opened daily (leaderboard, rivals, passport) → **booking happens where members already are**. Engagement-led booking.
+
+**The 3 killers to lead with:** retention (1), the booking→WOD→leaderboard loop (2), the drop-in network (4).
+
+## 4. Scope — surfaces & the "Gym management" nav group
+
+**Two surfaces, split by role (this is the B2B2C nature):**
+
+- **🏋️ Coach / gym_admin → B2B app (`/pro`)** — _sets up_ the operation: schedule, capacity, membership plans, payments, sees bookings, runs check-in. This is the **"Gestion salle"** nav group V3 shipped as placeholders (`soon`).
+- **🧍 Member / athlete → B2C app (`/app`)** — _consumes_ it: a new **"Ma salle"** section (visible only to athletes with an `affiliated_gym_id`) where they see their gym's schedule, **book a class**, manage their membership, pay. The athlete is already in `/app` (posts scores) and already affiliated since V3-01.
+
+Same database (sessions, bookings), two screens by role. V4 fills the `/pro` management group **and** adds the `/app` member booking section.
 
 | Module              | What                                                                                   | Status after V3 |
 | ------------------- | -------------------------------------------------------------------------------------- | --------------- |
@@ -38,30 +60,33 @@ V3 already shipped the PRO shell with a **"Gestion salle"** nav group whose item
 
 Out of scope for V4 (keep lean): full accounting/exports, payroll, retail/POS, access-control hardware.
 
-## 4. Architecture notes
+## 5. Architecture notes
 
 - **Multi-tenant reuse:** everything keys off `gyms` + `profiles.affiliated_gym_id` (already in place since V3-01). New tables: `gym_classes` (schedule templates), `gym_sessions` (dated instances), `gym_bookings`, `gym_memberships` (plans) + `gym_member_subscriptions` (a member ↔ plan), `gym_checkins`. All gym-scoped via RLS like the V3 tables.
 - **Member payments = Stripe Connect.** V3 billing (#117) charges the _gym_ on the platform account. V4 needs the _gym to charge its members_ → each gym becomes a **Stripe Connect (Express) connected account**; Truegrynd optionally takes an application fee. This is the one genuinely new payment surface (the rest reuses the V3 plumbing — `callEdgeFunction`, webhook pattern).
 - **Booking integrity:** capacity + waitlist needs transactional booking (RPC `book_session` with row locking) to avoid overbooking. Reuse the SECURITY-DEFINER RPC pattern.
 - **Roles:** `gym_admin` manages plans/schedule/payments; `coach` runs the session (check-in, sees the roster); `athlete` books + pays. Gate via the existing `roles.ts` helpers.
 
-## 5. Delivery slices (proposed)
+## 6. Delivery slices (proposed)
 
-1. **Planning + class types** — schedule CRUD, recurring slots, coach assignment. (Read-only calendar for members first.)
-2. **Reservations** — booking + waitlist + cancellation + no-show, capacity-safe.
-3. **Memberships & passes** — gym defines plans; assign to members; track remaining credits / validity.
-4. **Member payments (Stripe Connect)** — onboard gym as connected account; charge memberships; webhook → member subscription status.
-5. **Check-in / attendance** — coach kiosk; ties booking → attendance → passport activity.
+1. **Planning + class types** — coach builds the schedule (`/pro`): recurring slots, coach, capacity, type. Members get a read-only weekly calendar in `/app` "Ma salle".
+2. **Reservations** — member books/cancels (`/app`) + waitlist + no-show, capacity-safe. Coach sees the roster per session with each athlete's level (differentiator #5).
+3. **Booking ⇄ WOD loop** — attach the day's WOD (Events) to the session; show it at booking; check-in → score → class leaderboard (differentiator #2).
+4. **Retention dashboard** — `/pro` at-risk-members view from the engagement graph + nudges (differentiator #1, the sales argument — pull earlier if it sells).
+5. **Memberships & passes** — gym defines plans; assign to members; track credits / validity.
+6. **Member payments (Stripe Connect)** — onboard gym as connected account; charge memberships; webhook → member subscription status.
+7. **Check-in / attendance** — coach kiosk; ties booking → attendance → passport activity.
+8. **Social booking + drop-in network** — rivals/faction nudges; reputation waitlist; cross-gym drop-in (differentiators #3, #4).
 
-Each slice ships behind the existing PRO subscription gate and the "Gestion salle" nav group going `soon → live`.
+Management slices ship behind the PRO subscription gate (`/pro`, "Gestion salle" `soon → live`); member-facing slices ship in `/app` "Ma salle" for affiliated athletes.
 
-## 6. Open questions (to decide before building)
+## 7. Open questions (to decide before building)
 
 - **Stripe Connect model:** application fee % vs flat? KYB already done at gym creation (SIREN/SIRET) — does it satisfy Connect onboarding or is a separate Stripe onboarding required?
 - **Booking model granularity:** per-class capacity only, or per-equipment/lane (rower, rig) booking too?
 - **Migration from incumbents:** import members/plans from Peppy/Resawod (CSV)? Critical for switching cost / sales.
 - **Pricing impact:** does management stay in the $100/mo GYM PRO, or a higher tier? (Replacing Resawod ≈ €100–150/mo of value — room to raise ACV.)
 
-## 7. Success criteria
+## 8. Success criteria
 
 A pilot box (Igor's) **drops Peppy** and runs its full week on Truegrynd: schedule published, members booking, memberships billed, attendance tracked — while the same app runs the WODs, leaderboards and leagues. One product, one login, one data graph.

--- a/docs/V4_STRATEGY.md
+++ b/docs/V4_STRATEGY.md
@@ -61,6 +61,8 @@ The differentiators below (each = a real _"dommage que Resawod ne fasse pas ça"
 
 Same database (sessions, bookings), two screens by role. V4 fills the `/pro` management group **and** adds the `/app` member booking section.
 
+**V4 is all web.** The coach's on-the-floor tasks (Judge, check-in, today's roster) will move into a **native app later** — one role-aware Expo app covering athlete + coach-floor, while the `/pro` heavy back-office (and MOD/`/admin`) stays web. That's **V6, not before the MVP is launched** — see [V6_STRATEGY.md](./V6_STRATEGY.md).
+
 | Module              | What                                                                                   | Status after V3 |
 | ------------------- | -------------------------------------------------------------------------------------- | --------------- |
 | **Planning**        | Class schedule: recurring slots, coaches, capacity, types (WOD, open gym, Hyrox, etc.) | `soon`          |

--- a/docs/V4_STRATEGY.md
+++ b/docs/V4_STRATEGY.md
@@ -28,7 +28,20 @@ Resawod / Peppy / Wodify are **cashier + booking** tools. Truegrynd holds three 
 
 > **V4 is not "a booking tool with community bolted on" — it's a retention + community engine that also handles booking.**
 
-The differentiators (each = a real _"dommage que Resawod ne fasse pas ça"_):
+### 3.1 What users actually complain about (sourced)
+
+From Capterra/G2/Trustpilot reviews and FR comparators (Reddit itself is crawl-blocked). Note: **Peppy** (peppy.cool, 300+ FR boxes) is actually _well_ rated on booking — so we don't beat it head-on on booking; we win by **unifying** + being strong where the whole category is weak.
+
+| Complaint (real)                                                                                                                                                                                                                                            | Source                                         | Our answer                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **"All-in-one" that explodes into paid modules** — Wodify _"pricey to add features"_; Resawod's WOD/programming module (Trhade) **not in Starter/Pro**; Crossbook: _"49€ → 289€/mo with add-ons"_; Zen Planner forces an expensive payment processor + fees | Capterra (Wodify), crossbook, G2 (Zen Planner) | Genuinely one product + **transparent pricing**; competition layer is core, not an add-on      |
+| **Performance/score tracking is the category's weak spot** — Resawod (FR leader): _"manque l'analyse complète des scores des athlètes"_; generalist tools _"pas spécialisés CrossFit (RX/Scaled, WODs, benchmarks natifs)"_                                 | crossbook comparator                           | **Our native strength** — verified ranking, judge, benchmarks, passport. The data-backed wedge |
+| **Juggling 2–3 tools** — _"jonglage entre 3 outils, ~2h/semaine perdues"_                                                                                                                                                                                   | crossbook                                      | Unify booking + WOD + scores in one app (the n=1 wedge, at industry scale)                     |
+| **Booking app crashes / unintuitive** → silent unsubscribes; slow/foreign support                                                                                                                                                                           | crossbook, Zen Planner reviews                 | Engagement-led booking in an app members already open daily; native FR                         |
+| **Multi-gym is clunky** — Zen Planner: _"toggling between gyms should be one profile"_                                                                                                                                                                      | G2 (Zen Planner)                               | One portable athlete passport across all gyms → the drop-in network (#4)                       |
+| **Billing nightmares** — charged after cancellation, support unresponsive                                                                                                                                                                                   | Trustpilot / Capterra                          | Stripe-native, clean dunning; reuse the V3 billing plumbing                                    |
+
+The differentiators below (each = a real _"dommage que Resawod ne fasse pas ça"_) map onto these:
 
 1. **🚨 Retention / churn-risk engine** _(owners' #1 pain; our structural edge)._ Incumbents tell you who paid; never _"these 8 members' attendance dropped 40% — they're about to churn."_ We already have the streak/activity/passport graph → surface an **at-risk dashboard** + auto re-engagement nudges. Gyms don't want a cashier, they want **retention**. This is the lead sales argument.
 2. **🔗 Booking ⇄ WOD ⇄ leaderboard loop.** Book the 18h → **see the day's WOD while booking** → attend → post your score → it lands on the **class leaderboard, validated by the coach on the floor**. One app, one chain; impossible when programming and booking are separate tools.
@@ -90,3 +103,15 @@ Management slices ship behind the PRO subscription gate (`/pro`, "Gestion salle"
 ## 8. Success criteria
 
 A pilot box (Igor's) **drops Peppy** and runs its full week on Truegrynd: schedule published, members booking, memberships billed, attendance tracked — while the same app runs the WODs, leaderboards and leagues. One product, one login, one data graph.
+
+---
+
+## Sources (competitor pain points)
+
+- [Wodify reviews — Capterra](https://www.capterra.com/p/159663/Wodify/reviews/)
+- [Zen Planner reviews — Capterra](https://www.capterra.com/p/134351/Zen-Planner/reviews/) · [G2](https://www.g2.com/products/zen-planner/reviews)
+- [Resawod / Deciplus / Zen Planner comparator — crossbook.eu](https://www.crossbook.eu/logiciel-de-gestion-box-crossfit-comment-choisir-le-bon-outil-en-2026-comparatif-resawod-deciplus-zen-planner/)
+- [« Pourquoi ton logiciel de gestion de box te complique la vie » — crossbook.eu](https://www.crossbook.eu/pourquoi-ton-logiciel-de-gestion-de-box-te-complique-la-vie/)
+- [Peppy (peppy.cool)](https://www.peppy.cool/) — the booking tool Igor's box uses; well rated, no native competition layer
+
+> Reddit threads were not directly accessible (crawl-blocked); the above aggregators + comparators reflect the same complaints.

--- a/docs/V4_STRATEGY.md
+++ b/docs/V4_STRATEGY.md
@@ -1,0 +1,67 @@
+# Truegrynd V4 Strategy — The Gym Management Layer (Own the Daily Workflow)
+
+> Draft — started 24 June 2026. Sibling of [V3_STRATEGY.md](./V3_STRATEGY.md) (competition layer) and [V5_STRATEGY.md](./V5_STRATEGY.md) (B2C premium).
+> Tracking epic: [#140](https://github.com/igorms-pro/truegrynd/issues/140).
+
+## 1. Executive Summary & Thesis
+
+V3 made Truegrynd the **competition + community layer** for hybrid/functional gyms, deliberately operating _alongside_ existing booking systems. V4 is the strategic escalation: **own the daily management workflow too** — planning, reservations, memberships and member payments — so a box runs its whole operation on Truegrynd instead of stitching two tools together.
+
+**The wedge (n=1, the strongest signal in the project):** Igor's own CrossFit box runs on **Peppy** (management / booking / billing) **+ Hustle Up** (WOD / leaderboard) — two separate tools that don't talk to each other → _"ça me rend fou."_ Every hybrid box in Europe lives this same split: an administrative booking tool with zero community vibe, plus a separate WOD/score tool. **Truegrynd V4 collapses the two into one product.**
+
+**The shift from V3 → V4:**
+
+- V3: _"We own competition; coexist with your booking tool."_
+- V4: _"Replace your booking tool. One app for the WOD **and** the schedule, the leaderboard **and** the membership."_
+
+This is the moment Truegrynd stops being an add-on and becomes the **system of record** for the gym — which is what makes the $100/mo subscription sticky and raises the switching cost.
+
+## 2. Why this is defensible (vs Resawod / Deciplus / Wodify)
+
+- Incumbents (Resawod, Deciplus, Xplor) are **administrative**: booking + invoicing, corporate, no athletic identity, no community. US tools (Wodify, SugarWOD) are heavy, CrossFit-only, expensive.
+- None unify **management + competition + hybrid athletic identity** in one place. Truegrynd already owns the hard, differentiated half (verified ranking, judge, events, leagues, TV). Adding management is comparatively commoditized — but bundling it with the moat is what no incumbent can copy quickly.
+- The data flywheel: the schedule knows who trained, the WOD knows what they did, the passport knows how they progressed — **one graph**, not three exports.
+
+## 3. Scope — the "Gym management" nav group
+
+V3 already shipped the PRO shell with a **"Gestion salle"** nav group whose items are placeholders (`soon`). V4 fills them in.
+
+| Module              | What                                                                                   | Status after V3 |
+| ------------------- | -------------------------------------------------------------------------------------- | --------------- |
+| **Planning**        | Class schedule: recurring slots, coaches, capacity, types (WOD, open gym, Hyrox, etc.) | `soon`          |
+| **Reservations**    | Member booking, waitlist, cancellation window, no-show tracking                        | (new)           |
+| **Members**         | Roster — **shipped in V3** (extend with membership status, attendance)                 | 🟢 live         |
+| **Subscriptions**   | The gym's own membership plans/passes (e.g. unlimited, 10-pack), assigned to members   | `soon`          |
+| **Member payments** | The gym collects from its members (Stripe Connect — see §4)                            | (new)           |
+| **Check-in**        | Attendance at a session (kiosk / coach taps in present members)                        | (new)           |
+| **Settings**        | Gym profile, opening hours, class types, branding                                      | `soon`          |
+
+Out of scope for V4 (keep lean): full accounting/exports, payroll, retail/POS, access-control hardware.
+
+## 4. Architecture notes
+
+- **Multi-tenant reuse:** everything keys off `gyms` + `profiles.affiliated_gym_id` (already in place since V3-01). New tables: `gym_classes` (schedule templates), `gym_sessions` (dated instances), `gym_bookings`, `gym_memberships` (plans) + `gym_member_subscriptions` (a member ↔ plan), `gym_checkins`. All gym-scoped via RLS like the V3 tables.
+- **Member payments = Stripe Connect.** V3 billing (#117) charges the _gym_ on the platform account. V4 needs the _gym to charge its members_ → each gym becomes a **Stripe Connect (Express) connected account**; Truegrynd optionally takes an application fee. This is the one genuinely new payment surface (the rest reuses the V3 plumbing — `callEdgeFunction`, webhook pattern).
+- **Booking integrity:** capacity + waitlist needs transactional booking (RPC `book_session` with row locking) to avoid overbooking. Reuse the SECURITY-DEFINER RPC pattern.
+- **Roles:** `gym_admin` manages plans/schedule/payments; `coach` runs the session (check-in, sees the roster); `athlete` books + pays. Gate via the existing `roles.ts` helpers.
+
+## 5. Delivery slices (proposed)
+
+1. **Planning + class types** — schedule CRUD, recurring slots, coach assignment. (Read-only calendar for members first.)
+2. **Reservations** — booking + waitlist + cancellation + no-show, capacity-safe.
+3. **Memberships & passes** — gym defines plans; assign to members; track remaining credits / validity.
+4. **Member payments (Stripe Connect)** — onboard gym as connected account; charge memberships; webhook → member subscription status.
+5. **Check-in / attendance** — coach kiosk; ties booking → attendance → passport activity.
+
+Each slice ships behind the existing PRO subscription gate and the "Gestion salle" nav group going `soon → live`.
+
+## 6. Open questions (to decide before building)
+
+- **Stripe Connect model:** application fee % vs flat? KYB already done at gym creation (SIREN/SIRET) — does it satisfy Connect onboarding or is a separate Stripe onboarding required?
+- **Booking model granularity:** per-class capacity only, or per-equipment/lane (rower, rig) booking too?
+- **Migration from incumbents:** import members/plans from Peppy/Resawod (CSV)? Critical for switching cost / sales.
+- **Pricing impact:** does management stay in the $100/mo GYM PRO, or a higher tier? (Replacing Resawod ≈ €100–150/mo of value — room to raise ACV.)
+
+## 7. Success criteria
+
+A pilot box (Igor's) **drops Peppy** and runs its full week on Truegrynd: schedule published, members booking, memberships billed, attendance tracked — while the same app runs the WODs, leaderboards and leagues. One product, one login, one data graph.

--- a/docs/V5_STRATEGY.md
+++ b/docs/V5_STRATEGY.md
@@ -16,7 +16,7 @@ The B2C arena has always been the **free acquisition engine** that feeds B2B gym
 > **You never pay to _do_ or _track_ your sport. You pay for status, depth and credibility.**
 > If a feature helps you **train / grow / share** → free, forever. If it helps you **analyze yourself / prove yourself / stand out** → premium.
 
-This is a **brand stance**, not just a pricing rule — and it's aimed squarely at where Strava is bleeding trust (see §6). Strava is _"paywalling features one piece at a time"_ (Year in Sport now €80/yr); we do the opposite. We never paywall posting scores, the arena, leaderboards, factions, rivals, weeklies, finisher-card sharing. **Monetize smart, not greedy:** gating the engine kills the funnel that sells gyms — and betrays the athlete.
+This is a **brand stance**, not just a pricing rule — and it's aimed squarely at where Strava is bleeding trust (see §4). Strava is _"paywalling features one piece at a time"_ (Year in Sport now €80/yr); we do the opposite. We never paywall posting scores, the arena, leaderboards, factions, rivals, weeklies, finisher-card sharing. **Monetize smart, not greedy:** gating the engine kills the funnel that sells gyms — and betrays the athlete.
 
 The cheap interim B2C monetization (cosmetics) already respects this: it sells _look_, never access.
 

--- a/docs/V5_STRATEGY.md
+++ b/docs/V5_STRATEGY.md
@@ -1,0 +1,62 @@
+# Truegrynd V5 Strategy — B2C Premium ("Verified Athlete")
+
+> Draft — started 24 June 2026. Sibling of [V3_STRATEGY.md](./V3_STRATEGY.md) (competition) and [V4_STRATEGY.md](./V4_STRATEGY.md) (gym management).
+> Tracking epic: [#141](https://github.com/igorms-pro/truegrynd/issues/141).
+
+## 1. Executive Summary & Thesis
+
+The B2C arena has always been the **free acquisition engine** that feeds B2B gym sales. V5 adds a **second, independent revenue line**: a premium tier for serious individual athletes — once there is enough scale to convert.
+
+**The model = Strava's, with a twist Strava can't copy.** Keep the social/competitive core free (it's the growth engine); sell **depth + status** on top. The twist: Truegrynd's premium is anchored to the **verified-ranking moat** (judge / video / proof levels). "Verified Athlete" is a credential, not just analytics.
+
+**Timing:** V5 ships **after scale** (a large free base worth converting). Building it earlier monetizes nobody and adds a payment surface to maintain. Until then, interest is already captured (the cosmetics teaser fires a PostHog signal).
+
+## 2. The Golden Rule
+
+> **Premium sells data and status, never access.**
+> If a feature helps you **grow / share** → free. If it helps you **analyze yourself / stand out** → premium.
+
+We never paywall posting scores, the arena, leaderboards, factions, rivals, weeklies, finisher-card sharing. Gating the engine kills the funnel that sells gyms.
+
+## 3. The tier — "Verified Athlete"
+
+**🆓 Free (the engine, never gated):** post scores, arena, leaderboards, factions/clans, rivals, weeklies, proof submission, respects, finisher-card sharing.
+
+**⭐ Premium (depth + status, on top):**
+
+1. **Verified Athlete (the moat)**
+   - Verified badge on profile + finisher cards.
+   - Access to **verified-only rankings** (filter the leaderboard to judge/video-verified scores) — the Hyrox/Athlinks credibility, for subscribers.
+   - Enriched public passport (full proof history).
+2. **Analytics (the "Strava premium")**
+   - Rating evolution over time (Engine / Power / Strength / Grit).
+   - Per-movement progression, PR history, percentile vs division / region / age.
+   - Deep head-to-head vs rivals.
+3. **Full history** — unlimited score history + export (free = last N).
+4. **Cosmetics included** — finisher frames (neon / gold / carbon) come _with_ the subscription (see §5), boosting perceived value.
+
+## 4. Pricing & mechanics
+
+- Reference: Strava ≈ €12/mo. Target lower to convert wide early: **~€5–7/mo or ~€50/yr**.
+- Stripe **subscription**, reusing the V3 plumbing (`stripe-checkout` / `stripe-webhook` patterns, `callEdgeFunction` helper). The athlete is the customer (vs the gym in V3).
+- `profiles` (or a `user_subscriptions` table) carries the premium status; a `isPremium()` helper gates premium-only UI. Soft, never blocking the free core.
+
+## 5. Cosmetics (refold of ex-#119)
+
+The original plan was à-la-carte one-time cosmetic purchases (#119). **Decision (24 June): fold cosmetics into the V5 premium instead** — one payment system (the subscription), higher perceived value, no micro-transaction shop to maintain.
+
+- Rendering already exists: `drawFinisherCard` + `buildFinisherCardOptions` support `frameStyle` (neon/gold/carbon); a teaser + PostHog interest event are live.
+- Remaining: a `user_cosmetics` (or a derived "premium unlocks all frames") grant + a frame selector on the finish page.
+- Optional later: keep à-la-carte purchase as an alternative path for non-subscribers (coexist), if data justifies it.
+
+## 6. Sequencing & gates
+
+- **Do not build until there is scale.** Trigger = a meaningful free MAU base + the PostHog cosmetics/verified interest signals crossing a threshold (cf [MONETIZATION_V2-12.md](./MONETIZATION_V2-12.md) §2.2).
+- Comes **after** V4 in priority: B2B gyms (V3 live) + management (V4) are higher-ACV and the validated wedge; B2C premium is the long-tail upside.
+
+## 7. Open questions
+
+- Premium status storage: column on `profiles` vs dedicated `user_subscriptions` table (cleaner for history/trials).
+- Free trial length? Annual discount?
+- Which analytics are genuinely worth paying for — validate with power users before building the full dashboard.
+- Does "verified-only ranking" stay premium, or is a teaser version free (to advertise the moat)?

--- a/docs/V5_STRATEGY.md
+++ b/docs/V5_STRATEGY.md
@@ -11,12 +11,14 @@ The B2C arena has always been the **free acquisition engine** that feeds B2B gym
 
 **Timing:** V5 ships **after scale** (a large free base worth converting). Building it earlier monetizes nobody and adds a payment surface to maintain. Until then, interest is already captured (the cosmetics teaser fires a PostHog signal).
 
-## 2. The Golden Rule
+## 2. The Golden Rule — the anti "pay €XX to do your sport"
 
-> **Premium sells data and status, never access.**
-> If a feature helps you **grow / share** → free. If it helps you **analyze yourself / stand out** → premium.
+> **You never pay to _do_ or _track_ your sport. You pay for status, depth and credibility.**
+> If a feature helps you **train / grow / share** → free, forever. If it helps you **analyze yourself / prove yourself / stand out** → premium.
 
-We never paywall posting scores, the arena, leaderboards, factions, rivals, weeklies, finisher-card sharing. Gating the engine kills the funnel that sells gyms.
+This is a **brand stance**, not just a pricing rule — and it's aimed squarely at where Strava is bleeding trust (see §6). Strava is _"paywalling features one piece at a time"_ (Year in Sport now €80/yr); we do the opposite. We never paywall posting scores, the arena, leaderboards, factions, rivals, weeklies, finisher-card sharing. **Monetize smart, not greedy:** gating the engine kills the funnel that sells gyms — and betrays the athlete.
+
+The cheap interim B2C monetization (cosmetics) already respects this: it sells _look_, never access.
 
 ## 3. The tier — "Verified Athlete"
 
@@ -24,24 +26,39 @@ We never paywall posting scores, the arena, leaderboards, factions, rivals, week
 
 **⭐ Premium (depth + status, on top):**
 
-1. **Verified Athlete (the moat)**
+1. **Verified Athlete — the verified athletic CV (THE hook)**
+   - A **shareable public profile of your verified PRs** (Fran, Murph, 1RM, Hyrox time, benchmarks) **with the proof level** (judge/video). In a world of fake PRs, _you_ certify. Useful for competition seeding, dropping in at another box (the coach sees your real level), coaching applications, bragging _with credibility_.
    - Verified badge on profile + finisher cards.
    - Access to **verified-only rankings** (filter the leaderboard to judge/video-verified scores) — the Hyrox/Athlinks credibility, for subscribers.
    - Enriched public passport (full proof history).
-2. **Analytics (the "Strava premium")**
-   - Rating evolution over time (Engine / Power / Strength / Grit).
+2. **Analytics — graphs (web, on data we already have)**
+   - Rating evolution over time (Engine / Power / Strength / Grit) — `profile_rating_history` already exists.
    - Per-movement progression, PR history, percentile vs division / region / age.
    - Deep head-to-head vs rivals.
+   - _All from our own data — no wearable/cardio graphs here (that's V6)._
 3. **Full history** — unlimited score history + export (free = last N).
-4. **Cosmetics included** — finisher frames (neon / gold / carbon) come _with_ the subscription (see §5), boosting perceived value.
+4. **Cosmetics included** — finisher frames (neon / gold / carbon) come _with_ the subscription (see §6), boosting perceived value.
 
-## 4. Pricing & mechanics
+## 4. Competitive wedge vs Strava (where they bleed, we win)
+
+Strava is strong (passive capture, segments, the social feed) — we don't fight it on frequency. We attack its open wounds, all aligned with our moat:
+
+| Strava's pain (sourced)                                                                                          | Our wedge                                                                                                                |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Paywall creep / broken trust** — Year in Sport now €80/yr; _"paywalling features one piece at a time"_, opaque | **Anti pay-to-do-sport**: the engine is free forever, pricing transparent. _"Strava paywalled your year? Ours is free."_ |
+| **Fake / cheated KOMs** — GPS spoofing, e-bikes, cars; leaderboards aren't trusted                               | **Verified rankings** (judge/video) — our moat aimed straight at their biggest credibility hole                          |
+| **Cardio-only** — no home for strength / CrossFit / Hyrox                                                        | **The home of the hybrid / strength athlete**                                                                            |
+| **Walled-garden API** (Nov 2024: killed 3rd-party apps, banned AI use, can't show others' data)                  | **Open**: data flows in (direct Garmin in V6), we don't lock the athlete in; not dependent on their hostile API          |
+
+**Positioning one-liner:** Strava = cardio, unverified, walled, increasingly paywalled. **Truegrynd = hybrid/strength, verified, open, free engine.**
+
+## 5. Pricing & mechanics
 
 - Reference: Strava ≈ €12/mo. Target lower to convert wide early: **~€5–7/mo or ~€50/yr**.
 - Stripe **subscription**, reusing the V3 plumbing (`stripe-checkout` / `stripe-webhook` patterns, `callEdgeFunction` helper). The athlete is the customer (vs the gym in V3).
 - `profiles` (or a `user_subscriptions` table) carries the premium status; a `isPremium()` helper gates premium-only UI. Soft, never blocking the free core.
 
-## 5. Cosmetics (refold of ex-#119)
+## 6. Cosmetics (refold of ex-#119)
 
 The original plan was à-la-carte one-time cosmetic purchases (#119). **Decision (24 June): fold cosmetics into the V5 premium instead** — one payment system (the subscription), higher perceived value, no micro-transaction shop to maintain.
 
@@ -49,14 +66,25 @@ The original plan was à-la-carte one-time cosmetic purchases (#119). **Decision
 - Remaining: a `user_cosmetics` (or a derived "premium unlocks all frames") grant + a frame selector on the finish page.
 - Optional later: keep à-la-carte purchase as an alternative path for non-subscribers (coexist), if data justifies it.
 
-## 6. Sequencing & gates
+## 7. Sequencing & scope
 
+- **Web-only, on data we already have.** Everything here (verified CV, ranking filter, rating/PR graphs, cosmetics) is buildable in the web app from existing tables (`scores`, `profile_ratings`, `profile_rating_history`). **No native app, no wearable connectors.**
+- **Out of scope → V6** ([V6_STRATEGY.md](./V6_STRATEGY.md)): direct wearable connectors (Garmin first, server-to-server), passive cardio "genome", and Apple Health (which forces a native app). That's the "play Strava's frequency game" phase, separate from this credibility/depth tier.
 - **Do not build until there is scale.** Trigger = a meaningful free MAU base + the PostHog cosmetics/verified interest signals crossing a threshold (cf [MONETIZATION_V2-12.md](./MONETIZATION_V2-12.md) §2.2).
 - Comes **after** V4 in priority: B2B gyms (V3 live) + management (V4) are higher-ACV and the validated wedge; B2C premium is the long-tail upside.
 
-## 7. Open questions
+## 8. Open questions
 
 - Premium status storage: column on `profiles` vs dedicated `user_subscriptions` table (cleaner for history/trials).
 - Free trial length? Annual discount?
 - Which analytics are genuinely worth paying for — validate with power users before building the full dashboard.
 - Does "verified-only ranking" stay premium, or is a teaser version free (to advertise the moat)?
+- Is the **public verified CV** premium, or free-but-enriched-in-premium? (A free public CV is viral / acquisition — lean free, enrich in premium.)
+
+---
+
+## Sources (Strava pain points)
+
+- [Year in Sport behind €80 paywall — T3](https://www.t3.com/tech/dear-strava-we-have-a-paywall-problem-thats-gone-a-step-too-far) · [Slashdot](https://news.slashdot.org/story/25/12/19/2158235/strava-puts-popular-year-in-sport-recap-behind-an-80-paywall)
+- [API lockdown kills 3rd-party apps — DCRainmaker](https://www.dcrainmaker.com/2024/11/stravas-changes-to-kill-off-apps.html) · [Strava API agreement update](https://press.strava.com/articles/updates-to-stravas-api-agreement)
+- Fake/cheated KOMs (GPS spoofing, e-bikes) — long-standing community grievance.

--- a/docs/V6_STRATEGY.md
+++ b/docs/V6_STRATEGY.md
@@ -1,37 +1,78 @@
-# Truegrynd V6 Strategy — Wearable Connectors & the Passive Hybrid Genome
+# Truegrynd V6 Strategy — Native App & Wearable Connectors (the Mobile Era)
 
-> Draft — started 24 June 2026. Follows [V5_STRATEGY.md](./V5_STRATEGY.md) (B2C premium on existing data).
+> Draft — started 24 June 2026. Follows [V4_STRATEGY.md](./V4_STRATEGY.md) (gym management) and [V5_STRATEGY.md](./V5_STRATEGY.md) (B2C premium, web).
 > Epic: _to create._
+>
+> ⏱️ **Hard rule: nothing here ships before the MVP is launched & validated with the pilot box.** V3 (live) + V4 (management) + V5 (premium) are all **web** and come first. V6 is the mobile/native era, after product–market signal.
 
 ## 1. Thesis
 
-V5 monetizes the data we already have (verified WOD/strength). V6 adds the **other half of the hybrid athlete: passive cardio**, by ingesting wearables — **directly**, like Strava does from Garmin. This is what lets Truegrynd _play Strava's frequency game_ while keeping the verified moat Strava lacks.
+Two big mobile moves, related but distinct:
 
-> Strava sees only **cardio**. Wodify sees only the **gym**. With V6, Truegrynd sees **both** → the complete hybrid-athlete genome (passive cardio + verified strength). Nobody else has this.
+1. **A true native app (Expo / React Native)** — for the daily, on-the-go, push-driven experience (athletes _and_ coaches on the floor).
+2. **Wearable connectors (Garmin first)** — ingest passive cardio → the complete hybrid genome (passive cardio + verified strength). Lets us play Strava's frequency game while keeping the verified moat.
 
-## 2. Direct connectors — no Strava middleman
+> Strava sees only **cardio**; Wodify only the **gym**. V6 gives Truegrynd **both** + native push + verified ranking. Nobody else has all of it.
 
-We pull from the **devices directly**, never via a competitor's (now hostile) API.
+## 2. The 3 surfaces (recap — who uses what)
 
-- **Garmin first** — server-to-server: athlete connects their Garmin account (OAuth), Garmin **pushes** activities to a Truegrynd webhook (Garmin Health/Connect API "push/ping"). Same mechanism Garmin already uses to feed Strava. **No native app needed.** Requires Garmin developer-program approval.
-- **Then** Whoop / Coros / Polar — each has its own direct API (server-side, web is fine). Whoop is big in CrossFit (strain/recovery).
-- **Apple Health (HealthKit)** — iOS-native only → **requires a native/companion mobile app** (Capacitor/React Native). This is the trigger that justifies going native. Comes last.
-- **Strava: out.** It's a competitor with a locked-down API (Nov 2024). We don't depend on it.
+| Surface              | Who                | What                                                         | Role                |
+| -------------------- | ------------------ | ------------------------------------------------------------ | ------------------- |
+| **`/app`**           | everyone (athlete) | arena, passport, book classes, social                        | `athlete`           |
+| **`/pro`**           | coach / gym owner  | Judge, Events, TV, Leagues, Members, Billing, planning/mgmt  | `coach`/`gym_admin` |
+| **`MOD` (`/admin`)** | **you** (platform) | UGC/challenge moderation, proof audits, AI triage, gym leads | `platform_admin`    |
 
-## 3. The two-tier data model (never mix)
+Two _different_ validations to keep distinct: **MOD validates platform content** (user-submitted challenges/proofs); **/pro Judge validates a gym's members' scores**.
 
-1. **Tracked (passive, unverified)** ← wearables. Feeds the **feed, streaks, frequency, the cardio genome**, engagement. The "Strava-like" layer.
-2. **Verified (judge/video)** ← WOD/lifts. Feeds the **ranking, leagues, the credible CV**. The moat.
+## 3. Native app — one role-aware app, not two
 
-→ Passive boosts engagement; verified keeps credibility. **Passive data never enters a competitive ranking** (or is clearly flagged unverified). Keeping these separate is what protects the moat.
+**Decision: ONE native app (Expo), role-aware — not two apps.** The coach _is_ also an athlete (trains, posts scores) → one identity, one login, one app; the app reveals coach tools when the role allows (exactly like web shows `/pro` to staff today).
 
-## 4. Scope & sequencing
+| Surface                                                                                             | Where it lives in the mobile era                                           |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Athlete (`/app`)**                                                                                | **Native (Expo)** — daily use, push, store presence                        |
+| **Coach floor tasks** (Judge, check-in, today's roster, alerts)                                     | **Native** — same app, a "Coach" mode/tab when `role ∈ {coach, gym_admin}` |
+| **`/pro` heavy back-office** (planning builder, memberships, billing, reports, retention dashboard) | **stays Web** — data-dense, desktop                                        |
+| **MOD / `/admin`** (you)                                                                            | **stays Web** — your heavy back-office, desktop only, never native         |
 
-- Big undertaking (per-provider OAuth + webhooks + data normalization; Apple Health forces native). A **pillar phase**, after V4 (gym management) and V5 (premium on existing data).
-- Likely bundled into / unlocks part of the V5 premium ("connect your watch, see your full genome").
+→ **Native (Expo) = athlete + coach-on-the-floor. Web = `/pro` heavy + MOD.** Split by _moment of use_, not by role.
 
-## 5. Open questions
+### Why Expo (not Capacitor)
 
-- Which provider first beyond Garmin (Whoop given CrossFit overlap)?
-- Native app: Capacitor wrapper of the web app, or React Native rebuild?
-- Does passive cardio feed any (clearly-unverified) rating axis, or stay purely engagement/display?
+We want **strong = true native** (we're competing with Strava's polished native app; a WebView would feel second-rate). Expo = true native UI + best-in-class push + OTA updates.
+
+- **Cost (be honest):** the mobile UI is **rewritten** in React Native — you can't reuse the Next.js/Tailwind web components.
+- **Mitigation = monorepo with a shared core:** `packages/core` (Supabase client, services, types, Zod, scoring/rating) shared by `apps/web` (Next.js) and `apps/mobile` (Expo). Write logic once; only the UI layer differs. The `/pro` heavy back-office and MOD stay web — not rewritten.
+
+### Push path
+
+- **Interim (cheap, no app):** PWA web push — works Android + iOS 16.4+ (installed PWA). Good to validate the push need before committing.
+- **Native:** Expo Notifications (excellent). Push is the real ROI of going native: booking reminders, waitlist-opened, "your rival posted", at-risk nudges → retention.
+
+## 4. Wearable connectors — direct, no Strava middleman
+
+- **Garmin first** — server-to-server: athlete connects Garmin (OAuth), Garmin **pushes** activities to a Truegrynd webhook. Same mechanism Garmin uses to feed Strava. **No native app needed** (works with the web/server). Requires Garmin developer-program approval.
+- **Then** Whoop / Coros / Polar — own direct APIs, server-side.
+- **Apple Health (HealthKit)** — iOS-native only → **needs the native app** (§3). Comes after the Expo app exists.
+- **Strava: out** — competitor, locked-down API (Nov 2024). Not a dependency.
+
+### Two-tier data model (never mix)
+
+1. **Tracked (passive, unverified)** ← wearables → feed, streaks, frequency, cardio genome, engagement (the Strava-like layer).
+2. **Verified (judge/video)** ← WOD/lifts → ranking, leagues, the credible CV (the moat).
+   → Passive **never** enters a competitive ranking (or is clearly flagged). Keeping them separate protects the moat.
+
+## 5. Sequencing
+
+1. **MVP first (web).** V3 live → V4 management → V5 premium. **Do not start V6 before the MVP is out and validated with the pilot box.**
+2. **PWA push** to validate the push need (cheap).
+3. **Expo native app** (athlete + coach-floor) — monorepo, shared core; web keeps `/pro` heavy + MOD. Trigger = push ROI is proven and MVP is launched.
+4. **Garmin connector** (web/server, can run in parallel — doesn't need native).
+5. **Apple Health + the rest** once native is live.
+
+## 6. Open questions
+
+- Monorepo tooling (Turborepo / Nx) and how much core is genuinely shareable.
+- Expo + Supabase auth/session sharing with the web session model.
+- Garmin vs Whoop first (Whoop has strong CrossFit overlap).
+- Does passive cardio feed any clearly-unverified rating axis, or stay display-only?

--- a/docs/V6_STRATEGY.md
+++ b/docs/V6_STRATEGY.md
@@ -1,0 +1,37 @@
+# Truegrynd V6 Strategy — Wearable Connectors & the Passive Hybrid Genome
+
+> Draft — started 24 June 2026. Follows [V5_STRATEGY.md](./V5_STRATEGY.md) (B2C premium on existing data).
+> Epic: _to create._
+
+## 1. Thesis
+
+V5 monetizes the data we already have (verified WOD/strength). V6 adds the **other half of the hybrid athlete: passive cardio**, by ingesting wearables — **directly**, like Strava does from Garmin. This is what lets Truegrynd _play Strava's frequency game_ while keeping the verified moat Strava lacks.
+
+> Strava sees only **cardio**. Wodify sees only the **gym**. With V6, Truegrynd sees **both** → the complete hybrid-athlete genome (passive cardio + verified strength). Nobody else has this.
+
+## 2. Direct connectors — no Strava middleman
+
+We pull from the **devices directly**, never via a competitor's (now hostile) API.
+
+- **Garmin first** — server-to-server: athlete connects their Garmin account (OAuth), Garmin **pushes** activities to a Truegrynd webhook (Garmin Health/Connect API "push/ping"). Same mechanism Garmin already uses to feed Strava. **No native app needed.** Requires Garmin developer-program approval.
+- **Then** Whoop / Coros / Polar — each has its own direct API (server-side, web is fine). Whoop is big in CrossFit (strain/recovery).
+- **Apple Health (HealthKit)** — iOS-native only → **requires a native/companion mobile app** (Capacitor/React Native). This is the trigger that justifies going native. Comes last.
+- **Strava: out.** It's a competitor with a locked-down API (Nov 2024). We don't depend on it.
+
+## 3. The two-tier data model (never mix)
+
+1. **Tracked (passive, unverified)** ← wearables. Feeds the **feed, streaks, frequency, the cardio genome**, engagement. The "Strava-like" layer.
+2. **Verified (judge/video)** ← WOD/lifts. Feeds the **ranking, leagues, the credible CV**. The moat.
+
+→ Passive boosts engagement; verified keeps credibility. **Passive data never enters a competitive ranking** (or is clearly flagged unverified). Keeping these separate is what protects the moat.
+
+## 4. Scope & sequencing
+
+- Big undertaking (per-provider OAuth + webhooks + data normalization; Apple Health forces native). A **pillar phase**, after V4 (gym management) and V5 (premium on existing data).
+- Likely bundled into / unlocks part of the V5 premium ("connect your watch, see your full genome").
+
+## 5. Open questions
+
+- Which provider first beyond Garmin (Whoop given CrossFit overlap)?
+- Native app: Capacitor wrapper of the web app, or React Native rebuild?
+- Does passive cardio feed any (clearly-unverified) rating axis, or stay purely engagement/display?


### PR DESCRIPTION
Draft strategy docs for the next two phases, to iterate on together.

- **V4_STRATEGY.md** ([#140](https://github.com/igorms-pro/truegrynd/issues/140)) — gym management layer (planning · reservations · memberships · member payments via Stripe Connect · check-in). The shift: from *"coexist with your booking tool"* to *"replace it"* — unify Peppy + Hustle Up.
- **V5_STRATEGY.md** ([#141](https://github.com/igorms-pro/truegrynd/issues/141)) — B2C premium *Verified Athlete* (verified-only rankings + analytics + cosmetics), Strava model anchored to the proof moat; after scale.

Not auto-merging — review + refine. Each doc ends with **open questions** to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)