### PR TITLE
feat(pro): dedicated PRO workspace shell — sidebar, PRO nav entry, signal dashboard (QA)

### DIFF
--- a/src/app/[locale]/app/pro/layout.tsx
+++ b/src/app/[locale]/app/pro/layout.tsx
@@ -1,35 +1,7 @@
-'use client';
-
 import type { ReactNode } from 'react';
-import { notFound } from 'next/navigation';
-import { useTranslations } from 'next-intl';
 
-import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
-import { ProNav } from '@/features/pro/components/ProNav';
-import { SubscriptionGate } from '@/features/pro/components/SubscriptionGate';
-import { canAccessPro } from '@/lib/roles';
-
+// The PRO chrome (sidebar, guard, subscription gate) is provided by ProShell,
+// rendered from AppShell for every /pro route. This layout is a passthrough.
 export default function ProLayout({ children }: { children: ReactNode }) {
-  const profile = useOptionalAppProfile();
-  const t = useTranslations('pro');
-
-  if (!canAccessPro(profile)) {
-    notFound();
-  }
-
-  return (
-    <section className="space-y-6 py-4">
-      <header className="space-y-1">
-        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
-          {t('badge')}
-        </p>
-        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
-        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
-      </header>
-
-      <ProNav />
-
-      <SubscriptionGate>{children}</SubscriptionGate>
-    </section>
-  );
+  return <>{children}</>;
 }

--- a/src/features/appshell/components/AppShell.tsx
+++ b/src/features/appshell/components/AppShell.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
 import { AppHeader } from '@/features/appshell/components/AppHeader';
 import { BottomDock } from '@/features/appshell/components/BottomDock';
 import { AppProfileProvider } from '@/features/appshell/context/AppProfileContext';
 import { useRequireAppAccess } from '@/features/appshell/hooks/useRequireAppAccess';
