### PR TITLE
feat(pro): medium-term roster filters, consistent widths, billing redesign

### DIFF
--- a/src/features/pro/components/BillingScreen.tsx
+++ b/src/features/pro/components/BillingScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ExternalLink } from 'lucide-react';
+import { Check, ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
@@ -12,17 +12,19 @@ import {
 } from '@/features/pro/services/billing';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
 
+const FEATURES = ['judge', 'events', 'tv', 'leagues'] as const;
+
 function StatusBadge({ status }: { status: BillingStatus['status'] }) {
   const t = useTranslations('pro.billing');
   const tone =
     status === 'active' || status === 'trialing'
-      ? 'bg-primary text-primary-foreground'
+      ? 'bg-emerald-500/15 text-emerald-500'
       : status === 'past_due'
         ? 'bg-amber-500/20 text-amber-600 dark:text-amber-400'
         : 'bg-muted text-muted-foreground';
   return (
     <span
-      className={`rounded-sm px-2 py-1 text-[10px] font-black uppercase tracking-[0.14em] ${tone}`}
+      className={`rounded-full px-2.5 py-1 text-[10px] font-black uppercase tracking-[0.14em] ${tone}`}
     >
       {t(`status.${status}`)}
     </span>
@@ -56,31 +58,64 @@ function BillingBody({ data }: { data: BillingStatus }) {
   const subscribed = data.status === 'active' || data.status === 'trialing';
 
   return (
-    <div className="max-w-md space-y-5">
-      <div className="space-y-3 rounded-md border border-border bg-card p-5">
-        <div className="flex items-center justify-between">
-          <span className="text-sm font-black uppercase tracking-[0.12em]">{data.gymName}</span>
-          <StatusBadge status={data.status} />
+    <div className="mx-auto max-w-2xl space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <div className="overflow-hidden rounded-md border border-border bg-card">
+        <div className="space-y-5 p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
+                {t('planName')}
+              </p>
+              <p className="mt-1 text-sm font-black uppercase tracking-[0.12em]">{data.gymName}</p>
+            </div>
+            <StatusBadge status={data.status} />
+          </div>
+
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-4xl font-black tabular-nums tracking-tight">
+              {t('priceAmount')}
+            </span>
+            <span className="text-sm font-semibold text-muted-foreground">{t('pricePeriod')}</span>
+          </div>
+
+          <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {FEATURES.map((f) => (
+              <li key={f} className="flex items-center gap-2 text-sm">
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500/15">
+                  <Check className="h-3 w-3 text-emerald-500" aria-hidden />
+                </span>
+                {t(`features.${f}`)}
+              </li>
+            ))}
+          </ul>
+
+          {data.currentPeriodEnd ? (
+            <p className="text-xs text-muted-foreground">
+              {t('renews', { date: new Date(data.currentPeriodEnd).toLocaleDateString() })}
+            </p>
+          ) : null}
+
+          {error ? <p className="text-sm font-semibold text-primary">{error}</p> : null}
         </div>
-        <p className="text-sm text-muted-foreground">{t('plan')}</p>
-        {data.currentPeriodEnd ? (
-          <p className="text-xs text-muted-foreground">
-            {t('renews', { date: new Date(data.currentPeriodEnd).toLocaleDateString() })}
-          </p>
-        ) : null}
 
-        {error ? <p className="text-sm font-semibold text-primary">{error}</p> : null}
-
-        <button
-          type="button"
-          disabled={busy}
-          onClick={() => go(subscribed ? 'portal' : 'checkout')}
-          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
-        >
-          {busy ? t('loading') : subscribed ? t('manage') : t('subscribe')}
-          {!busy ? <ExternalLink className="h-4 w-4" aria-hidden /> : null}
-        </button>
+        <div className="border-t border-border bg-muted/30 p-4">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => go(subscribed ? 'portal' : 'checkout')}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {busy ? t('loading') : subscribed ? t('manage') : t('subscribe')}
+            {!busy ? <ExternalLink className="h-4 w-4" aria-hidden /> : null}
+          </button>
+        </div>
       </div>
+
       <p className="text-xs text-muted-foreground">{t('note')}</p>
     </div>
   );

--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -361,7 +361,7 @@ function EventBody({ event, onChanged }: { event: GymEvent; onChanged: () => voi
   }
 
   return (
-    <section className="mx-auto max-w-3xl space-y-6">
+    <section className="mx-auto max-w-5xl space-y-6">
       <Link
         href={`/${locale}/app/pro/events`}
         className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"

--- a/src/features/pro/components/LeagueDetail.tsx
+++ b/src/features/pro/components/LeagueDetail.tsx
@@ -20,7 +20,7 @@ export function LeagueDetail({ leagueId }: { leagueId: string }) {
     leaguesState.status === 'ready' ? leaguesState.data.find((l) => l.id === leagueId) : null;
 
   return (
-    <section className="mx-auto max-w-2xl space-y-5">
+    <section className="mx-auto max-w-5xl space-y-5">
       <Link
         href={`/${locale}/app/pro/leagues`}
         className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"

--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ExternalLink } from 'lucide-react';
+import { BadgeCheck, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
@@ -24,6 +24,21 @@ function lastActiveLabel(iso: string | null, locale: string, never: string): str
 const SEX_FILTERS = ['all', 'male', 'female'] as const;
 type SexFilter = (typeof SEX_FILTERS)[number];
 
+const PROOF_FILTERS = ['all', 'verified'] as const;
+type ProofFilter = (typeof PROOF_FILTERS)[number];
+
+/** Hyrox-style age buckets — the same cuts event divisions will use later. */
+const AGE_CATS = ['u24', 'a2534', 'a3544', 'm45'] as const;
+type AgeCat = (typeof AGE_CATS)[number];
+
+function ageCategory(age: number | null): AgeCat | null {
+  if (age == null) return null;
+  if (age < 25) return 'u24';
+  if (age < 35) return 'a2534';
+  if (age < 45) return 'a3544';
+  return 'm45';
+}
+
 function MemberRow({ member }: { member: GymMember }) {
   const locale = useLocale();
   const t = useTranslations('pro.members');
@@ -41,7 +56,12 @@ function MemberRow({ member }: { member: GymMember }) {
         />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-bold">{member.username ?? '—'}</span>
+        <span className="flex items-center gap-1.5">
+          <span className="truncate text-sm font-bold">{member.username ?? '—'}</span>
+          {member.verifiedCount > 0 ? (
+            <BadgeCheck className="h-3.5 w-3.5 shrink-0 text-emerald-500" aria-hidden />
+          ) : null}
+        </span>
         <span className="block text-xs text-muted-foreground sm:hidden">
           {member.division ?? '—'}
         </span>
@@ -58,6 +78,16 @@ function MemberRow({ member }: { member: GymMember }) {
       <span className="hidden w-20 shrink-0 text-xs text-muted-foreground md:block">
         {member.sex === 'male' ? t('sex.male') : member.sex === 'female' ? t('sex.female') : '—'}
         {member.age != null ? ` · ${member.age}` : ''}
+      </span>
+      <span className="hidden w-20 shrink-0 text-xs tabular-nums text-muted-foreground lg:block">
+        {member.weightKg != null ? t('weightValue', { kg: member.weightKg }) : '—'}
+      </span>
+      <span className="hidden w-20 shrink-0 text-right text-xs tabular-nums lg:block">
+        {member.verifiedCount > 0 ? (
+          <span className="font-black text-emerald-500">{member.verifiedCount}</span>
+        ) : (
+          <span className="text-muted-foreground">0</span>
+        )}
       </span>
       <span className="w-24 shrink-0 text-right text-xs text-muted-foreground">
         {lastActiveLabel(member.lastActivityAt, locale, t('never'))}
@@ -95,7 +125,9 @@ export function MembersList() {
   const { state } = useAsyncResource(listGymMembers, []);
   const [query, setQuery] = useState('');
   const [sexFilter, setSexFilter] = useState<SexFilter>('all');
+  const [proofFilter, setProofFilter] = useState<ProofFilter>('all');
   const [divisionFilter, setDivisionFilter] = useState('');
+  const [ageFilter, setAgeFilter] = useState('');
 
   const members = useMemo(() => (state.status === 'ready' ? state.data : []), [state]);
 
@@ -111,10 +143,12 @@ export function MembersList() {
       members.filter((m) => {
         if (q && !(m.username ?? '').toLowerCase().includes(q)) return false;
         if (sexFilter !== 'all' && m.sex !== sexFilter) return false;
+        if (proofFilter === 'verified' && m.verifiedCount === 0) return false;
         if (divisionFilter && m.division !== divisionFilter) return false;
+        if (ageFilter && ageCategory(m.age) !== ageFilter) return false;
         return true;
       }),
-    [members, q, sexFilter, divisionFilter],
+    [members, q, sexFilter, proofFilter, divisionFilter, ageFilter],
   );
 
   if (state.status === 'loading' || state.status === 'idle') {
@@ -124,10 +158,17 @@ export function MembersList() {
     return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
   }
 
+  const header = (
+    <header className="space-y-1">
+      <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+      <p className="text-sm text-muted-foreground">{t('intro')}</p>
+    </header>
+  );
+
   if (members.length === 0) {
     return (
       <div className="space-y-4">
-        <p className="text-sm text-muted-foreground">{t('intro')}</p>
+        {header}
         <p className="rounded-md border border-border bg-card p-6 text-center text-sm text-muted-foreground">
           {t('empty')}
         </p>
@@ -136,8 +177,8 @@ export function MembersList() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl space-y-4">
-      <p className="text-sm text-muted-foreground">{t('intro')}</p>
+    <div className="space-y-4">
+      {header}
 
       <div className="space-y-3 rounded-md border border-border bg-card p-3">
         <div className="flex flex-wrap items-center gap-2">
@@ -163,6 +204,29 @@ export function MembersList() {
               </button>
             ))}
           </div>
+          <div
+            role="group"
+            aria-label={t('filterProofLabel')}
+            className="inline-flex overflow-hidden rounded-md border border-border"
+          >
+            {PROOF_FILTERS.map((f, i) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setProofFilter(f)}
+                className={`inline-flex items-center gap-1 px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] transition-colors ${
+                  i > 0 ? 'border-l border-border' : ''
+                } ${
+                  proofFilter === f
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-background text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {f === 'verified' ? <BadgeCheck className="h-3 w-3" aria-hidden /> : null}
+                {t(`filterProof.${f}`)}
+              </button>
+            ))}
+          </div>
           <input
             type="search"
             value={query}
@@ -171,6 +235,19 @@ export function MembersList() {
             aria-label={t('searchPlaceholder')}
             className="min-w-[10rem] flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
+          <select
+            value={ageFilter}
+            onChange={(e) => setAgeFilter(e.target.value)}
+            aria-label={t('filterAgeLabel')}
+            className="max-w-[11rem] rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="">{t('allAges')}</option>
+            {AGE_CATS.map((c) => (
+              <option key={c} value={c}>
+                {t(`ageCat.${c}`)}
+              </option>
+            ))}
+          </select>
           {divisions.length > 1 ? (
             <select
               value={divisionFilter}
@@ -203,6 +280,8 @@ export function MembersList() {
             <span className="min-w-0 flex-1">{t('colAthlete')}</span>
             <span className="hidden w-24 shrink-0 sm:block">{t('colDivision')}</span>
             <span className="hidden w-20 shrink-0 md:block">{t('colSexAge')}</span>
+            <span className="hidden w-20 shrink-0 lg:block">{t('colWeight')}</span>
+            <span className="hidden w-20 shrink-0 text-right lg:block">{t('colVerified')}</span>
             <span className="w-24 shrink-0 text-right">{t('colLastActive')}</span>
             <span className="w-3.5 shrink-0" />
           </li>

--- a/src/features/pro/components/ProShell.tsx
+++ b/src/features/pro/components/ProShell.tsx
@@ -186,7 +186,14 @@ export function ProShell({ children }: { children: ReactNode }) {
       </aside>
 
       <main className="min-w-0 flex-1 px-4 py-6 md:px-8">
-        <SubscriptionGate>{children}</SubscriptionGate>
+        {/* One consistent content width for every PRO page; the TV broadcast stays full-bleed. */}
+        <SubscriptionGate>
+          {/\/tv(\/|$)/.test(pathname) ? (
+            children
+          ) : (
+            <div className="mx-auto w-full max-w-7xl">{children}</div>
+          )}
+        </SubscriptionGate>
       </main>
     </div>
   );

--- a/src/features/pro/services/members.ts
+++ b/src/features/pro/services/members.ts
@@ -8,6 +8,8 @@ export type GymMember = {
   faction: string | null;
   sex: string | null;
   age: number | null;
+  weightKg: number | null;
+  verifiedCount: number;
   avatarUrl: string | null;
   lastActivityAt: string | null;
 };
@@ -19,6 +21,8 @@ type Row = {
   faction: string | null;
   sex: string | null;
   age: number | null;
+  weight_kg: number | null;
+  verified_count: number | null;
   avatar_url: string | null;
   last_activity_at: string | null;
 };
@@ -34,6 +38,8 @@ export async function listGymMembers(): Promise<GymMember[]> {
     faction: row.faction,
     sex: row.sex,
     age: row.age,
+    weightKg: row.weight_kg == null ? null : Number(row.weight_kg),
+    verifiedCount: Number(row.verified_count ?? 0),
     avatarUrl: row.avatar_url,
     lastActivityAt: row.last_activity_at,
   }));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1495,12 +1495,40 @@
       "colAthlete": "Athlete",
       "colDivision": "Division",
       "colSexAge": "Sex · Age",
-      "colLastActive": "Last active"
+      "colWeight": "Weight",
+      "colVerified": "Verified",
+      "colLastActive": "Last active",
+      "title": "Members",
+      "weightValue": "{kg} kg",
+      "filterProofLabel": "Filter by proof",
+      "filterProof": {
+        "all": "All",
+        "verified": "Verified"
+      },
+      "filterAgeLabel": "Filter by age category",
+      "allAges": "All ages",
+      "ageCat": {
+        "u24": "U24",
+        "a2534": "25–34",
+        "a3544": "35–44",
+        "m45": "Masters 45+"
+      }
     },
     "billing": {
       "loading": "Loading…",
       "noGym": "Create your gym first to manage billing.",
       "plan": "TrueGrynd GYM PRO — 100/mo. Validation, events, TV cast, leagues.",
+      "title": "Billing",
+      "subtitle": "Your TrueGrynd GYM PRO subscription.",
+      "planName": "TrueGrynd GYM PRO",
+      "priceAmount": "€100",
+      "pricePeriod": "/ month",
+      "features": {
+        "judge": "Judge Console — verified scores",
+        "events": "Unlimited competitions & events",
+        "tv": "Live TV cast",
+        "leagues": "Box-vs-box leagues"
+      },
       "subscribe": "Subscribe",
       "gateTitle": "Subscription required",
       "gateBody": "Your gym's TrueGrynd GYM PRO subscription is inactive. Subscribe to restore validation, events, TV cast and leagues.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1495,12 +1495,40 @@
       "colAthlete": "Athlète",
       "colDivision": "Division",
       "colSexAge": "Sexe · Âge",
-      "colLastActive": "Dernière activité"
+      "colWeight": "Poids",
+      "colVerified": "Vérifiés",
+      "colLastActive": "Dernière activité",
+      "title": "Membres",
+      "weightValue": "{kg} kg",
+      "filterProofLabel": "Filtrer par preuve",
+      "filterProof": {
+        "all": "Tous",
+        "verified": "Vérifiés"
+      },
+      "filterAgeLabel": "Filtrer par catégorie d'âge",
+      "allAges": "Tous les âges",
+      "ageCat": {
+        "u24": "U24",
+        "a2534": "25–34",
+        "a3544": "35–44",
+        "m45": "Masters 45+"
+      }
     },
     "billing": {
       "loading": "Chargement…",
       "noGym": "Crée d'abord ta salle pour gérer la facturation.",
       "plan": "TrueGrynd GYM PRO — 100/mois. Validation, events, TV cast, ligues.",
+      "title": "Facturation",
+      "subtitle": "Ton abonnement TrueGrynd GYM PRO.",
+      "planName": "TrueGrynd GYM PRO",
+      "priceAmount": "100 €",
+      "pricePeriod": "/ mois",
+      "features": {
+        "judge": "Judge Console — scores vérifiés",
+        "events": "Compétitions & events illimités",
+        "tv": "TV cast en direct",
+        "leagues": "Ligues box vs box"
+      },
       "subscribe": "S'abonner",
       "gateTitle": "Abonnement requis",
       "gateBody": "L'abonnement TrueGrynd GYM PRO de ta salle est inactif. Abonne-toi pour rétablir la validation, les events, le TV cast et les ligues.",

--- a/supabase/migrations/049_gym_members_weight_verified.sql
+++ b/supabase/migrations/049_gym_members_weight_verified.sql
@@ -1,0 +1,40 @@
+-- Medium-term roster filters (age categories, verified athletes, weight classes): gym_members
+-- gains weight_kg and the member's count of judge-verified scores. Age categories are derived
+-- client-side from `age`. Return type changes → drop + recreate (scoping unchanged from 046).
+
+DROP FUNCTION IF EXISTS public.gym_members();
+
+CREATE FUNCTION public.gym_members()
+RETURNS TABLE (
+  id uuid,
+  username text,
+  division text,
+  faction text,
+  sex text,
+  age int,
+  weight_kg numeric,
+  verified_count int,
+  avatar_url text,
+  last_activity_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT p.id, p.username, p.division, p.faction, p.sex, p.age, p.weight_kg,
+         (SELECT count(*)::int
+            FROM public.scores s
+            WHERE s.user_id = p.id
+              AND s.is_hidden = false
+              AND s.proof_level = 'judge_verified') AS verified_count,
+         p.avatar_url, p.last_activity_at
+  FROM public.profiles p
+  JOIN public.profiles caller ON caller.id = auth.uid()
+  WHERE caller.affiliated_gym_id IS NOT NULL
+    AND p.affiliated_gym_id = caller.affiliated_gym_id
+  ORDER BY p.last_activity_at DESC NULLS LAST
+  LIMIT 500;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_members() TO authenticated;


### PR DESCRIPTION
## Medium-term filters + wide-screen consistency + billing redesign

**Members — medium-term filters** (on top of sex/search/division):
- **Age categories** — U24 / 25–34 / 35–44 / Masters 45+ (Hyrox-style cuts; the same buckets event divisions will reuse).
- **Verified filter** — segmented All / ✓ Verified (athletes holding judge-verified scores); green BadgeCheck on rows + a **Verified count column**.
- **Weight column** (kg). Migration **049**: `gym_members` returns `weight_kg` + `verified_count` (scoping unchanged). Applied to prod.
- Page title added.

**Consistent widths on big screens** ("sur 2500px ça fait vide" / TV list full-width vs members narrow):
- ProShell now wraps every PRO page in one **max-w-7xl** container; detail pages align at max-w-5xl inside it. The TV **broadcast** route stays full-bleed for gym screens.

**Billing — real SaaS page** ("billing moche"):
- Title + subtitle, plan card: plan name + gym + status pill, **big 100€/mois**, 2-col feature checklist (✓ Judge Console, ✓ events illimités, ✓ TV cast, ✓ ligues), renewal date, footer CTA (Stripe in a new tab).

### Smoke (live, Playwright)
- Members: title + double segmented + search + 2 selects; **Verified → 2 members**, **35–44 → iron_ghost only** ✓
- Verified counts honest: an INSERTed fake `judge_verified` score got auto-downgraded by the DB trigger (moat working) — only real judge-validated scores count ✓
- Billing: pricing card renders (ESSAI pill, 100€/mois, checklist) ✓

Migrations prod = up to **049**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)