### PR TITLE
fix(pro): QA v3 — judge filters, event detail, member nav, leagues + gym scoping

### DIFF
--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -311,10 +311,7 @@ function WorkoutPanel({
       ) : null}
 
       <div className="space-y-2">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {t('detail.standings')}
-          </h2>
+        <div className="flex justify-end">
           <Link
             href={`/${locale}/app/pro/events/${event.id}/tv`}
             className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
@@ -364,7 +361,7 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
   }
 
   return (
-    <section className="space-y-6">
+    <section className="mx-auto max-w-3xl space-y-6">
       <Link
         href={`/${locale}/app/pro/events`}
         className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"

--- a/src/features/pro/components/JudgeConsole.tsx
+++ b/src/features/pro/components/JudgeConsole.tsx
@@ -102,6 +102,8 @@ export function JudgeConsole() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const [proofFilter, setProofFilter] = useState<'all' | 'video' | 'novideo'>('all');
+  const [challengeFilter, setChallengeFilter] = useState('');
   const [page, setPage] = useState(0);
 
   const onVerify = useCallback(async (id: string) => {
@@ -124,16 +126,26 @@ export function JudgeConsole() {
 
   const PAGE_SIZE = 15;
   const q = query.trim().toLowerCase();
+  // Distinct events/challenges present in the queue, for the event filter dropdown.
+  const challenges = useMemo(
+    () => [...new Set(rows.map((r) => r.challengeTitle))].sort((a, b) => a.localeCompare(b)),
+    [rows],
+  );
   const filtered = useMemo(
     () =>
-      q
-        ? rows.filter(
-            (r) =>
-              (r.athleteUsername ?? '').toLowerCase().includes(q) ||
-              r.challengeTitle.toLowerCase().includes(q),
-          )
-        : rows,
-    [rows, q],
+      rows.filter((r) => {
+        if (q) {
+          const hit =
+            (r.athleteUsername ?? '').toLowerCase().includes(q) ||
+            r.challengeTitle.toLowerCase().includes(q);
+          if (!hit) return false;
+        }
+        if (proofFilter === 'video' && !r.videoUrl) return false;
+        if (proofFilter === 'novideo' && r.videoUrl) return false;
+        if (challengeFilter && r.challengeTitle !== challengeFilter) return false;
+        return true;
+      }),
+    [rows, q, proofFilter, challengeFilter],
   );
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
@@ -156,21 +168,60 @@ export function JudgeConsole() {
         </p>
       ) : (
         <>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-              {t('pendingCount', { count: filtered.length })}
-            </p>
-            <input
-              type="search"
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setPage(0);
-              }}
-              placeholder={t('searchPlaceholder')}
-              aria-label={t('searchPlaceholder')}
-              className="w-full max-w-xs rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            />
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+                {t('pendingCount', { count: filtered.length })}
+              </p>
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setPage(0);
+                }}
+                placeholder={t('searchPlaceholder')}
+                aria-label={t('searchPlaceholder')}
+                className="w-full max-w-xs rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {(['all', 'video', 'novideo'] as const).map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  onClick={() => {
+                    setProofFilter(f);
+                    setPage(0);
+                  }}
+                  className={`rounded-sm px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] transition-colors ${
+                    proofFilter === f
+                      ? 'bg-primary text-primary-foreground'
+                      : 'border border-border text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {t(`filter.${f}`)}
+                </button>
+              ))}
+              {challenges.length > 1 ? (
+                <select
+                  value={challengeFilter}
+                  onChange={(e) => {
+                    setChallengeFilter(e.target.value);
+                    setPage(0);
+                  }}
+                  aria-label={t('filter.eventLabel')}
+                  className="ml-auto max-w-[16rem] rounded-sm border border-border bg-background px-3 py-1.5 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <option value="">{t('filter.allEvents')}</option>
+                  {challenges.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+            </div>
           </div>
 
           {filtered.length === 0 ? (

--- a/src/features/pro/components/LeagueDetail.tsx
+++ b/src/features/pro/components/LeagueDetail.tsx
@@ -20,7 +20,7 @@ export function LeagueDetail({ leagueId }: { leagueId: string }) {
     leaguesState.status === 'ready' ? leaguesState.data.find((l) => l.id === leagueId) : null;
 
   return (
-    <section className="space-y-5">
+    <section className="mx-auto max-w-2xl space-y-5">
       <Link
         href={`/${locale}/app/pro/leagues`}
         className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
@@ -44,11 +44,25 @@ export function LeagueDetail({ leagueId }: { leagueId: string }) {
       ) : state.status === 'error' ? (
         <p className="text-sm font-semibold text-primary">{t('error')}</p>
       ) : state.data.length === 0 ? (
-        <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
-          {t('detail.empty')}
-        </p>
+        <div className="space-y-4 rounded-md border border-dashed border-border bg-muted/20 p-6 text-center">
+          <p className="text-sm font-black uppercase tracking-[0.14em] text-foreground">
+            {t('detail.emptyTitle')}
+          </p>
+          <p className="mx-auto max-w-md text-sm text-muted-foreground">{t('detail.emptyBody')}</p>
+          <Link
+            href={`/${locale}/app/pro/leagues`}
+            className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.14em] text-primary-foreground hover:opacity-90"
+          >
+            {t('detail.joinCta')}
+          </Link>
+        </div>
       ) : (
         <ul className="rounded-md border border-border bg-card">
+          <li className="flex items-center gap-3 border-b border-border px-3 py-2 text-[9px] font-black uppercase tracking-[0.16em] text-muted-foreground">
+            <span className="w-6 shrink-0 text-center">#</span>
+            <span className="min-w-0 flex-1">{t('detail.colGym')}</span>
+            <span className="shrink-0 text-right">{t('detail.avgRating')}</span>
+          </li>
           {state.data.map((row, i) => (
             <li
               key={row.gymId}
@@ -71,17 +85,15 @@ export function LeagueDetail({ leagueId }: { leagueId: string }) {
                   {t('detail.members', { count: row.memberCount })}
                 </span>
               </span>
-              <span className="shrink-0 text-right">
-                <span className="block text-lg font-black tabular-nums">{row.avgRating}</span>
-                <span className="block text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-                  {t('detail.avgRating')}
-                </span>
+              <span className="shrink-0 text-right text-lg font-black tabular-nums">
+                {row.avgRating}
               </span>
             </li>
           ))}
         </ul>
       )}
       <p className="text-xs text-muted-foreground">{t('detail.note')}</p>
+      <p className="text-[11px] text-muted-foreground">{t('detail.runBy')}</p>
     </section>
   );
 }

--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
@@ -42,6 +43,9 @@ function MemberRow({ member }: { member: GymMember }) {
       <span className="w-28 shrink-0 text-right text-xs text-muted-foreground">
         {lastActiveLabel(member.lastActivityAt, locale, t('never'))}
       </span>
+      {member.username ? (
+        <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      ) : null}
     </>
   );
 
@@ -51,6 +55,9 @@ function MemberRow({ member }: { member: GymMember }) {
       {member.username ? (
         <Link
           href={`/${locale}/app/u/${member.username}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={t('openProfile')}
           className="flex items-center gap-3 px-3 py-3 transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {inner}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1441,6 +1441,13 @@
       "error": "Could not load the queue.",
       "empty": "Nothing to validate right now. 🎉",
       "pendingCount": "{count} to validate",
+      "filter": {
+        "all": "All",
+        "video": "With video",
+        "novideo": "No video",
+        "allEvents": "All events",
+        "eventLabel": "Filter by event"
+      },
       "searchPlaceholder": "Search athlete or challenge…",
       "noMatch": "No pending score matches your search.",
       "pagePrev": "Prev",
@@ -1465,7 +1472,8 @@
       "error": "Could not load members.",
       "empty": "No members affiliated yet.",
       "count": "{count} members",
-      "never": "never"
+      "never": "never",
+      "openProfile": "Open athlete profile (new tab)"
     },
     "billing": {
       "loading": "Loading…",
@@ -1506,9 +1514,14 @@
         "back": "Back to leagues",
         "intro": "Member boxes ranked by their athletes' average rating.",
         "empty": "No member gyms yet.",
+        "emptyTitle": "No box is competing here yet",
+        "emptyBody": "Be the first. Join this league from the leagues list and your box enters the ranking as soon as your members post ranked scores.",
+        "joinCta": "Go to leagues to join",
+        "colGym": "Box",
         "members": "{count, plural, =0 {no members} =1 {1 member} other {# members}}",
         "avgRating": "Avg rating",
-        "note": "Score = average of each box's members' global rating. Shared-WOD matches are coming next."
+        "note": "Score = average of each box's members' global rating. Shared-WOD matches are coming next.",
+        "runBy": "Leagues are run by TrueGrynd — you opt your box in or out, you don't create them."
       }
     },
     "events": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1441,6 +1441,13 @@
       "error": "Impossible de charger la file.",
       "empty": "Rien à valider pour le moment. 🎉",
       "pendingCount": "{count} à valider",
