### PR TITLE
feat(pro): theme/lang in PRO shell + member profile links (QA v2)

### DIFF
--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { listGymMembers, type GymMember } from '@/features/pro/services/members';
@@ -23,8 +24,8 @@ function MemberRow({ member }: { member: GymMember }) {
   const t = useTranslations('pro.members');
   const isHorde = member.faction === 'horde';
 
-  return (
-    <li className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0">
+  const inner = (
+    <>
       <span
         aria-hidden
         className={`h-2 w-2 shrink-0 rounded-full ${isHorde ? 'bg-[var(--faction-horde)]' : 'bg-sky-500'}`}
@@ -41,6 +42,22 @@ function MemberRow({ member }: { member: GymMember }) {
       <span className="w-28 shrink-0 text-right text-xs text-muted-foreground">
         {lastActiveLabel(member.lastActivityAt, locale, t('never'))}
       </span>
+    </>
+  );
+
+  // A member is an athlete → link to their public B2C profile.
+  return (
+    <li className="border-b border-border last:border-b-0">
+      {member.username ? (
+        <Link
+          href={`/${locale}/app/u/${member.username}`}
+          className="flex items-center gap-3 px-3 py-3 transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {inner}
+        </Link>
+      ) : (
+        <div className="flex items-center gap-3 px-3 py-3">{inner}</div>
+      )}
     </li>
   );
 }

--- a/src/features/pro/components/ProShell.tsx
+++ b/src/features/pro/components/ProShell.tsx
@@ -7,6 +7,8 @@ import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { CreateGymScreen } from '@/features/pro/components/CreateGymScreen';
 import { SubscriptionGate } from '@/features/pro/components/SubscriptionGate';
@@ -45,12 +47,22 @@ export function ProShell({ children }: { children: ReactNode }) {
     </Link>
   );
 
+  const themeControls = (
+    <div className="flex items-center gap-1.5">
+      <ThemeToggle size="sm" />
+      <LanguageSwitcher variant="dropdown" size="sm" />
+    </div>
+  );
+
   // No gym yet → focused onboarding, not the empty shell.
   if (!hasGym) {
     return (
       <div className="min-h-screen bg-background text-foreground">
         <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-6">
-          {backToApp}
+          <div className="flex items-center justify-between gap-4">
+            {backToApp}
+            {themeControls}
+          </div>
           <CreateGymScreen />
         </div>
       </div>
@@ -116,6 +128,8 @@ export function ProShell({ children }: { children: ReactNode }) {
               );
             })}
           </nav>
+
+          <div className="border-t border-border pt-3">{themeControls}</div>
         </div>
       </aside>
 


### PR DESCRIPTION
QA v2 quick wins.

- **#2 (regression)** — the PRO workspace lost theme + language when the B2C header was dropped. Added ThemeToggle + LanguageSwitcher to the sidebar footer AND the no-gym onboarding header. The PRO space already themes via TrueGrynd's tokens — **verified light + dark** (Playwright).
- **#8** — member rows now link to the athlete's public B2C profile (`/app/u/[username]`).

typecheck / lint / 222 tests / build green.

Next in the QA batch: #5/#6 event form (number/time/date pickers + design), #7 gym page, #1 collapse sidebar, #4 judge filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)