### PR TITLE
feat(pro): design pass — members table + filters, event hero, league standings

### DIFF
--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, Plus, Radio } from 'lucide-react';
+import { ArrowLeft, CalendarDays, Clock, Dumbbell, Plus, Radio } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
@@ -271,7 +271,7 @@ function WorkoutPanel({
   return (
     <div className="space-y-4">
       {workout.rules ? (
-        <div className="rounded-md border border-border bg-card p-4">
+        <div className="rounded-md border border-border border-l-2 border-l-primary bg-card p-4">
           <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
             {t('detail.workout')}
           </p>
@@ -370,33 +370,68 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
         {t('detail.back')}
       </Link>
 
-      <header className="space-y-2">
-        <span className="inline-flex items-center rounded-sm border border-border bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
-          {t(`phase.${phase}`)}
-        </span>
-        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{event.title}</h1>
-        <p className="text-sm text-muted-foreground">
-          {formatEventWindow(event.startsAt, locale)} → {formatEventWindow(event.endsAt, locale)}
-        </p>
-        {canManage && !editing ? (
-          <div className="flex gap-2 pt-1">
-            <button
-              type="button"
-              onClick={() => setEditing(true)}
-              className="rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
-            >
-              {t('manage.edit')}
-            </button>
-            <button
-              type="button"
-              disabled={cancelling}
-              onClick={doCancel}
-              className="rounded-sm border border-primary/40 px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] text-primary hover:opacity-80 disabled:opacity-50"
-            >
-              {cancelling ? t('manage.cancelling') : t('manage.cancel')}
-            </button>
-          </div>
-        ) : null}
+      <header className="space-y-4 rounded-md border border-border bg-card p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.18em] ${
+              phase === 'live'
+                ? 'bg-primary text-primary-foreground'
+                : phase === 'upcoming'
+                  ? 'bg-sky-500/15 text-sky-400'
+                  : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            {phase === 'live' ? (
+              <span aria-hidden className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
+            ) : null}
+            {t(`phase.${phase}`)}
+          </span>
+          {canManage && !editing ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="rounded-md border border-border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                {t('manage.edit')}
+              </button>
+              <button
+                type="button"
+                disabled={cancelling}
+                onClick={doCancel}
+                className="rounded-md border border-primary/40 px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-primary hover:bg-primary/10 disabled:opacity-50"
+              >
+                {cancelling ? t('manage.cancelling') : t('manage.cancel')}
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="space-y-1.5">
+          <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">
+            {event.title}
+          </h1>
+          {event.description ? (
+            <p className="text-sm text-muted-foreground">{event.description}</p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-semibold">
+            <CalendarDays className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+            {formatEventWindow(event.startsAt, locale)}
+          </span>
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-semibold">
+            <Clock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+            {formatEventWindow(event.endsAt, locale)}
+          </span>
+          {workouts.length > 0 ? (
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-semibold">
+              <Dumbbell className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+              {t('detail.wodCount', { count: workouts.length })}
+            </span>
+          ) : null}
+        </div>
       </header>
 
       {editing ? (
@@ -408,10 +443,6 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
           }}
           onClose={() => setEditing(false)}
         />
-      ) : null}
-
-      {!editing && event.description ? (
-        <p className="text-sm text-muted-foreground">{event.description}</p>
       ) : null}
 
       {!editing ? <PacingCard eventId={event.id} canManage={canManage} /> : null}

--- a/src/features/pro/components/LeagueDetail.tsx
+++ b/src/features/pro/components/LeagueDetail.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Building2, Trophy } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
@@ -29,14 +29,25 @@ export function LeagueDetail({ leagueId }: { leagueId: string }) {
         {t('detail.back')}
       </Link>
 
-      <header className="space-y-1">
-        <span className="inline-flex items-center rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-          {league ? t(`scope.${league.scope}`) : '—'}
-        </span>
+      <header className="space-y-3 rounded-md border border-border bg-card p-5">
+        <div className="flex items-center gap-2">
+          <Trophy className="h-4 w-4 text-primary" aria-hidden />
+          <span className="inline-flex items-center rounded-full bg-primary/15 px-2 py-0.5 text-[9px] font-black uppercase tracking-[0.14em] text-primary">
+            {league ? t(`scope.${league.scope}`) : '—'}
+          </span>
+        </div>
         <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">
           {league?.name ?? '…'}
         </h1>
-        <p className="text-sm text-muted-foreground">{t('detail.intro')}</p>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+          <span>{t('detail.intro')}</span>
+          {state.status === 'ready' ? (
+            <span className="inline-flex items-center gap-1.5 font-semibold text-foreground">
+              <Building2 className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+              {t('detail.boxCount', { count: state.data.length })}
+            </span>
+          ) : null}
+        </div>
       </header>
 
       {state.status === 'loading' || state.status === 'idle' ? (
@@ -58,21 +69,26 @@ export function LeagueDetail({ leagueId }: { leagueId: string }) {
         </div>
       ) : (
         <ul className="rounded-md border border-border bg-card">
-          <li className="flex items-center gap-3 border-b border-border px-3 py-2 text-[9px] font-black uppercase tracking-[0.16em] text-muted-foreground">
+          <li className="flex items-center gap-3 border-b border-border px-4 py-2 text-[9px] font-black uppercase tracking-[0.16em] text-muted-foreground">
             <span className="w-6 shrink-0 text-center">#</span>
+            <span className="w-9 shrink-0" />
             <span className="min-w-0 flex-1">{t('detail.colGym')}</span>
-            <span className="shrink-0 text-right">{t('detail.avgRating')}</span>
+            <span className="hidden w-20 shrink-0 text-right sm:block">{t('detail.colRated')}</span>
+            <span className="w-20 shrink-0 text-right">{t('detail.avgRating')}</span>
           </li>
           {state.data.map((row, i) => (
             <li
               key={row.gymId}
-              className="flex items-center gap-3 border-b border-border px-3 py-3 last:border-b-0"
+              className="flex items-center gap-3 border-b border-border px-4 py-3 last:border-b-0"
             >
               <span
                 className="w-6 shrink-0 text-center text-base font-black tabular-nums"
                 style={{ color: RANK_MEDAL[i] ?? 'inherit' }}
               >
                 {i + 1}
+              </span>
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-black">
+                {row.gymName.slice(0, 2).toUpperCase()}
               </span>
               <span className="min-w-0 flex-1">
                 <Link
@@ -85,7 +101,10 @@ export function LeagueDetail({ leagueId }: { leagueId: string }) {
                   {t('detail.members', { count: row.memberCount })}
                 </span>
               </span>
-              <span className="shrink-0 text-right text-lg font-black tabular-nums">
+              <span className="hidden w-20 shrink-0 text-right text-xs tabular-nums text-muted-foreground sm:block">
+                {row.ratedCount}
+              </span>
+              <span className="w-20 shrink-0 text-right text-lg font-black tabular-nums">
                 {row.avgRating}
               </span>
             </li>

--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -2,6 +2,7 @@
 
 import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
+import { useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { listGymMembers, type GymMember } from '@/features/pro/services/members';
@@ -20,6 +21,9 @@ function lastActiveLabel(iso: string | null, locale: string, never: string): str
   });
 }
 
+const SEX_FILTERS = ['all', 'male', 'female'] as const;
+type SexFilter = (typeof SEX_FILTERS)[number];
+
 function MemberRow({ member }: { member: GymMember }) {
   const locale = useLocale();
   const t = useTranslations('pro.members');
@@ -27,29 +31,46 @@ function MemberRow({ member }: { member: GymMember }) {
 
   const inner = (
     <>
-      <span
-        aria-hidden
-        className={`h-2 w-2 shrink-0 rounded-full ${isHorde ? 'bg-[var(--faction-horde)]' : 'bg-sky-500'}`}
-      />
-      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-black">
+      <span className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-black">
         {initials(member.username)}
+        <span
+          aria-hidden
+          className={`absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-card ${
+            isHorde ? 'bg-[var(--faction-horde)]' : 'bg-sky-500'
+          }`}
+        />
       </span>
-      <span className="min-w-0 flex-1 truncate text-sm font-bold">{member.username ?? '—'}</span>
-      {member.division ? (
-        <span className="shrink-0 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground">
-          {member.division}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-bold">{member.username ?? '—'}</span>
+        <span className="block text-xs text-muted-foreground sm:hidden">
+          {member.division ?? '—'}
         </span>
-      ) : null}
-      <span className="w-28 shrink-0 text-right text-xs text-muted-foreground">
+      </span>
+      <span className="hidden w-24 shrink-0 sm:block">
+        {member.division ? (
+          <span className="rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground">
+            {member.division}
+          </span>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        )}
+      </span>
+      <span className="hidden w-20 shrink-0 text-xs text-muted-foreground md:block">
+        {member.sex === 'male' ? t('sex.male') : member.sex === 'female' ? t('sex.female') : '—'}
+        {member.age != null ? ` · ${member.age}` : ''}
+      </span>
+      <span className="w-24 shrink-0 text-right text-xs text-muted-foreground">
         {lastActiveLabel(member.lastActivityAt, locale, t('never'))}
       </span>
       {member.username ? (
         <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-      ) : null}
+      ) : (
+        <span className="w-3.5 shrink-0" />
+      )}
     </>
   );
 
-  // A member is an athlete → link to their public B2C profile.
+  // A member is an athlete → link to their public B2C profile (new tab, /pro stays put).
   return (
     <li className="border-b border-border last:border-b-0">
       {member.username ? (
@@ -58,12 +79,12 @@ function MemberRow({ member }: { member: GymMember }) {
           target="_blank"
           rel="noopener noreferrer"
           title={t('openProfile')}
-          className="flex items-center gap-3 px-3 py-3 transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {inner}
         </Link>
       ) : (
-        <div className="flex items-center gap-3 px-3 py-3">{inner}</div>
+        <div className="flex items-center gap-3 px-4 py-3">{inner}</div>
       )}
     </li>
   );
@@ -72,6 +93,29 @@ function MemberRow({ member }: { member: GymMember }) {
 export function MembersList() {
   const t = useTranslations('pro.members');
   const { state } = useAsyncResource(listGymMembers, []);
+  const [query, setQuery] = useState('');
+  const [sexFilter, setSexFilter] = useState<SexFilter>('all');
+  const [divisionFilter, setDivisionFilter] = useState('');
+
+  const members = useMemo(() => (state.status === 'ready' ? state.data : []), [state]);
+
+  const divisions = useMemo(
+    () =>
+      [...new Set(members.map((m) => m.division).filter((d): d is string => Boolean(d)))].sort(),
+    [members],
+  );
+
+  const q = query.trim().toLowerCase();
+  const filtered = useMemo(
+    () =>
+      members.filter((m) => {
+        if (q && !(m.username ?? '').toLowerCase().includes(q)) return false;
+        if (sexFilter !== 'all' && m.sex !== sexFilter) return false;
+        if (divisionFilter && m.division !== divisionFilter) return false;
+        return true;
+      }),
+    [members, q, sexFilter, divisionFilter],
+  );
 
   if (state.status === 'loading' || state.status === 'idle') {
     return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
@@ -80,26 +124,92 @@ export function MembersList() {
     return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
   }
 
-  const members = state.data;
-
-  return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">{t('intro')}</p>
-      {members.length === 0 ? (
+  if (members.length === 0) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">{t('intro')}</p>
         <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
           {t('empty')}
         </p>
-      ) : (
-        <>
-          <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {t('count', { count: members.length })}
-          </p>
-          <ul className="rounded-md border border-border bg-card">
-            {members.map((m) => (
-              <MemberRow key={m.id} member={m} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4">
+      <p className="text-sm text-muted-foreground">{t('intro')}</p>
+
+      <div className="space-y-3 rounded-md border border-border bg-card p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div
+            role="group"
+            aria-label={t('filterSexLabel')}
+            className="inline-flex overflow-hidden rounded-md border border-border"
+          >
+            {SEX_FILTERS.map((f, i) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setSexFilter(f)}
+                className={`px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] transition-colors ${
+                  i > 0 ? 'border-l border-border' : ''
+                } ${
+                  sexFilter === f
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-background text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {t(`filterSex.${f}`)}
+              </button>
             ))}
-          </ul>
-        </>
+          </div>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t('searchPlaceholder')}
+            aria-label={t('searchPlaceholder')}
+            className="min-w-[10rem] flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          {divisions.length > 1 ? (
+            <select
+              value={divisionFilter}
+              onChange={(e) => setDivisionFilter(e.target.value)}
+              aria-label={t('filterDivisionLabel')}
+              className="max-w-[12rem] rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="">{t('allDivisions')}</option>
+              {divisions.map((d) => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          ) : null}
+        </div>
+        <p className="text-[11px] font-black uppercase tracking-[0.16em] text-muted-foreground">
+          {t('count', { count: filtered.length })}
+        </p>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+          {t('noMatch')}
+        </p>
+      ) : (
+        <ul className="rounded-md border border-border bg-card">
+          <li className="flex items-center gap-3 border-b border-border px-4 py-2 text-[9px] font-black uppercase tracking-[0.16em] text-muted-foreground">
+            <span className="w-9 shrink-0" />
+            <span className="min-w-0 flex-1">{t('colAthlete')}</span>
+            <span className="hidden w-24 shrink-0 sm:block">{t('colDivision')}</span>
+            <span className="hidden w-20 shrink-0 md:block">{t('colSexAge')}</span>
+            <span className="w-24 shrink-0 text-right">{t('colLastActive')}</span>
+            <span className="w-3.5 shrink-0" />
+          </li>
+          {filtered.map((m) => (
+            <MemberRow key={m.id} member={m} />
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/src/features/pro/services/members.ts
+++ b/src/features/pro/services/members.ts
@@ -6,6 +6,8 @@ export type GymMember = {
   username: string | null;
   division: string | null;
   faction: string | null;
+  sex: string | null;
+  age: number | null;
   avatarUrl: string | null;
   lastActivityAt: string | null;
 };
@@ -15,6 +17,8 @@ type Row = {
   username: string | null;
   division: string | null;
   faction: string | null;
+  sex: string | null;
+  age: number | null;
   avatar_url: string | null;
   last_activity_at: string | null;
 };
@@ -28,6 +32,8 @@ export async function listGymMembers(): Promise<GymMember[]> {
     username: row.username,
     division: row.division,
     faction: row.faction,
+    sex: row.sex,
+    age: row.age,
     avatarUrl: row.avatar_url,
     lastActivityAt: row.last_activity_at,
   }));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1475,9 +1475,27 @@
       "loading": "Loading members…",
       "error": "Could not load members.",
       "empty": "No members affiliated yet.",
-      "count": "{count} members",
+      "count": "{count, plural, =0 {No members} one {# member} other {# members}}",
       "never": "never",
-      "openProfile": "Open athlete profile (new tab)"
+      "openProfile": "Open athlete profile (new tab)",
+      "searchPlaceholder": "Search an athlete…",
+      "filterSexLabel": "Filter by sex",
+      "filterDivisionLabel": "Filter by division",
+      "allDivisions": "All divisions",
+      "noMatch": "No member matches your filters.",
+      "filterSex": {
+        "all": "All",
+        "male": "Men",
+        "female": "Women"
+      },
+      "sex": {
+        "male": "M",
+        "female": "F"
+      },
+      "colAthlete": "Athlete",
+      "colDivision": "Division",
+      "colSexAge": "Sex · Age",
+      "colLastActive": "Last active"
     },
     "billing": {
       "loading": "Loading…",
@@ -1522,6 +1540,8 @@
         "emptyBody": "Be the first. Join this league from the leagues list and your box enters the ranking as soon as your members post ranked scores.",
         "joinCta": "Go to leagues to join",
         "colGym": "Box",
+        "colRated": "Rated",
+        "boxCount": "{count, plural, =0 {No boxes} one {# box} other {# boxes}}",
         "members": "{count, plural, =0 {no members} =1 {1 member} other {# members}}",
         "avgRating": "Avg rating",
         "note": "Score = average of each box's members' global rating. Shared-WOD matches are coming next.",
@@ -1543,6 +1563,7 @@
         "workout": "Workout",
         "standings": "Standings",
         "noStandings": "Standings will appear once the event is set up.",
+        "wodCount": "{count, plural, one {# WOD} other {# WODs}}",
         "submit": "Submit my score",
         "submitted": "Score submitted — it's in the standings and the Judge queue.",
         "cast": "Cast to TV",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1475,9 +1475,27 @@
       "loading": "Chargement des membres…",
       "error": "Impossible de charger les membres.",
       "empty": "Aucun membre affilié pour le moment.",
-      "count": "{count} membres",
+      "count": "{count, plural, =0 {Aucun membre} one {# membre} other {# membres}}",
       "never": "jamais",
-      "openProfile": "Ouvrir le profil de l'athlète (nouvel onglet)"
+      "openProfile": "Ouvrir le profil de l'athlète (nouvel onglet)",
+      "searchPlaceholder": "Rechercher un athlète…",
+      "filterSexLabel": "Filtrer par sexe",
+      "filterDivisionLabel": "Filtrer par division",
+      "allDivisions": "Toutes les divisions",
+      "noMatch": "Aucun membre ne correspond à tes filtres.",
+      "filterSex": {
+        "all": "Tous",
+        "male": "Hommes",
+        "female": "Femmes"
+      },
+      "sex": {
+        "male": "H",
+        "female": "F"
+      },
+      "colAthlete": "Athlète",
+      "colDivision": "Division",
+      "colSexAge": "Sexe · Âge",
+      "colLastActive": "Dernière activité"
     },
     "billing": {
       "loading": "Chargement…",
@@ -1522,6 +1540,8 @@
         "emptyBody": "Sois la première. Rejoins cette ligue depuis la liste des ligues — ta box entre au classement dès que tes membres postent des scores classés.",
         "joinCta": "Aller aux ligues pour rejoindre",
         "colGym": "Box",
+        "colRated": "Classés",
+        "boxCount": "{count, plural, =0 {Aucune box} one {# box} other {# box}}",
         "members": "{count, plural, =0 {aucun membre} =1 {1 membre} other {# membres}}",
         "avgRating": "Rating moyen",
         "note": "Score = moyenne du rating global des membres de chaque box. Les matchs sur WOD partagé arrivent ensuite.",
@@ -1543,6 +1563,7 @@
         "workout": "WOD",
         "standings": "Classement",
         "noStandings": "Le classement apparaîtra une fois l'event configuré.",
+        "wodCount": "{count, plural, one {# WOD} other {# WODs}}",
         "submit": "Soumettre mon score",
         "submitted": "Score soumis — il est dans le classement et la file Judge.",
         "cast": "Caster sur la TV",

--- a/supabase/migrations/048_gym_members_sex_age.sql
+++ b/supabase/migrations/048_gym_members_sex_age.sql
@@ -1,0 +1,32 @@
+-- QA design pass: the members roster gains real filters (sex, age, division). gym_members
+-- now returns sex + age so the UI can filter without a second query. Return type changes,
+-- so drop + recreate (scoping unchanged from 046: always the caller's own gym).
+
+DROP FUNCTION IF EXISTS public.gym_members();
+
+CREATE FUNCTION public.gym_members()
+RETURNS TABLE (
+  id uuid,
+  username text,
+  division text,
+  faction text,
+  sex text,
+  age int,
+  avatar_url text,
+  last_activity_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT p.id, p.username, p.division, p.faction, p.sex, p.age, p.avatar_url, p.last_activity_at
+  FROM public.profiles p
+  JOIN public.profiles caller ON caller.id = auth.uid()
+  WHERE caller.affiliated_gym_id IS NOT NULL
+    AND p.affiliated_gym_id = caller.affiliated_gym_id
+  ORDER BY p.last_activity_at DESC NULLS LAST
+  LIMIT 500;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_members() TO authenticated;


### PR DESCRIPTION
## QA feedback: pages read as flat stacked text → real design pass, big-app patterns

**Members** (the big one — "faut des filtres, pense au futur"):
- Filter toolbar: **sex segmented control** (All / Men / Women) + **athlete search** + **division select**.
- Proper roster **table**: header columns Athlete / Division / Sex·Age / Last active, avatar with faction status dot, division badges, hover rows, ↗ new-tab.
- **Migration 048**: `gym_members` now returns `sex` + `age` to power the filters (gym scoping unchanged from 046). Applied to prod.

**Event detail** ("toujours aussi moche"):
- Hero card: **color-coded phase badge** (pulsing dot when LIVE), title + description grouped, manage actions top-right, **info chips** (start / end / WOD count).
- WOD card gets a primary accent border.

**League detail** ("aussi moche"):
- Header card: trophy + scope pill + **box-count chip**.
- Standings table: **box avatar initials** + **Rated column** alongside avg rating.

### Smoke (live, Playwright)
- Members: toolbar + table render; **Women filter → 1 member (F·28)** ✓
- Event: hero card with À VENIR badge + 3 chips ✓
- League: header card + enriched table (CR avatar, Classés column, 53.7) ✓

Migrations prod = up to **048**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)