+      "filter": {
+        "all": "Tous",
+        "video": "Avec vidéo",
+        "novideo": "Sans vidéo",
+        "allEvents": "Tous les events",
+        "eventLabel": "Filtrer par event"
+      },
       "searchPlaceholder": "Rechercher un athlète ou un défi…",
       "noMatch": "Aucun score en attente ne correspond à ta recherche.",
       "pagePrev": "Précédent",
@@ -1465,7 +1472,8 @@
       "error": "Impossible de charger les membres.",
       "empty": "Aucun membre affilié pour le moment.",
       "count": "{count} membres",
-      "never": "jamais"
+      "never": "jamais",
+      "openProfile": "Ouvrir le profil de l'athlète (nouvel onglet)"
     },
     "billing": {
       "loading": "Chargement…",
@@ -1506,9 +1514,14 @@
         "back": "Retour aux ligues",
         "intro": "Les box membres classées par le rating moyen de leurs athlètes.",
         "empty": "Aucune salle membre pour le moment.",
+        "emptyTitle": "Aucune box ne concourt encore ici",
+        "emptyBody": "Sois la première. Rejoins cette ligue depuis la liste des ligues — ta box entre au classement dès que tes membres postent des scores classés.",
+        "joinCta": "Aller aux ligues pour rejoindre",
+        "colGym": "Box",
         "members": "{count, plural, =0 {aucun membre} =1 {1 membre} other {# membres}}",
         "avgRating": "Rating moyen",
-        "note": "Score = moyenne du rating global des membres de chaque box. Les matchs sur WOD partagé arrivent ensuite."
+        "note": "Score = moyenne du rating global des membres de chaque box. Les matchs sur WOD partagé arrivent ensuite.",
+        "runBy": "Les ligues sont gérées par TrueGrynd — tu inscris/retires ta box, tu ne les crées pas."
       }
     },
     "events": {

--- a/supabase/migrations/046_gym_scope_admin_fix.sql
+++ b/supabase/migrations/046_gym_scope_admin_fix.sql
@@ -1,0 +1,107 @@
+-- QA v3 fix: gym_members() and gym_overview() are "my gym" views, but both carried an
+-- `is_platform_admin()` bypass that UNSCOPED them entirely — a platform_admin who also runs a
+-- gym (e.g. the founder testing their own box) saw EVERY profile/score on the platform as their
+-- gym's roster + KPIs, not just their gym's. These functions must always scope to the caller's
+-- affiliated_gym_id; platform-wide views live under /admin. (Same family of fix as #152.)
+
+CREATE OR REPLACE FUNCTION public.gym_members()
+RETURNS TABLE (
+  id uuid,
+  username text,
+  division text,
+  faction text,
+  avatar_url text,
+  last_activity_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT p.id, p.username, p.division, p.faction, p.avatar_url, p.last_activity_at
+  FROM public.profiles p
+  JOIN public.profiles caller ON caller.id = auth.uid()
+  WHERE caller.affiliated_gym_id IS NOT NULL
+    AND p.affiliated_gym_id = caller.affiliated_gym_id
+  ORDER BY p.last_activity_at DESC NULLS LAST
+  LIMIT 500;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_members() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.gym_overview()
+RETURNS TABLE (member_count integer, pending_count integer, active_7d_count integer)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_gym uuid;
+BEGIN
+  SELECT affiliated_gym_id INTO v_gym
+  FROM public.profiles
+  WHERE id = auth.uid();
+
+  -- No gym affiliated (incl. a platform_admin not running a box) → zeros.
+  IF v_gym IS NULL THEN
+    RETURN QUERY SELECT 0, 0, 0;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    (SELECT count(*)::int
+       FROM public.profiles p
+       WHERE p.affiliated_gym_id = v_gym),
+    (SELECT count(*)::int
+       FROM public.scores s
+       JOIN public.profiles p ON p.id = s.user_id
+       WHERE s.is_hidden = false
+         AND s.proof_level <> 'judge_verified'
+         AND p.affiliated_gym_id = v_gym),
+    (SELECT count(*)::int
+       FROM public.profiles p
+       WHERE p.affiliated_gym_id = v_gym
+         AND p.last_activity_at >= now() - interval '7 days');
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_overview() TO authenticated;
+
+-- Same bypass in the Judge queue: a platform_admin saw EVERY pending score on the platform,
+-- not their gym's. Keep the staff/admin role gate, but always scope to the caller's own gym.
+CREATE OR REPLACE FUNCTION public.pending_verifications()
+RETURNS TABLE (
+  score_id uuid, value numeric, video_url text, proof_level proof_level,
+  is_validated boolean, submitted_at timestamptz, athlete_id uuid,
+  athlete_username text, athlete_division text, athlete_faction text,
+  athlete_avatar_url text, challenge_id uuid, challenge_title text, score_type text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    s.id, s.value, s.video_url, s.proof_level, s.is_validated, s.submitted_at,
+    p.id, p.username, p.division, p.faction, p.avatar_url,
+    c.id, c.title, c.score_type
+  FROM public.scores s
+  JOIN public.profiles p ON p.id = s.user_id
+  JOIN public.challenges c ON c.id = s.challenge_id
+  WHERE s.is_hidden = false
+    AND s.proof_level <> 'judge_verified'
+    AND EXISTS (
+      SELECT 1
+      FROM public.profiles caller
+      WHERE caller.id = auth.uid()
+        AND caller.affiliated_gym_id IS NOT NULL
+        AND p.affiliated_gym_id = caller.affiliated_gym_id
+        AND (caller.role IN ('coach', 'gym_admin') OR public.is_platform_admin())
+    )
+  ORDER BY s.submitted_at DESC
+  LIMIT 200;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.pending_verifications() TO authenticated;


### PR DESCRIPTION
## V3 v3 QA — all 5 points + a scoping bug the QA surfaced

Smoked live in the browser (session restored) as CROSSFIT MADEC.

**#1 Judge Console — filters.** Search alone wasn't enough for a busy queue. Added filter chips **All / With video / No video** + an **event dropdown**, on top of the existing search & pagination. Verified: "No video" hides all video rows.

**#2 Event detail ("moche").** Constrained to `max-w-3xl`, removed the **duplicate "CLASSEMENT"** heading (the Leaderboard already renders its own), tidied the cast button.

**#3 Members navigation.** Clicking a member threw you out of `/pro` into the B2C app with a stray "back to clan" and no way back. Now opens the athlete profile in a **new tab** (external-link icon + tooltip) — the PRO workspace stays.

**#4/#5 Leagues.** Detail was blank when no box had joined → added a **guided empty state** (join CTA), **labeled standings columns** (`# / Box / Rating`), and a note that **leagues are run by TrueGrynd** (answers "who creates them"). Width constrained. Verified empty *and* populated (joined CROSSFIT MADEC → ranking renders).

**Migration 046 — gym scoping bug (found while smoking #3).** `gym_members`, `gym_overview` and `pending_verifications` each had an `is_platform_admin()` bypass that **unscoped them entirely**: a platform admin who also runs a gym (i.e. the founder) saw the *whole platform's* members, dashboard KPIs and pending scores as their own gym's. Verified: roster went 10→2, judge queue 31→21 (now only affiliated members). Scoped to the caller's gym always; same fix family as #152. **Applied to prod.**

Migrations prod = up to **046**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)