+import { ProShell } from '@/features/pro/components/ProShell';
 
 type Props = {
   children: React.ReactNode;
@@ -26,9 +28,20 @@ function AppShellLoading() {
 
 export function AppShell({ children }: Props) {
   const access = useRequireAppAccess();
+  const pathname = usePathname();
 
   if (access.status !== 'ready') {
     return <AppShellLoading />;
+  }
+
+  // The PRO space is its own workspace: dedicated sidebar shell, no B2C header/dock.
+  const isPro = /\/app\/pro(\/|$)/.test(pathname);
+  if (isPro) {
+    return (
+      <AppProfileProvider profile={access.profile}>
+        <ProShell>{children}</ProShell>
+      </AppProfileProvider>
+    );
   }
 
   return (

--- a/src/features/appshell/components/DesktopNav.tsx
+++ b/src/features/appshell/components/DesktopNav.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from 'next-intl';
 import { DesktopNavLink } from '@/features/appshell/components/DesktopNavLink';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { APP_TABS, isTabActive } from '@/features/appshell/lib/tabs';
+import { canAccessPro } from '@/lib/roles';
 
 export function DesktopNav() {
   const pathname = usePathname();
@@ -15,6 +16,7 @@ export function DesktopNav() {
   const profile = useOptionalAppProfile();
   const adminHref = `/${locale}/app/admin/challenges`;
   const adminActive = pathname === adminHref || pathname.startsWith(`${adminHref}/`);
+  const proHref = `/${locale}/app/pro`;
 
   return (
     <nav className="hidden md:flex items-center gap-7" aria-label="Primary">
@@ -26,6 +28,11 @@ export function DesktopNav() {
           </DesktopNavLink>
         );
       })}
+      {canAccessPro(profile) ? (
+        <DesktopNavLink href={proHref} isActive={false}>
+          PRO
+        </DesktopNavLink>
+      ) : null}
       {profile?.is_admin ? (
         <DesktopNavLink href={adminHref} isActive={adminActive}>
           {tAdmin('link')}

--- a/src/features/pro/components/ProDashboard.tsx
+++ b/src/features/pro/components/ProDashboard.tsx
@@ -1,117 +1,65 @@
 'use client';
 
+import { Gavel, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
-import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
-import { PRO_NAV } from '@/features/pro/lib/proNav';
 import { fetchGymOverview } from '@/features/pro/services/dashboard';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
-import { isGymManager } from '@/lib/roles';
 
-function GymKpis() {
-  const t = useTranslations('pro.dashboard.kpi');
+/** PRO home = signal (what needs attention), not a mirror of the sidebar nav. */
+export function ProDashboard() {
+  const t = useTranslations('pro');
+  const tKpi = useTranslations('pro.dashboard.kpi');
+  const tEvents = useTranslations('pro.events');
+  const tNav = useTranslations('pro.nav');
+  const locale = useLocale();
   const { state } = useAsyncResource(fetchGymOverview, []);
-  const ready = state.status === 'ready' ? state.data : null;
+  const data = state.status === 'ready' ? state.data : null;
 
   const cards: ReadonlyArray<{ key: string; value: number | null }> = [
-    { key: 'members', value: ready?.memberCount ?? null },
-    { key: 'pending', value: ready?.pendingCount ?? null },
-    { key: 'active7d', value: ready?.active7dCount ?? null },
+    { key: 'members', value: data?.memberCount ?? null },
+    { key: 'pending', value: data?.pendingCount ?? null },
+    { key: 'active7d', value: data?.active7dCount ?? null },
   ];
 
   return (
-    <ul className="grid grid-cols-3 gap-3">
-      {cards.map((c) => (
-        <li key={c.key} className="rounded-md border border-border bg-card p-4">
-          <p className="text-2xl font-black tabular-nums">
-            {state.status === 'error' ? '—' : (c.value ?? '·')}
-          </p>
-          <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-            {t(c.key)}
-          </p>
-        </li>
-      ))}
-    </ul>
-  );
-}
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('dashboard.intro')}</p>
+      </header>
 
-function NoGymCta() {
-  const t = useTranslations('pro.createGym');
-  const locale = useLocale();
-  return (
-    <Link
-      href={`/${locale}/app/pro/gyms/new`}
-      className="block rounded-md border border-primary/40 bg-card p-5 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-    >
-      <p className="text-[10px] font-black uppercase tracking-[0.18em] text-primary">
-        {t('ctaBadge')}
-      </p>
-      <p className="mt-1 text-base font-black uppercase tracking-tight">{t('title')}</p>
-      <p className="mt-1 text-sm text-muted-foreground">{t('ctaBody')}</p>
-    </Link>
-  );
-}
-
-export function ProDashboard() {
-  const t = useTranslations('pro');
-  const tNav = useTranslations('pro.nav');
-  const locale = useLocale();
-  const profile = useOptionalAppProfile();
-  const canManage = isGymManager(profile);
-  const hasGym = Boolean(profile?.affiliated_gym_id);
-
-  // Flatten every section except the dashboard itself into overview cards.
-  const cards = PRO_NAV.flatMap((group) => group.items)
-    .filter((item) => item.id !== 'dashboard')
-    .filter((item) => !item.managerOnly || canManage);
-
-  return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">{t('dashboard.intro')}</p>
-
-      {hasGym ? <GymKpis /> : <NoGymCta />}
-
-      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {cards.map((item) => {
-          const Icon = item.icon;
-          const isSoon = item.status === 'soon';
-          const label = tNav(item.labelKey);
-
-          const inner = (
-            <div className="flex h-full flex-col gap-2 rounded-md border border-border bg-card p-4">
-              <div className="flex items-center justify-between">
-                <Icon className="h-5 w-5 text-primary" aria-hidden />
-                {isSoon ? (
-                  <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-                    {tNav('soon')}
-                  </span>
-                ) : null}
-              </div>
-              <span className="text-sm font-black uppercase tracking-[0.12em] text-foreground">
-                {label}
-              </span>
-            </div>
-          );
-
-          return (
-            <li key={item.id}>
-              {isSoon ? (
-                <div aria-disabled="true" className="opacity-60">
-                  {inner}
-                </div>
-              ) : (
-                <Link
-                  href={`/${locale}${item.path}`}
-                  className="block transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  {inner}
-                </Link>
-              )}
-            </li>
-          );
-        })}
+      <ul className="grid grid-cols-3 gap-3">
+        {cards.map((c) => (
+          <li key={c.key} className="rounded-md border border-border bg-card p-4">
+            <p className="text-3xl font-black tabular-nums">
+              {state.status === 'error' ? '—' : (c.value ?? '·')}
+            </p>
+            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+              {tKpi(c.key)}
+            </p>
+          </li>
+        ))}
       </ul>
+
+      <div className="flex flex-wrap gap-3">
+        <Link
+          href={`/${locale}/app/pro/events/new`}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90"
+        >
+          <Plus className="h-4 w-4" />
+          {tEvents('create.cta')}
+        </Link>
+        <Link
+          href={`/${locale}/app/pro/judge`}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+        >
+          <Gavel className="h-4 w-4" />
+          {tNav('judge')}
+          {data?.pendingCount ? ` (${data.pendingCount})` : ''}
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/features/pro/components/ProShell.tsx
+++ b/src/features/pro/components/ProShell.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { ChevronLeft } from 'lucide-react';
+import Link from 'next/link';
+import { notFound, usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { useCallback } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { CreateGymScreen } from '@/features/pro/components/CreateGymScreen';
+import { SubscriptionGate } from '@/features/pro/components/SubscriptionGate';
+import { PRO_NAV, isProItemActive } from '@/features/pro/lib/proNav';
+import { getMyGym } from '@/features/pro/services/gym';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { canAccessPro, isGymManager } from '@/lib/roles';
+
+/**
+ * Dedicated PRO workspace shell: left sidebar (no B2C header), a "‹ App" way back, the gym
+ * name, and the grouped nav. If the caller has no gym yet, it shows a focused onboarding
+ * (create your gym) instead of the empty shell. Rendered by AppShell for every /pro route.
+ */
+export function ProShell({ children }: { children: ReactNode }) {
+  const profile = useOptionalAppProfile();
+  const locale = useLocale();
+  const t = useTranslations('pro');
+  const tNav = useTranslations('pro.nav');
+  const pathname = usePathname();
+  const loadGym = useCallback(() => getMyGym(), []);
+  const { state } = useAsyncResource(loadGym, [profile?.affiliated_gym_id ?? '']);
+
+  if (!canAccessPro(profile)) notFound();
+
+  const hasGym = Boolean(profile?.affiliated_gym_id);
+  const canManage = isGymManager(profile);
+  const gymName = state.status === 'ready' && state.data ? state.data.name : null;
+
+  const backToApp = (
+    <Link
+      href={`/${locale}/app/overview`}
+      className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+    >
+      <ChevronLeft className="h-4 w-4" />
+      {t('shell.backToApp')}
+    </Link>
+  );
+
+  // No gym yet → focused onboarding, not the empty shell.
+  if (!hasGym) {
+    return (
+      <div className="min-h-screen bg-background text-foreground">
+        <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-6">
+          {backToApp}
+          <CreateGymScreen />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground md:flex">
+      <aside className="border-b border-border md:min-h-screen md:w-60 md:shrink-0 md:border-b-0 md:border-r">
+        <div className="space-y-4 px-4 py-4">
+          {backToApp}
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
+              {t('badge')}
+            </p>
+            <p className="mt-1 truncate text-sm font-black uppercase tracking-tight">
+              {gymName ?? '…'}
+            </p>
+          </div>
+          <nav className="flex flex-wrap gap-1 md:flex-col md:gap-4" aria-label={tNav('label')}>
+            {PRO_NAV.map((group) => {
+              const items = group.items.filter((it) => !it.managerOnly || canManage);
+              if (items.length === 0) return null;
+              return (
+                <div key={group.id} className="w-full space-y-1">
+                  {group.labelKey ? (
+                    <p className="px-2 text-[9px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+                      {tNav(`groups.${group.labelKey}`)}
+                    </p>
+                  ) : null}
+                  {items.map((item) => {
+                    const Icon = item.icon;
+                    const active = isProItemActive(pathname, locale, item);
+                    if (item.status === 'soon') {
+                      return (
+                        <div
+                          key={item.id}
+                          aria-disabled="true"
+                          className="flex items-center gap-2 rounded-md px-2 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground opacity-50"
+                        >
+                          <Icon className="h-4 w-4 shrink-0" aria-hidden />
+                          <span className="truncate">{tNav(item.labelKey)}</span>
+                          <span className="ml-auto text-[8px]">{tNav('soon')}</span>
+                        </div>
+                      );
+                    }
+                    return (
+                      <Link
+                        key={item.id}
+                        href={`/${locale}${item.path}`}
+                        className={`flex items-center gap-2 rounded-md px-2 py-2 text-xs font-black uppercase tracking-[0.12em] ${
+                          active
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                        }`}
+                      >
+                        <Icon className="h-4 w-4 shrink-0" aria-hidden />
+                        <span className="truncate">{tNav(item.labelKey)}</span>
+                      </Link>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </nav>
+        </div>
+      </aside>
+
+      <main className="min-w-0 flex-1 px-4 py-6 md:px-8">
+        <SubscriptionGate>{children}</SubscriptionGate>
+      </main>
+    </div>
+  );
+}

--- a/src/features/pro/services/gym.ts
+++ b/src/features/pro/services/gym.ts
@@ -1,4 +1,24 @@
 import { callEdgeFunction } from '@/lib/edgeFunction';
+import { supabase } from '@/lib/supabase';
+
+/** The caller's gym (name for the PRO shell). Null if unaffiliated. */
+export async function getMyGym(): Promise<{ id: string; name: string } | null> {
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) return null;
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('affiliated_gym_id')
+    .eq('id', auth.user.id)
+    .maybeSingle<{ affiliated_gym_id: string | null }>();
+  if (!profile?.affiliated_gym_id) return null;
+  const { data, error } = await supabase
+    .from('gyms')
+    .select('id, name')
+    .eq('id', profile.affiliated_gym_id)
+    .maybeSingle<{ id: string; name: string }>();
+  if (error) throw new Error(error.message);
+  return data ?? null;
+}
 
 /** A gym just created via KYB verification. */
 export type CreatedGym = {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1377,6 +1377,9 @@
     "badge": "TrueGrynd PRO",
     "title": "Gym command center",
     "subtitle": "Validate scores, run competitions and manage your box — all in one place.",
+    "shell": {
+      "backToApp": "App"
+    },
     "nav": {
       "label": "PRO sections",
       "soon": "Soon",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1377,6 +1377,9 @@
     "badge": "TrueGrynd PRO",
     "title": "Espace PRO",
     "subtitle": "Valide les scores, organise tes compétitions et gère ta box — au même endroit.",
+    "shell": {
+      "backToApp": "App"
+    },
     "nav": {
       "label": "Sections PRO",
       "soon": "Bientôt",


### PR DESCRIPTION
Addresses the biggest V3 QA feedback (navigation & onboarding).

## What
- **#1 — PRO entry**: a "PRO" link in the B2C header (visible to gym staff / platform_admin, like MOD). No more typing the URL.
- **#8 — dedicated workspace**: `/pro` is now its own shell (`ProShell`) — **left sidebar** (`‹ App` back + gym name + grouped nav), **no B2C header**, no duplicated nav. `AppShell` branches on the `/pro` route.
- **#8/#5/#7 — onboarding**: no gym yet → a **focused "Create your gym"** screen (not a buried card) → unblocks the `no_gym` errors on event/league create.
- **#2 — dashboard = signal**: members / to-validate / active + quick actions (New event, Judge), not a mirror of the nav.

## Smoke (Playwright)
- PRO link in header ✅ · no-gym onboarding (‹ App + Create your gym) ✅ · sidebar shell + signal dashboard (11 members / 27 to validate / actions) ✅
- typecheck / lint / 222 tests / build green.

## Follow-up (same QA, next PR)
#3 leagues rows · #4 event **Live/Online** label · #5a friendlier time input · #6 league detail · (+ mobile: PRO in bottom dock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)