### PR TITLE
fix(pro): tidy judge filter bar + enrich public gym page

### DIFF
--- a/src/features/gym/components/GymProfileScreen.tsx
+++ b/src/features/gym/components/GymProfileScreen.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { MapPin, Users } from 'lucide-react';
+import { ArrowLeft, BadgeCheck, MapPin, Trophy, Users } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
@@ -15,6 +16,7 @@ type Props = {
 
 export function GymProfileScreen({ slug }: Props) {
   const locale = useLocale();
+  const router = useRouter();
   const t = useTranslations('gym.public');
   const load = useCallback(() => getGymProfileBySlug(slug), [slug]);
   const { state, refetch } = useAsyncResource(load, [slug]);
@@ -60,10 +62,27 @@ export function GymProfileScreen({ slug }: Props) {
 
   return (
     <section className="mx-auto max-w-2xl space-y-6">
-      <header className="space-y-2">
-        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
-          {t('kicker')}
-        </p>
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {t('back')}
+      </button>
+
+      <header className="space-y-3 rounded-md border border-border bg-card p-5">
+        <div className="flex items-center gap-2">
+          <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
+            {t('kicker')}
+          </p>
+          {gym.verified ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.14em] text-emerald-500">
+              <BadgeCheck className="h-3.5 w-3.5" aria-hidden />
+              {t('verified')}
+            </span>
+          ) : null}
+        </div>
         <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{gym.name}</h1>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
           {location ? (
@@ -78,6 +97,26 @@ export function GymProfileScreen({ slug }: Props) {
           </span>
         </div>
       </header>
+
+      {gym.leagues.length > 0 ? (
+        <div className="space-y-2">
+          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('leaguesTitle')}
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {gym.leagues.map((l) => (
+              <Link
+                key={l.id}
+                href={`/${locale}/app/pro/leagues/${l.id}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-bold hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Trophy className="h-3.5 w-3.5" aria-hidden />
+                {l.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : null}
 
       <div className="space-y-3">
         <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">

--- a/src/features/gym/services/gymProfile.ts
+++ b/src/features/gym/services/gymProfile.ts
@@ -8,13 +8,21 @@ export type GymEventSummary = {
   scoreType: 'time' | 'reps';
 };
 
+export type GymLeagueSummary = {
+  id: string;
+  name: string;
+  scope: 'local' | 'regional' | 'national';
+};
+
 export type GymProfile = {
   id: string;
   name: string;
   slug: string;
   city: string | null;
   countryCode: string | null;
+  verified: boolean;
   memberCount: number;
+  leagues: GymLeagueSummary[];
   events: GymEventSummary[];
 };
 
@@ -32,7 +40,9 @@ type Raw = {
   slug: string;
   city: string | null;
   countryCode: string | null;
+  verified: boolean;
   memberCount: number;
+  leagues: GymLeagueSummary[] | null;
   events: RawEvent[] | null;
 };
 
@@ -48,7 +58,9 @@ export async function getGymProfileBySlug(slug: string): Promise<GymProfile> {
     slug: raw.slug,
     city: raw.city,
     countryCode: raw.countryCode,
+    verified: Boolean(raw.verified),
     memberCount: Number(raw.memberCount ?? 0),
+    leagues: raw.leagues ?? [],
     events: (raw.events ?? []).map((e) => ({
       id: e.id,
       title: e.title,

--- a/src/features/pro/components/JudgeConsole.tsx
+++ b/src/features/pro/components/JudgeConsole.tsx
@@ -160,19 +160,40 @@ export function JudgeConsole() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">{t('intro')}</p>
-
       {rows.length === 0 ? (
         <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
           {t('empty')}
         </p>
       ) : (
         <>
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-                {t('pendingCount', { count: filtered.length })}
-              </p>
+          <div className="space-y-3 rounded-md border border-border bg-card p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Proof filter — one segmented control, not loose buttons. */}
+              <div
+                role="group"
+                aria-label={t('filter.proofLabel')}
+                className="inline-flex overflow-hidden rounded-md border border-border"
+              >
+                {(['all', 'video', 'novideo'] as const).map((f, i) => (
+                  <button
+                    key={f}
+                    type="button"
+                    onClick={() => {
+                      setProofFilter(f);
+                      setPage(0);
+                    }}
+                    className={`px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] transition-colors ${
+                      i > 0 ? 'border-l border-border' : ''
+                    } ${
+                      proofFilter === f
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-background text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {t(`filter.${f}`)}
+                  </button>
+                ))}
+              </div>
               <input
                 type="search"
                 value={query}
@@ -182,27 +203,8 @@ export function JudgeConsole() {
                 }}
                 placeholder={t('searchPlaceholder')}
                 aria-label={t('searchPlaceholder')}
-                className="w-full max-w-xs rounded-sm border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="min-w-[10rem] flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               />
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              {(['all', 'video', 'novideo'] as const).map((f) => (
-                <button
-                  key={f}
-                  type="button"
-                  onClick={() => {
-                    setProofFilter(f);
-                    setPage(0);
-                  }}
-                  className={`rounded-sm px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] transition-colors ${
-                    proofFilter === f
-                      ? 'bg-primary text-primary-foreground'
-                      : 'border border-border text-muted-foreground hover:text-foreground'
-                  }`}
-                >
-                  {t(`filter.${f}`)}
-                </button>
-              ))}
               {challenges.length > 1 ? (
                 <select
                   value={challengeFilter}
@@ -211,7 +213,7 @@ export function JudgeConsole() {
                     setPage(0);
                   }}
                   aria-label={t('filter.eventLabel')}
-                  className="ml-auto max-w-[16rem] rounded-sm border border-border bg-background px-3 py-1.5 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="max-w-[14rem] rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   <option value="">{t('filter.allEvents')}</option>
                   {challenges.map((c) => (
@@ -222,6 +224,9 @@ export function JudgeConsole() {
                 </select>
               ) : null}
             </div>
+            <p className="text-[11px] font-black uppercase tracking-[0.16em] text-muted-foreground">
+              {t('pendingCount', { count: filtered.length })}
+            </p>
           </div>
 
           {filtered.length === 0 ? (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1378,6 +1378,9 @@
   "gym": {
     "public": {
       "kicker": "Gym",
+      "back": "Back",
+      "verified": "Verified",
+      "leaguesTitle": "Leagues",
       "loading": "Loading gym…",
       "errorTitle": "Gym not found",
       "errorBody": "This gym doesn't exist or isn't available.",
@@ -1446,7 +1449,8 @@
         "video": "With video",
         "novideo": "No video",
         "allEvents": "All events",
-        "eventLabel": "Filter by event"
+        "eventLabel": "Filter by event",
+        "proofLabel": "Filter by proof"
       },
       "searchPlaceholder": "Search athlete or challenge…",
       "noMatch": "No pending score matches your search.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1378,6 +1378,9 @@
   "gym": {
     "public": {
       "kicker": "Salle",
+      "back": "Retour",
+      "verified": "Vérifiée",
+      "leaguesTitle": "Ligues",
       "loading": "Chargement de la salle…",
       "errorTitle": "Salle introuvable",
       "errorBody": "Cette salle n'existe pas ou n'est pas disponible.",
@@ -1446,7 +1449,8 @@
         "video": "Avec vidéo",
         "novideo": "Sans vidéo",
         "allEvents": "Tous les events",
-        "eventLabel": "Filtrer par event"
+        "eventLabel": "Filtrer par event",
+        "proofLabel": "Filtrer par preuve"
       },
       "searchPlaceholder": "Rechercher un athlète ou un défi…",
       "noMatch": "Aucun score en attente ne correspond à ta recherche.",

--- a/supabase/migrations/047_gym_public_profile_enrich.sql
+++ b/supabase/migrations/047_gym_public_profile_enrich.sql
@@ -1,0 +1,54 @@
+-- QA: the public gym page felt too bare. Enrich gym_public_profile with the gym's KYB-verified
+-- flag and the leagues it competes in, so the page shows real competitive context, not just a name.
+-- Return shape is additive (new keys); existing callers keep working.
+
+CREATE OR REPLACE FUNCTION public.gym_public_profile(p_slug text)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'id', g.id,
+    'name', g.name,
+    'slug', g.slug,
+    'city', g.city,
+    'countryCode', g.country_code,
+    'verified', (g.verified_at IS NOT NULL),
+    'memberCount', (
+      SELECT count(*) FROM public.profiles p WHERE p.affiliated_gym_id = g.id
+    ),
+    'leagues', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object('id', l.id, 'name', l.name, 'scope', l.scope)
+        ORDER BY l.name
+      )
+      FROM public.league_gyms lg
+      JOIN public.leagues l ON l.id = lg.league_id
+      WHERE lg.gym_id = g.id
+    ), '[]'::jsonb),
+    'events', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', e.id,
+          'title', e.title,
+          'startsAt', e.starts_at,
+          'endsAt', e.ends_at,
+          'scoreType', e.score_type
+        ) ORDER BY e.starts_at DESC
+      )
+      FROM (
+        SELECT id, title, starts_at, ends_at, score_type
+        FROM public.gym_events ge
+        WHERE ge.gym_id = g.id AND ge.status <> 'cancelled'
+        ORDER BY ge.starts_at DESC
+        LIMIT 20
+      ) e
+    ), '[]'::jsonb)
+  )
+  FROM public.gyms g
+  WHERE g.slug = p_slug;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_public_profile(text) TO authenticated;


### PR DESCRIPTION
Follow-up to the QA v3 feedback (screenshots).

**Judge Console filter bar** — was scattered (3 loose buttons, a detached search on top, a select off to the side) with a "meh" intro. Now one toolbar card: **segmented proof control** (All / With video / No video) + **search** + **event dropdown** on a single aligned row, count beneath. Intro paragraph dropped.

**Public gym page** (`/app/gym/[slug]`) — "trop simpliste, on revient comment?". Added:
- **← Back** button (browser history).
- **✓ Verified** KYB badge.
- **Leagues** the box competes in (chips → league detail).
- Migration **047** extends `gym_public_profile` with `verified` + `leagues` (additive). Applied to prod.

Both smoked live (segmented toolbar renders; gym page shows back + verified + "TrueGrynd National" league chip + events).

Migrations prod = up to **047**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)