### PR TITLE
feat(events): min/sec duration pickers + numeric reps (QA v2 #5/#6)

### DIFF
--- a/.playwright-mcp/console-2026-07-03T14-08-08-197Z.log
+++ b/.playwright-mcp/console-2026-07-03T14-08-08-197Z.log
@@ -1,0 +1,2 @@
+[     669ms] [INFO] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold @ http://localhost:3000/_next/static/chunks/7d626_next_dist_e768cca1._.js:2297
+[     715ms] [LOG] [HMR] connected @ http://localhost:3000/_next/static/chunks/7d626_next_dist_e768cca1._.js:2297

--- a/.playwright-mcp/page-2026-07-03T14-08-08-964Z.yml
+++ b/.playwright-mcp/page-2026-07-03T14-08-08-964Z.yml
@@ -1,0 +1,6 @@
+- generic [active] [ref=e1]:
+  - status [ref=e2]:
+    - paragraph [ref=e3]: Chargement...
+  - button "Open Next.js Dev Tools" [ref=e9] [cursor=pointer]:
+    - img [ref=e10]
+  - alert [ref=e13]

--- a/memory.md
+++ b/memory.md
@@ -1,0 +1,31 @@
+# 🧠 memory.md — truegrynd (scratch, à supprimer)
+
+> Récap pour switcher entre mes 3 autres Claudes. Session du 18 juin 2026.
+
+## ✅ Fait aujourd'hui (tout mergé sur `main`)
+
+- QA V2 close (#100)
+- Refontes design : Overview · Arena (+ page leaderboard dédiée) · Faction · Profil en onglets
+- Clean code : split gros composants + dédupe hooks (`useAsyncResource`)
+- PostHog **réparé en prod** (events + identify/email vérifiés en live)
+- PRs #101 → #108 mergées
+
+## 🔴 EN COURS — V3 (B2B2C, gyms 100 $/mo)
+
+- Roadmap = issues **#109–#119** (phasée, dans `docs/issues/issues.md`)
+- **V3-00 RBAC codé → PR #120 OUVERTE, PAS mergée**
+- Branche : `feature/issue-109-v3-rbac`
+
+## 👉 LA SEULE ACTION QUI M'ATTEND
+
+1. Lancer **`supabase/migrations/028_user_roles.sql`** dans le **Supabase SQL Editor** (additive, safe : enum `user_role` + `profiles.role` + backfill + helper)
+2. Dire à Claude **« 028 appliquée »**
+3. → il smoke + merge #120 + enchaîne **V3-01 (table gyms + RLS)**
+
+⚠️ Ne PAS merger #120 avant la migration (les profils casseraient — `PROFILE_COLUMNS` lit `role`).
+
+## ℹ️ Infos utiles
+
+- Migrations = manuelles dans Supabase SQL Editor (pas de CI auto)
+- Reprendre la conversation complète : `claude --resume`
+- État aussi sauvé dans la mémoire persistante Claude (rappel auto)

--- a/src/features/challenges/components/CreateChallengeCircuitSection.tsx
+++ b/src/features/challenges/components/CreateChallengeCircuitSection.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { useCallback } from 'react';
 import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
 
+import { DurationInput } from '@/features/challenges/components/DurationInput';
 import type { CreateChallengeFormValues } from '@/features/challenges/lib/createChallengeSchema';
 import {
   movementsByCategory,
@@ -212,16 +213,34 @@ export function CreateChallengeCircuitSection({ disabled }: { disabled: boolean 
                 >
                   {kind === 'hold' ? t('circuit.amountHoldLabel') : t('circuit.amountRepsLabel')}
                 </label>
-                <input
-                  id={`cc-amt-${field.id}`}
-                  type="text"
-                  inputMode="numeric"
-                  disabled={disabled}
-                  placeholder={amountPlaceholder}
-                  autoComplete="off"
-                  className="mt-1 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  {...register(`circuitBlocks.${index}.amount`)}
-                />
+                {kind === 'hold' ? (
+                  <>
+                    <DurationInput
+                      id={`cc-amt-${field.id}`}
+                      value={blocks[index]?.amount ?? ''}
+                      disabled={disabled}
+                      minutesLabel={t('circuit.durationMin')}
+                      secondsLabel={t('circuit.durationSec')}
+                      onChange={(next) =>
+                        setValue(`circuitBlocks.${index}.amount`, next, { shouldValidate: true })
+                      }
+                    />
+                    <input type="hidden" {...register(`circuitBlocks.${index}.amount`)} />
+                  </>
+                ) : (
+                  <input
+                    id={`cc-amt-${field.id}`}
+                    type="number"
+                    inputMode="numeric"
+                    min={1}
+                    step={1}
+                    disabled={disabled}
+                    placeholder={amountPlaceholder}
+                    autoComplete="off"
+                    className="mt-1 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    {...register(`circuitBlocks.${index}.amount`)}
+                  />
+                )}
                 <FieldError message={errors.circuitBlocks?.[index]?.amount?.message} />
               </div>
             </div>

--- a/src/features/challenges/components/CreateChallengeScoringSection.tsx
+++ b/src/features/challenges/components/CreateChallengeScoringSection.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { useFormContext, useWatch } from 'react-hook-form';
 
+import { DurationInput } from '@/features/challenges/components/DurationInput';
 import type { CreateChallengeFormValues } from '@/features/challenges/lib/createChallengeSchema';
 
 function FieldError({ message }: { message?: string }) {
@@ -18,6 +19,8 @@ export function CreateChallengeScoringSection({ disabled }: { disabled: boolean 
   const t = useTranslations('arena.create');
   const { control, register, setValue, formState } = useFormContext<CreateChallengeFormValues>();
   const scoringMode = useWatch({ control, name: 'scoringMode' }) ?? 'for_time';
+  const forTimeCap = useWatch({ control, name: 'forTimeCap' }) ?? '';
+  const amrapCap = useWatch({ control, name: 'amrapCap' }) ?? '';
 
   const modeBtnClass = (mode: 'for_time' | 'amrap') =>
     [
@@ -67,16 +70,15 @@ export function CreateChallengeScoringSection({ disabled }: { disabled: boolean 
           >
             {t('scoring.forTimeCapLabel')}
           </label>
-          <input
+          <DurationInput
             id="cc-for-time-cap"
-            type="text"
-            inputMode="numeric"
-            autoComplete="off"
+            value={forTimeCap}
             disabled={disabled}
-            placeholder={t('scoring.forTimeCapPlaceholder')}
-            className="mt-2 w-full max-w-[10rem] rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            {...register('forTimeCap')}
+            minutesLabel={t('circuit.durationMin')}
+            secondsLabel={t('circuit.durationSec')}
+            onChange={(next) => setValue('forTimeCap', next, { shouldValidate: true })}
           />
+          <input type="hidden" {...register('forTimeCap')} />
           <p className="mt-1 text-[10px] text-muted-foreground">{t('scoring.forTimeCapHint')}</p>
           <FieldError message={formState.errors.forTimeCap?.message} />
         </div>
@@ -90,16 +92,15 @@ export function CreateChallengeScoringSection({ disabled }: { disabled: boolean 
           >
             {t('scoring.amrapCapLabel')}
           </label>
-          <input
+          <DurationInput
             id="cc-amrap-cap"
-            type="text"
-            inputMode="numeric"
-            autoComplete="off"
+            value={amrapCap}
             disabled={disabled}
-            placeholder={t('scoring.amrapCapPlaceholder')}
-            className="mt-2 w-full max-w-[10rem] rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            {...register('amrapCap')}
+            minutesLabel={t('circuit.durationMin')}
+            secondsLabel={t('circuit.durationSec')}
+            onChange={(next) => setValue('amrapCap', next, { shouldValidate: true })}
           />
+          <input type="hidden" {...register('amrapCap')} />
           <FieldError message={formState.errors.amrapCap?.message} />
         </div>
       ) : null}

--- a/src/features/challenges/components/DurationInput.tsx
+++ b/src/features/challenges/components/DurationInput.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+/**
+ * MM:SS duration picker — two number steppers (minutes 0–999, seconds 0–59) that emit a
+ * single "M:SS" string, the exact shape `isValidHoldTime` / `capDurationSeconds` accept.
+ * Replaces free-text time entry (no more typing colons) for hold blocks and scoring caps.
+ */
+
+function parse(value: string): { minutes: string; seconds: string } {
+  const match = /^(\d{1,3}):([0-5]?\d)$/.exec(value.trim());
+  if (!match) return { minutes: '', seconds: '' };
+  return { minutes: match[1], seconds: match[2] };
+}
+
+function clamp(raw: string, max: number): string {
+  const digits = raw.replace(/\D/g, '');
+  if (digits === '') return '';
+  return String(Math.min(Number(digits), max));
+}
+
+function combine(minutes: string, seconds: string): string {
+  if (minutes === '' && seconds === '') return '';
+  const m = minutes === '' ? 0 : Number(minutes);
+  const s = seconds === '' ? 0 : Number(seconds);
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+type DurationInputProps = {
+  id?: string;
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+  minutesLabel: string;
+  secondsLabel: string;
+};
+
+export function DurationInput({
+  id,
+  value,
+  onChange,
+  disabled,
+  minutesLabel,
+  secondsLabel,
+}: DurationInputProps) {
+  const { minutes, seconds } = parse(value);
+
+  const inputClass =
+    'w-20 rounded-sm border border-border bg-background px-3 py-2 text-center text-sm tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50';
+
+  return (
+    <div className="mt-1 flex items-end gap-2">
+      <div>
+        <label
+          htmlFor={id ? `${id}-min` : undefined}
+          className="block text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground"
+        >
+          {minutesLabel}
+        </label>
+        <input
+          id={id ? `${id}-min` : undefined}
+          type="number"
+          inputMode="numeric"
+          min={0}
+          max={999}
+          step={1}
+          disabled={disabled}
+          placeholder="0"
+          autoComplete="off"
+          className={inputClass}
+          value={minutes}
+          onChange={(e) => onChange(combine(clamp(e.target.value, 999), seconds))}
+        />
+      </div>
+      <span aria-hidden className="pb-2 text-sm font-black text-muted-foreground">
+        :
+      </span>
+      <div>
+        <label
+          htmlFor={id ? `${id}-sec` : undefined}
+          className="block text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground"
+        >
+          {secondsLabel}
+        </label>
+        <input
+          id={id ? `${id}-sec` : undefined}
+          type="number"
+          inputMode="numeric"
+          min={0}
+          max={59}
+          step={1}
+          disabled={disabled}
+          placeholder="00"
+          autoComplete="off"
+          className={inputClass}
+          value={seconds}
+          onChange={(e) => onChange(combine(minutes, clamp(e.target.value, 59)))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/pro/components/CreateGymEventScreen.tsx
+++ b/src/features/pro/components/CreateGymEventScreen.tsx
@@ -68,7 +68,7 @@ export function CreateGymEventScreen() {
   });
 
   return (
-    <section className="space-y-6">
+    <section className="mx-auto max-w-2xl space-y-6">
       <Link
         href={`/${locale}/app/pro/events`}
         className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
@@ -90,73 +90,75 @@ export function CreateGymEventScreen() {
 
       <FormProvider {...form}>
         <form className="space-y-5" onSubmit={onSubmit} noValidate>
-          <div>
-            <label
-              htmlFor="ev-title"
-              className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
-            >
-              {t('fields.title')}
-            </label>
-            <input
-              id="ev-title"
-              type="text"
-              autoComplete="off"
-              disabled={busy}
-              className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              {...form.register('title')}
-            />
-            <FieldError message={form.formState.errors.title?.message} />
-          </div>
-
-          <div>
-            <label
-              htmlFor="ev-description"
-              className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
-            >
-              {t('fields.description')}
-            </label>
-            <textarea
-              id="ev-description"
-              rows={3}
-              disabled={busy}
-              className="mt-2 w-full resize-y rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              {...form.register('description')}
-            />
-            <FieldError message={form.formState.errors.description?.message} />
-          </div>
-
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-5 rounded-md border border-border bg-card p-4 sm:p-6">
             <div>
               <label
-                htmlFor="ev-starts"
+                htmlFor="ev-title"
                 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
               >
-                {t('fields.startsAt')}
+                {t('fields.title')}
               </label>
               <input
-                id="ev-starts"
-                type="datetime-local"
+                id="ev-title"
+                type="text"
+                autoComplete="off"
                 disabled={busy}
                 className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                {...form.register('startsAt')}
+                {...form.register('title')}
               />
-              <FieldError message={form.formState.errors.startsAt?.message} />
+              <FieldError message={form.formState.errors.title?.message} />
             </div>
+
             <div>
               <label
-                htmlFor="ev-ends"
+                htmlFor="ev-description"
                 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
               >
-                {t('fields.endsAt')}
+                {t('fields.description')}
               </label>
-              <input
-                id="ev-ends"
-                type="datetime-local"
+              <textarea
+                id="ev-description"
+                rows={3}
                 disabled={busy}
-                className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                {...form.register('endsAt')}
+                className="mt-2 w-full resize-y rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                {...form.register('description')}
               />
-              <FieldError message={form.formState.errors.endsAt?.message} />
+              <FieldError message={form.formState.errors.description?.message} />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div>
+                <label
+                  htmlFor="ev-starts"
+                  className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
+                >
+                  {t('fields.startsAt')}
+                </label>
+                <input
+                  id="ev-starts"
+                  type="datetime-local"
+                  disabled={busy}
+                  className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  {...form.register('startsAt')}
+                />
+                <FieldError message={form.formState.errors.startsAt?.message} />
+              </div>
+              <div>
+                <label
+                  htmlFor="ev-ends"
+                  className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground"
+                >
+                  {t('fields.endsAt')}
+                </label>
+                <input
+                  id="ev-ends"
+                  type="datetime-local"
+                  disabled={busy}
+                  className="mt-2 w-full rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  {...form.register('endsAt')}
+                />
+                <FieldError message={form.formState.errors.endsAt?.message} />
+              </div>
             </div>
           </div>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -332,6 +332,8 @@
         "amountHoldLabel": "Hold time",
         "amountPlaceholderReps": "10",
         "amountPlaceholderHold": "3:00",
+        "durationMin": "Min",
+        "durationSec": "Sec",
         "addMovement": "ADD MOVEMENT",
         "removeRow": "Remove movement"
       },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -332,6 +332,8 @@
         "amountHoldLabel": "Temps",
         "amountPlaceholderReps": "10",
         "amountPlaceholderHold": "3:00",
+        "durationMin": "Min",
+        "durationSec": "Sec",
         "addMovement": "AJOUTER UN MOUVEMENT",
         "removeRow": "Retirer ce mouvement"
       },


### PR DESCRIPTION
## QA v2 — points #5 / #6 (event & workout form)

Igor's feedback: *"New event: reps juste chiffre, hold time un select… des milliard de datepicker… la page est moche."*

### Changes
- **Reps** amount → `type="number"` (numeric keyboard, steppers), no more free-text.
- **Hold time** and **scoring caps** (for-time / AMRAP) → new `DurationInput` **MIN : SEC** stepper. No more typing colons.
  - Emits the exact same `M:SS` string `isValidHoldTime` / `capDurationSeconds` already accept → **zero validation/behaviour change** for B2C challenges or PRO events. Seconds clamp to 59, minutes to 999.
- **Event-create page** ("moche"): basics (title / hook / dates) grouped into a `bg-card` block, section constrained to `max-w-2xl` so it no longer reads as a flat full-width stack.

### Shared-component note
`DurationInput` lands in `CreateChallengeCircuitSection` + `CreateChallengeScoringSection`, reused by **both** B2C Arena challenge creation and PRO event creation — one fix, both surfaces.

### Smoke
Visual Playwright on `/fr/app/arena/create` (light theme): reps input `type=number` ✓, Hold → MIN:SEC picker emits `1:30` ✓, seconds `90`→`59` clamp ✓, scoring cap picker renders ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)