### PR TITLE
feat(pro): dashboard purpose + billing new tab (QA v2 #3, #9)

### DIFF
--- a/src/features/pro/components/BillingScreen.tsx
+++ b/src/features/pro/components/BillingScreen.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
@@ -40,7 +41,11 @@ function BillingBody({ data }: { data: BillingStatus }) {
       const returnUrl = window.location.href;
       const url =
         action === 'checkout' ? await startCheckout(returnUrl) : await openPortal(returnUrl);
-      window.location.href = url;
+      // Open Stripe in a new tab so the PRO workspace stays put; fall back to same-tab
+      // navigation if the popup is blocked.
+      const opened = window.open(url, '_blank', 'noopener,noreferrer');
+      if (!opened) window.location.href = url;
+      setBusy(false);
     } catch {
       setError(t('error'));
       setBusy(false);
@@ -70,9 +75,10 @@ function BillingBody({ data }: { data: BillingStatus }) {
           type="button"
           disabled={busy}
           onClick={() => go(subscribed ? 'portal' : 'checkout')}
-          className="w-full rounded-md bg-primary px-4 py-2.5 text-sm font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
         >
           {busy ? t('loading') : subscribed ? t('manage') : t('subscribe')}
+          {!busy ? <ExternalLink className="h-4 w-4" aria-hidden /> : null}
         </button>
       </div>
       <p className="text-xs text-muted-foreground">{t('note')}</p>

--- a/src/features/pro/components/ProDashboard.tsx
+++ b/src/features/pro/components/ProDashboard.tsx
@@ -11,12 +11,15 @@ import { useAsyncResource } from '@/hooks/useAsyncResource';
 export function ProDashboard() {
   const t = useTranslations('pro');
   const tKpi = useTranslations('pro.dashboard.kpi');
+  const tKpiHint = useTranslations('pro.dashboard.kpiHint');
   const tEvents = useTranslations('pro.events');
   const tNav = useTranslations('pro.nav');
   const locale = useLocale();
   const { state } = useAsyncResource(fetchGymOverview, []);
   const data = state.status === 'ready' ? state.data : null;
 
+  const pending = data?.pendingCount ?? 0;
+  const needsReview = pending > 0;
   const cards: ReadonlyArray<{ key: string; value: number | null }> = [
     { key: 'members', value: data?.memberCount ?? null },
     { key: 'pending', value: data?.pendingCount ?? null },
@@ -30,35 +33,57 @@ export function ProDashboard() {
         <p className="text-sm text-muted-foreground">{t('dashboard.intro')}</p>
       </header>
 
-      <ul className="grid grid-cols-3 gap-3">
-        {cards.map((c) => (
-          <li key={c.key} className="rounded-md border border-border bg-card p-4">
-            <p className="text-3xl font-black tabular-nums">
-              {state.status === 'error' ? '—' : (c.value ?? '·')}
-            </p>
-            <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-              {tKpi(c.key)}
-            </p>
-          </li>
-        ))}
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {cards.map((c) => {
+          const highlight = c.key === 'pending' && needsReview;
+          return (
+            <li
+              key={c.key}
+              className={`rounded-md border p-4 ${
+                highlight ? 'border-primary bg-primary/5' : 'border-border bg-card'
+              }`}
+            >
+              <p className={`text-3xl font-black tabular-nums ${highlight ? 'text-primary' : ''}`}>
+                {state.status === 'error' ? '—' : (c.value ?? '·')}
+              </p>
+              <p className="text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
+                {tKpi(c.key)}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{tKpiHint(c.key)}</p>
+              {highlight ? (
+                <Link
+                  href={`/${locale}/app/pro/judge`}
+                  className="mt-2 inline-block text-xs font-black uppercase tracking-[0.12em] text-primary hover:underline"
+                >
+                  {t('dashboard.pendingCta')} →
+                </Link>
+              ) : null}
+            </li>
+          );
+        })}
       </ul>
 
-      <div className="flex flex-wrap gap-3">
-        <Link
-          href={`/${locale}/app/pro/events/new`}
-          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90"
-        >
-          <Plus className="h-4 w-4" />
-          {tEvents('create.cta')}
-        </Link>
-        <Link
-          href={`/${locale}/app/pro/judge`}
-          className="inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-foreground hover:bg-muted"
-        >
-          <Gavel className="h-4 w-4" />
-          {tNav('judge')}
-          {data?.pendingCount ? ` (${data.pendingCount})` : ''}
-        </Link>
+      <div className="space-y-3">
+        <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('dashboard.quickTitle')}
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href={`/${locale}/app/pro/events/new`}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" />
+            {tEvents('create.cta')}
+          </Link>
+          <Link
+            href={`/${locale}/app/pro/judge`}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+          >
+            <Gavel className="h-4 w-4" />
+            {tNav('judge')}
+            {data?.pendingCount ? ` (${data.pendingCount})` : ''}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1421,12 +1421,19 @@
       "billing": "Billing"
     },
     "dashboard": {
-      "intro": "Welcome to your PRO space. The Judge Console arrives next — the rest is on the way.",
+      "intro": "Your gym at a glance — what needs your attention today.",
       "kpi": {
         "members": "Members",
         "pending": "To validate",
         "active7d": "Active (7d)"
-      }
+      },
+      "kpiHint": {
+        "members": "Affiliated athletes",
+        "pending": "Scores awaiting a judge",
+        "active7d": "Trained in the last 7 days"
+      },
+      "quickTitle": "Quick actions",
+      "pendingCta": "Review now"
     },
     "judge": {
       "intro": "Validate performances you witnessed on the floor — a validated score jumps to the verified ranking.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1421,12 +1421,19 @@
       "billing": "Facturation"
     },
     "dashboard": {
-      "intro": "Bienvenue dans ton espace PRO. La Judge Console arrive juste après — le reste suit.",
+      "intro": "Ta salle en un coup d'œil — ce qui demande ton attention aujourd'hui.",
       "kpi": {
         "members": "Membres",
         "pending": "À valider",
         "active7d": "Actifs (7j)"
-      }
+      },
+      "kpiHint": {
+        "members": "Athlètes affiliés",
+        "pending": "Scores en attente d'un juge",
+        "active7d": "Entraînés ces 7 derniers jours"
+      },
+      "quickTitle": "Actions rapides",
+      "pendingCta": "Valider maintenant"
     },
     "judge": {
       "intro": "Valide les performances vues sur le floor — un score validé passe au ranking vérifié.",


### PR DESCRIPTION
## QA v2 — points #3 & #9 (the last two)

**#3 — "Dashboard je sais pas trop à quoi il sert."** It read as filler (stale copy: *"the Judge Console arrives next…"*). Now:
- Intro states the purpose: *your gym at a glance — what needs your attention today.*
- One-line hint under each KPI (Members = affiliated athletes, To validate = scores awaiting a judge, Active 7d = trained in the last 7 days).
- The **To validate** card highlights (primary border/tint) and links straight to the Judge Console when scores are pending — the dashboard now *drives an action*.
- "Quick actions" heading over the buttons.

**#9 — "Billing bien mais couvre une new tab."** It opened Stripe via a same-tab redirect, replacing the whole PRO workspace. Now opens Stripe checkout/portal in a **new tab** (same-tab fallback if popups blocked), with an external-link icon on the button so the behaviour is signposted.

### Verification
tsc / eslint / JSON green. Interactive smoke deferred to next login (session expired mid-work, magic-link/OAuth only). Both are UI/copy changes over existing data flows.

Completes the full QA v2 list (#1–#9). 🤖 Generated with [Claude Code](https://claude.com/claude-code)