### PR TITLE
docs(issues): V3 finito + V4 slice plan (#167–#174)

### DIFF
--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -3,15 +3,16 @@
 > **Tracker vivant** (suivi + tâches en cours).  
 > Détail historique V1/V2 (sections A–L, V2-00–12) : **[archive-v1-v2-detail.md](./archive-v1-v2-detail.md)** · Stratégie V3 : **[V3_STRATEGY.md](../V3_STRATEGY.md)**
 
-**Dernière mise à jour :** 24 juin 2026
+**Dernière mise à jour :** 5 juillet 2026
 
 ---
 
 ## Prochaine action
 
-🟢 **V3 — Écosystème B2B2C : TERMINÉE.** Toutes les issues #109–#119 + #122/#136/#137/#139 livrées et fermées. Migrations prod **028→043**. Surface PRO complète : Dashboard · Judge · Events (multi-WOD, edit/cancel) · TV (realtime) · Ligues (opt-in + standings) · Members · Billing (Stripe GYM PRO live) · PLG · Pacing.  
-👉 **QA visuel de fin de V3** (Igor), puis lancer la prochaine grande phase : **V4** (gestion salle, [#140](https://github.com/igorms-pro/truegrynd/issues/140)) ou **V5** (premium B2C, [#141](https://github.com/igorms-pro/truegrynd/issues/141)).
+🟢 **V3 FINITO** — build + **3 rounds de QA Igor** (refonte /pro #155/#156 · QA v2 #157–#161 · QA v3 + design pass #162–#166). Migrations prod **028→049**. Surface PRO niveau « big app » : sidebar collapsible, dashboard signal, Judge (filtres/recherche/pagination), Events (hero, pickers MIN:SEC), Membres (table + filtres sexe/âge/vérifiés/poids), Ligues, page gym publique `/app/gym/[slug]`, Billing SaaS (Stripe new tab). Fixes sécu : scoping RPCs (mig 044, 046).
+👉 **V4 — gestion salle** ([#140](https://github.com/igorms-pro/truegrynd/issues/140)) : slices **V4-01→08** créées ([#167](https://github.com/igorms-pro/truegrynd/issues/167)–[#174](https://github.com/igorms-pro/truegrynd/issues/174)). Démarrer par **V4-01 Planning**. En parallèle recommandé : **pilote box réelle d'Igor** (vrai SIRET, vrai event, vrais membres).
 
+_Backlog transverse ouvert :_ [#154](https://github.com/igorms-pro/truegrynd/issues/154) commentaires communauté (s'intercale quand on veut) · [#153](https://github.com/igorms-pro/truegrynd/issues/153) matching partenaires (s'insère autour de V4-08).
 _Reste V2 (non bloquant, suivi dans [#100](https://github.com/igorms-pro/truegrynd/issues/100)) :_ passe **prod Vercel** + **PostHog Live** · duel rival end-to-end (2 comptes) · pagination leaderboard 100k (backend).
 
 ---
@@ -50,27 +51,58 @@ Pivot B2B2C : l'arène B2C gratuite reste le moteur d'acquisition, les salles pa
 
 ---
 
-## V4 / V5 — Phases futures (epics)
+### Phase 3 — QA & polish (rounds Igor) ✅
 
-| Epic                                                              | Rôle                                                         |
-| ----------------------------------------------------------------- | ------------------------------------------------------------ |
-| **V4** [#140](https://github.com/igorms-pro/truegrynd/issues/140) | App **gestion de salle** (planning/résa/abos, Peppy/Resawod) |
-| **V5** [#141](https://github.com/igorms-pro/truegrynd/issues/141) | **Premium B2C** « Verified Athlete » (+ cosmetics)           |
+| Round               | Contenu                                                                                                                                                                                       | Statut                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| Refonte `/pro`      | Workspace dédié (sidebar, onboarding KYB first, thème/langue) + liens profils membres                                                                                                         | 🟢 #155/#156               |
+| QA v2 (9 pts)       | Pickers MIN:SEC + reps number · page gym publique `/app/gym/[slug]` · sidebar collapsible · Judge search+pagination · dashboard signal · billing new tab                                      | 🟢 #157–#161 (mig 045)     |
+| QA v3 + design pass | Judge filtres (chips+event) · hero event · membres table+filtres (sexe/âge/vérifiés/poids) · ligues enrichies · billing SaaS · FilterSelect themé · largeurs 7xl · **fix scoping RPCs admin** | 🟢 #162–#166 (mig 046–049) |
+
+---
+
+## V4 — Gestion salle (en cours de prépa)
+
+Remplacer Peppy : planning, résa, abos, paiements membres — bundlé avec le moat compétition. Stratégie : [V4_STRATEGY.md](../V4_STRATEGY.md) · Epic [#140](https://github.com/igorms-pro/truegrynd/issues/140).
+
+| Slice      | Issue                                                                                                                   | Rôle                                                                  | Statut |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------ |
+| **V4-01**  | [#167](https://github.com/igorms-pro/truegrynd/issues/167)                                                              | Planning : créneaux récurrents + calendrier membre « Ma salle »       | 🔴     |
+| **V4-02**  | [#168](https://github.com/igorms-pro/truegrynd/issues/168)                                                              | Réservations : booking, waitlist, no-show + roster coach avec niveau  | 🔴     |
+| **V4-03**  | [#169](https://github.com/igorms-pro/truegrynd/issues/169)                                                              | Boucle résa ⇄ WOD + leaderboard de classe (killer #2)                 | 🔴     |
+| **V4-04**  | [#170](https://github.com/igorms-pro/truegrynd/issues/170)                                                              | Retention dashboard : membres à risque (killer #1, argument de vente) | 🔴     |
+| **V4-05**  | [#171](https://github.com/igorms-pro/truegrynd/issues/171)                                                              | Abonnements & carnets (plans de la salle)                             | 🔴     |
+| **V4-06**  | [#172](https://github.com/igorms-pro/truegrynd/issues/172)                                                              | Paiements membres — Stripe Connect Express                            | 🔴     |
+| **V4-07**  | [#173](https://github.com/igorms-pro/truegrynd/issues/173)                                                              | Check-in / présence (kiosk coach)                                     | 🔴     |
+| **V4-08**  | [#174](https://github.com/igorms-pro/truegrynd/issues/174)                                                              | Social booking + drop-in cross-gym (killers #3/#4)                    | 🔴     |
+| Transverse | [#153](https://github.com/igorms-pro/truegrynd/issues/153) / [#154](https://github.com/igorms-pro/truegrynd/issues/154) | Matching partenaires · commentaires communauté                        | 🔴     |
+
+**Critère de succès V4 :** la box pilote lâche Peppy et fait tourner sa semaine complète sur TrueGrynd.
+
+---
+
+## V5 — Phase future (epic)
+
+| Epic                                                              | Rôle                                               |
+| ----------------------------------------------------------------- | -------------------------------------------------- |
+| **V5** [#141](https://github.com/igorms-pro/truegrynd/issues/141) | **Premium B2C** « Verified Athlete » (+ cosmetics) |
 
 ---
 
 ## Suivi synthétique
 
-| Bloc                                  | Avancement                                                                                                                                                                                                 |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **V1 core** (UGC, admin, B–G)         | 🟢 PR [#30](https://github.com/igorms-pro/truegrynd/pull/30)–[#55](https://github.com/igorms-pro/truegrynd/pull/55) · migrations **`006`–`014`**                                                           |
-| **V1.5** (faction, profil, settings)  | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57)–[#62](https://github.com/igorms-pro/truegrynd/issues/62)                                                                                       |
-| **Pré-V2 polish**                     | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63)–[#68](https://github.com/igorms-pro/truegrynd/issues/68)                                                                                       |
-| **Production hardening**              | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70)                                                                                      |
-| **V2-00–12**                          | 🟢 [#71](https://github.com/igorms-pro/truegrynd/issues/71)–[#99](https://github.com/igorms-pro/truegrynd/pull/99) · migrations **`015`–`027`**                                                            |
-| **QA V2 + clean code**                | 🟢 [#100](https://github.com/igorms-pro/truegrynd/issues/100) · PRs [#101](https://github.com/igorms-pro/truegrynd/pull/101)–[#108](https://github.com/igorms-pro/truegrynd/pull/108)                      |
-| **V3 B2B2C**                          | 🟢 **terminée** · [#109](https://github.com/igorms-pro/truegrynd/issues/109)–[#119](https://github.com/igorms-pro/truegrynd/issues/119) + #122/#136/#137/#139 · PRs #120–#148 · migrations **`028`–`043`** |
-| **V4 gestion salle / V5 premium B2C** | 🔴 epics [#140](https://github.com/igorms-pro/truegrynd/issues/140) / [#141](https://github.com/igorms-pro/truegrynd/issues/141)                                                                           |
+| Bloc                                 | Avancement                                                                                                                                                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **V1 core** (UGC, admin, B–G)        | 🟢 PR [#30](https://github.com/igorms-pro/truegrynd/pull/30)–[#55](https://github.com/igorms-pro/truegrynd/pull/55) · migrations **`006`–`014`**                                                              |
+| **V1.5** (faction, profil, settings) | 🟢 [#57](https://github.com/igorms-pro/truegrynd/issues/57)–[#62](https://github.com/igorms-pro/truegrynd/issues/62)                                                                                          |
+| **Pré-V2 polish**                    | 🟢 [#63](https://github.com/igorms-pro/truegrynd/issues/63)–[#68](https://github.com/igorms-pro/truegrynd/issues/68)                                                                                          |
+| **Production hardening**             | 🟢 [#69](https://github.com/igorms-pro/truegrynd/issues/69) PR [#70](https://github.com/igorms-pro/truegrynd/pull/70)                                                                                         |
+| **V2-00–12**                         | 🟢 [#71](https://github.com/igorms-pro/truegrynd/issues/71)–[#99](https://github.com/igorms-pro/truegrynd/pull/99) · migrations **`015`–`027`**                                                               |
+| **QA V2 + clean code**               | 🟢 [#100](https://github.com/igorms-pro/truegrynd/issues/100) · PRs [#101](https://github.com/igorms-pro/truegrynd/pull/101)–[#108](https://github.com/igorms-pro/truegrynd/pull/108)                         |
+| **V3 B2B2C**                         | 🟢 **terminée** · [#109](https://github.com/igorms-pro/truegrynd/issues/109)–[#119](https://github.com/igorms-pro/truegrynd/issues/119) + #122/#136/#137/#139 · PRs #120–#148 · migrations **`028`–`043`**    |
+| **QA V3 (3 rounds) + design pass**   | 🟢 PRs #155–#166 · migrations **`044`–`049`**                                                                                                                                                                 |
+| **V4 gestion salle**                 | 🟡 **prépa** · epic [#140](https://github.com/igorms-pro/truegrynd/issues/140) · slices [#167](https://github.com/igorms-pro/truegrynd/issues/167)–[#174](https://github.com/igorms-pro/truegrynd/issues/174) |
+| **V5 premium B2C**                   | 🔴 epic [#141](https://github.com/igorms-pro/truegrynd/issues/141)                                                                                                                                            |
 
 ---
 


### PR DESCRIPTION
Tracker update only:
- **V3 marked FINITO**: build + 3 Igor QA rounds + design pass (PRs #155–#166), migrations prod **028→049**, new "Phase 3 — QA & polish" table.
- **V4 section**: the 8 slices just created on GitHub ([#167](https://github.com/igorms-pro/truegrynd/issues/167)–[#174](https://github.com/igorms-pro/truegrynd/issues/174)) with roles + success criterion (pilot box drops Peppy). Epic #140 body updated with the same checklist.
- Suivi synthétique + next action refreshed (start V4-01 Planning; run the real-box pilot in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)