### PR TITLE
fix(pro): themed FilterSelect + cast button in leaderboard header

### DIFF
--- a/src/components/FilterSelect.tsx
+++ b/src/components/FilterSelect.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Check, ChevronDown } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+type Option = { value: string; label: string };
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  options: Option[];
+  /** Label for the empty value ('' = no filter), always shown first. */
+  allLabel: string;
+  ariaLabel: string;
+  className?: string;
+};
+
+/**
+ * Themed replacement for a native `<select>` used as a list filter — the OS popup can't be
+ * styled and clashes with the app. Button trigger + card-styled listbox, closes on outside
+ * click / Escape.
+ */
+export function FilterSelect({ value, onChange, options, allLabel, ariaLabel, className }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const items = [{ value: '', label: allLabel }, ...options];
+  const current = items.find((o) => o.value === value) ?? items[0];
+
+  return (
+    <div ref={ref} className={`relative ${className ?? ''}`}>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex w-full items-center justify-between gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <span className={`truncate ${value ? 'font-semibold' : 'text-muted-foreground'}`}>
+          {current.label}
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${
+            open ? 'rotate-180' : ''
+          }`}
+          aria-hidden
+        />
+      </button>
+      {open ? (
+        <ul
+          role="listbox"
+          aria-label={ariaLabel}
+          className="absolute right-0 z-20 mt-1 max-h-64 w-full min-w-[11rem] overflow-auto rounded-md border border-border bg-card p-1 shadow-lg"
+        >
+          {items.map((o) => (
+            <li key={o.value}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={o.value === value}
+                onClick={() => {
+                  onChange(o.value);
+                  setOpen(false);
+                }}
+                className={`flex w-full items-center gap-2 rounded-sm px-2.5 py-2 text-left text-sm ${
+                  o.value === value
+                    ? 'bg-primary/10 font-bold text-primary'
+                    : 'text-foreground hover:bg-muted'
+                }`}
+              >
+                <span className="min-w-0 flex-1 truncate">{o.label}</span>
+                {o.value === value ? <Check className="h-3.5 w-3.5 shrink-0" aria-hidden /> : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/challenges/components/Leaderboard.tsx
+++ b/src/features/challenges/components/Leaderboard.tsx
@@ -33,6 +33,8 @@ type Props = {
   availableVariants: readonly import('@/lib/types/database.types').ChallengeVariant[];
   /** 'preview' = compact top rows + link to the full page; 'full' = filterable page. */
   mode?: 'preview' | 'full';
+  /** Extra actions rendered in the header next to the filters toggle (e.g. PRO "cast to TV"). */
+  headerActions?: React.ReactNode;
 };
 
 const PROOF_SUMMARY_KEY: Record<string, string> = {
@@ -52,7 +54,13 @@ function pickDefaultPreset(
   );
 }
 
-export function Leaderboard({ challengeId, scoreType, availableVariants, mode = 'full' }: Props) {
+export function Leaderboard({
+  challengeId,
+  scoreType,
+  availableVariants,
+  mode = 'full',
+  headerActions,
+}: Props) {
   const isPreview = mode === 'preview';
   const locale = useLocale();
   const t = useTranslations('leaderboard');
@@ -175,26 +183,29 @@ export function Leaderboard({ challengeId, scoreType, availableVariants, mode = 
     <section className="space-y-3">
       <header className="flex items-center justify-between gap-3">
         <h2 className="text-lg font-black uppercase tracking-tight">{t('title')}</h2>
-        {!isPreview ? (
-          <button
-            type="button"
-            onClick={() => setFiltersOpen((open) => !open)}
-            aria-expanded={filtersOpen}
-            className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-[11px] font-black uppercase tracking-[0.16em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden />
-            {t('filtersToggle')}
-            {filterChips.length > 0 ? (
-              <span className="rounded-full bg-primary px-1.5 text-[10px] tabular-nums text-primary-foreground">
-                {filterChips.length}
-              </span>
-            ) : null}
-            <ChevronDown
-              className={`h-3.5 w-3.5 transition-transform ${filtersOpen ? 'rotate-180' : ''}`}
-              aria-hidden
-            />
-          </button>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {headerActions}
+          {!isPreview ? (
+            <button
+              type="button"
+              onClick={() => setFiltersOpen((open) => !open)}
+              aria-expanded={filtersOpen}
+              className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-[11px] font-black uppercase tracking-[0.16em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden />
+              {t('filtersToggle')}
+              {filterChips.length > 0 ? (
+                <span className="rounded-full bg-primary px-1.5 text-[10px] tabular-nums text-primary-foreground">
+                  {filterChips.length}
+                </span>
+              ) : null}
+              <ChevronDown
+                className={`h-3.5 w-3.5 transition-transform ${filtersOpen ? 'rotate-180' : ''}`}
+                aria-hidden
+              />
+            </button>
+          ) : null}
+        </div>
       </header>
 
       {isPreview ? null : filtersOpen ? (

--- a/src/features/pro/components/EventDetail.tsx
+++ b/src/features/pro/components/EventDetail.tsx
@@ -311,21 +311,21 @@ function WorkoutPanel({
       ) : null}
 
       <div className="space-y-2">
-        <div className="flex justify-end">
-          <Link
-            href={`/${locale}/app/pro/events/${event.id}/tv`}
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
-          >
-            <Radio className="h-3.5 w-3.5" />
-            {t('detail.cast')}
-          </Link>
-        </div>
         <Leaderboard
           key={`${workout.challengeId}-${reloadKey}-${profile?.id ?? ''}`}
           challengeId={workout.challengeId}
           scoreType={workout.scoreType}
           availableVariants={GYM_EVENT_VARIANTS}
           mode="full"
+          headerActions={
+            <Link
+              href={`/${locale}/app/pro/events/${event.id}/tv`}
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-3 py-2 text-[11px] font-black uppercase tracking-[0.16em] text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Radio className="h-3.5 w-3.5" aria-hidden />
+              {t('detail.cast')}
+            </Link>
+          }
         />
       </div>
     </div>

--- a/src/features/pro/components/JudgeConsole.tsx
+++ b/src/features/pro/components/JudgeConsole.tsx
@@ -4,6 +4,7 @@ import { Check, Play } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
 
+import { FilterSelect } from '@/components/FilterSelect';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
 import {
   listPendingVerifications,
@@ -206,22 +207,17 @@ export function JudgeConsole() {
                 className="min-w-[10rem] flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               />
               {challenges.length > 1 ? (
-                <select
+                <FilterSelect
                   value={challengeFilter}
-                  onChange={(e) => {
-                    setChallengeFilter(e.target.value);
+                  onChange={(v) => {
+                    setChallengeFilter(v);
                     setPage(0);
                   }}
-                  aria-label={t('filter.eventLabel')}
-                  className="max-w-[14rem] rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <option value="">{t('filter.allEvents')}</option>
-                  {challenges.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
+                  options={challenges.map((c) => ({ value: c, label: c }))}
+                  allLabel={t('filter.allEvents')}
+                  ariaLabel={t('filter.eventLabel')}
+                  className="w-56"
+                />
               ) : null}
             </div>
             <p className="text-[11px] font-black uppercase tracking-[0.16em] text-muted-foreground">

--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { FilterSelect } from '@/components/FilterSelect';
 import { listGymMembers, type GymMember } from '@/features/pro/services/members';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
 
@@ -235,33 +236,23 @@ export function MembersList() {
             aria-label={t('searchPlaceholder')}
             className="min-w-[10rem] flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
-          <select
+          <FilterSelect
             value={ageFilter}
-            onChange={(e) => setAgeFilter(e.target.value)}
-            aria-label={t('filterAgeLabel')}
-            className="max-w-[11rem] rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <option value="">{t('allAges')}</option>
-            {AGE_CATS.map((c) => (
-              <option key={c} value={c}>
-                {t(`ageCat.${c}`)}
-              </option>
-            ))}
-          </select>
+            onChange={setAgeFilter}
+            options={AGE_CATS.map((c) => ({ value: c, label: t(`ageCat.${c}`) }))}
+            allLabel={t('allAges')}
+            ariaLabel={t('filterAgeLabel')}
+            className="w-44"
+          />
           {divisions.length > 1 ? (
-            <select
+            <FilterSelect
               value={divisionFilter}
-              onChange={(e) => setDivisionFilter(e.target.value)}
-              aria-label={t('filterDivisionLabel')}
-              className="max-w-[12rem] rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <option value="">{t('allDivisions')}</option>
-              {divisions.map((d) => (
-                <option key={d} value={d}>
-                  {d}
-                </option>
-              ))}
-            </select>
+              onChange={setDivisionFilter}
+              options={divisions.map((d) => ({ value: d, label: d }))}
+              allLabel={t('allDivisions')}
+              ariaLabel={t('filterDivisionLabel')}
+              className="w-48"
+            />
           ) : null}
         </div>
         <p className="text-[11px] font-black uppercase tracking-[0.16em] text-muted-foreground">


### PR DESCRIPTION
Follow-up to the two QA screenshots.

**Native select popup ("pas ouf")** — the OS dropdown can't be styled. New **`FilterSelect`** component: themed trigger + card-styled listbox (active item highlighted + check, outside-click/Escape close). Used by:
- Judge Console — event filter
- Members — age category + division filters

**Event detail** — the *Cast to TV* button floated alone above the leaderboard. `Leaderboard` gains an optional `headerActions` slot (additive prop — B2C callers unchanged); the cast button now sits **in the leaderboard header next to Filters**, one aligned row: `CLASSEMENT ——— [CASTER SUR LA TV] [FILTRES]`.

Smoked live: members dropdown opens themed (dark card, U24/25–34/35–44/Masters 45+, check on active), event page header aligned. 🤖 Generated with [Claude Code](https://claude.com/claude-code)