### PR TITLE
feat(pro): V4-01 planning — weekly schedule + member « Ma salle » (#167)

### DIFF
--- a/src/app/[locale]/app/my-gym/page.tsx
+++ b/src/app/[locale]/app/my-gym/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { MyGymScreen } from '@/features/gym/components/MyGymScreen';
+
+export default function MyGymPage() {
+  return <MyGymScreen />;
+}

--- a/src/app/[locale]/app/pro/planning/page.tsx
+++ b/src/app/[locale]/app/pro/planning/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { PlanningScreen } from '@/features/pro/components/PlanningScreen';
+
+export default function ProPlanningPage() {
+  return <PlanningScreen />;
+}

--- a/src/features/appshell/components/DesktopNav.tsx
+++ b/src/features/appshell/components/DesktopNav.tsx
@@ -13,10 +13,13 @@ export function DesktopNav() {
   const locale = useLocale();
   const t = useTranslations('app.tabs');
   const tAdmin = useTranslations('admin.nav');
+  const tMyGym = useTranslations('myGym');
   const profile = useOptionalAppProfile();
   const adminHref = `/${locale}/app/admin/challenges`;
   const adminActive = pathname === adminHref || pathname.startsWith(`${adminHref}/`);
   const proHref = `/${locale}/app/pro`;
+  const myGymHref = `/${locale}/app/my-gym`;
+  const myGymActive = pathname === myGymHref || pathname.startsWith(`${myGymHref}/`);
 
   return (
     <nav className="hidden md:flex items-center gap-7" aria-label="Primary">
@@ -28,6 +31,11 @@ export function DesktopNav() {
           </DesktopNavLink>
         );
       })}
+      {profile?.affiliated_gym_id ? (
+        <DesktopNavLink href={myGymHref} isActive={myGymActive}>
+          {tMyGym('navLabel')}
+        </DesktopNavLink>
+      ) : null}
       {canAccessPro(profile) ? (
         <DesktopNavLink href={proHref} isActive={false}>
           PRO

--- a/src/features/gym/components/MyGymScreen.tsx
+++ b/src/features/gym/components/MyGymScreen.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { CalendarDays, ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { WeekScheduleGrid } from '@/features/gym/components/WeekScheduleGrid';
+import { listGymClasses } from '@/features/pro/services/planning';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { supabase } from '@/lib/supabase';
+
+type GymHeader = { name: string; slug: string };
+
+async function getGymHeader(gymId: string): Promise<GymHeader> {
+  const { data, error } = await supabase
+    .from('gyms')
+    .select('name, slug')
+    .eq('id', gymId)
+    .maybeSingle<GymHeader>();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('gym_not_found');
+  return data;
+}
+
+/** Member view of their own gym: weekly schedule (read-only). Booking arrives with V4-02. */
+export function MyGymScreen() {
+  const t = useTranslations('myGym');
+  const locale = useLocale();
+  const profile = useOptionalAppProfile();
+  const gymId = profile?.affiliated_gym_id ?? null;
+
+  const load = useCallback(async () => {
+    const [gym, classes] = await Promise.all([
+      getGymHeader(gymId ?? ''),
+      listGymClasses(gymId ?? ''),
+    ]);
+    return { gym, classes: classes.filter((c) => c.isActive) };
+  }, [gymId]);
+  const { state } = useAsyncResource(load, [gymId ?? ''], { enabled: gymId !== null });
+
+  if (!gymId) {
+    return (
+      <section className="space-y-3">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="rounded-md border border-dashed border-border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+          {t('noGym')}
+        </p>
+      </section>
+    );
+  }
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error') {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+
+  const { gym, classes } = state.data;
+
+  return (
+    <section className="space-y-5">
+      <header className="space-y-2">
+        <p className="text-[10px] font-black uppercase tracking-[0.22em] text-primary">
+          {t('kicker')}
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{gym.name}</h1>
+          <Link
+            href={`/${locale}/app/gym/${gym.slug}`}
+            className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.14em] text-muted-foreground hover:text-foreground"
+          >
+            {t('publicPage')}
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+          </Link>
+        </div>
+      </header>
+
+      <div className="space-y-3">
+        <h2 className="inline-flex items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          <CalendarDays className="h-4 w-4" aria-hidden />
+          {t('scheduleTitle')}
+        </h2>
+        {classes.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+            {t('scheduleEmpty')}
+          </p>
+        ) : (
+          <WeekScheduleGrid classes={classes} />
+        )}
+        <p className="text-xs text-muted-foreground">{t('bookingSoon')}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/features/gym/components/WeekScheduleGrid.tsx
+++ b/src/features/gym/components/WeekScheduleGrid.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { Pencil, Trash2, Users } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import type { ClassType, GymClass } from '@/features/pro/services/planning';
+
+/** Monday-first weekday labels from the locale (no i18n keys needed). */
+function weekdayLabels(locale: string): string[] {
+  const fmt = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+  // 2024-01-01 is a Monday.
+  return Array.from({ length: 7 }, (_, i) => fmt.format(new Date(Date.UTC(2024, 0, 1 + i))));
+}
+
+function endTime(start: string, durationMin: number): string {
+  const [h, m] = start.split(':').map(Number);
+  const total = h * 60 + m + durationMin;
+  const eh = Math.floor(total / 60) % 24;
+  const em = total % 60;
+  return `${String(eh).padStart(2, '0')}:${String(em).padStart(2, '0')}`;
+}
+
+/** WOD is the brand — red. The rest stays quieter. */
+const TYPE_BADGE: Record<ClassType, string> = {
+  wod: 'bg-primary/15 text-primary',
+  hyrox: 'bg-sky-500/15 text-sky-400',
+  open_gym: 'bg-muted text-muted-foreground',
+  weightlifting: 'bg-amber-500/15 text-amber-500',
+  gymnastics: 'bg-violet-500/15 text-violet-400',
+  endurance: 'bg-emerald-500/15 text-emerald-500',
+  other: 'bg-muted text-muted-foreground',
+};
+
+/** A slot with more bookings than this is "popular" → red highlight (Igor's rule). */
+const POPULAR_THRESHOLD = 10;
+
+/** Booked counts arrive with V4-02 (gym_bookings); until then cards show capacity only. */
+export type ScheduleSlot = GymClass & { bookedCount?: number };
+
+type Props = {
+  classes: ScheduleSlot[];
+  /** Staff-only row actions; omit for the member read-only view. */
+  onEdit?: (c: GymClass) => void;
+  onDelete?: (c: GymClass) => void;
+};
+
+/**
+ * Monday→Sunday weekly schedule grid (Peppy DNA, TrueGrynd skin). 7 columns on lg+,
+ * stacked day sections below. Shared by /pro/planning (editable) and "Ma salle" (read-only).
+ */
+export function WeekScheduleGrid({ classes, onEdit, onDelete }: Props) {
+  const locale = useLocale();
+  const t = useTranslations('gym.schedule');
+  const days = weekdayLabels(locale);
+
+  const byDay: ScheduleSlot[][] = Array.from({ length: 7 }, () => []);
+  for (const c of classes) byDay[c.weekday]?.push(c);
+
+  const card = (c: ScheduleSlot) => {
+    const popular = (c.bookedCount ?? 0) > POPULAR_THRESHOLD;
+    return (
+      <div
+        key={c.id}
+        className={`space-y-1.5 rounded-md border p-2.5 ${
+          popular ? 'border-primary bg-primary/10' : 'border-border bg-card'
+        } ${c.isActive ? '' : 'opacity-50'}`}
+      >
+        <div className="flex items-center justify-between gap-1">
+          <p className="text-xs font-black tabular-nums">
+            {c.startTime}
+            <span className="text-muted-foreground"> – {endTime(c.startTime, c.durationMin)}</span>
+          </p>
+          {popular ? (
+            <span className="rounded-full bg-primary px-1.5 py-0.5 text-[8px] font-black uppercase tracking-[0.1em] text-primary-foreground">
+              {t('popular')}
+            </span>
+          ) : null}
+        </div>
+        <p className="truncate text-sm font-bold" title={c.title}>
+          {c.title}
+        </p>
+        <div className="flex items-center justify-between gap-1">
+          <span
+            className={`rounded-sm px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.1em] ${TYPE_BADGE[c.classType]}`}
+          >
+            {t(`type.${c.classType}`)}
+          </span>
+          <span
+            className={`inline-flex items-center gap-1 text-[10px] tabular-nums ${
+              popular ? 'font-black text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            <Users className="h-3 w-3" aria-hidden />
+            {c.bookedCount != null ? `${c.bookedCount}/${c.capacity}` : c.capacity}
+          </span>
+        </div>
+        {onEdit || onDelete ? (
+          <div className="flex justify-end gap-1 border-t border-border pt-1.5">
+            {onEdit ? (
+              <button
+                type="button"
+                onClick={() => onEdit(c)}
+                aria-label={t('edit')}
+                className="rounded-sm p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Pencil className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            ) : null}
+            {onDelete ? (
+              <button
+                type="button"
+                onClick={() => onDelete(c)}
+                aria-label={t('delete')}
+                className="rounded-sm p-1 text-muted-foreground hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Trash2 className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-7 lg:gap-2">
+      {days.map((label, i) => (
+        <div key={label} className="space-y-2">
+          <p className="rounded-sm bg-muted/50 px-2 py-1.5 text-center text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {label}
+          </p>
+          {byDay[i].length === 0 ? (
+            <p className="rounded-md border border-dashed border-border/60 p-2 text-center text-[10px] text-muted-foreground/60">
+              —
+            </p>
+          ) : (
+            byDay[i].map(card)
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/pro/components/PlanningScreen.tsx
+++ b/src/features/pro/components/PlanningScreen.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { FilterSelect } from '@/components/FilterSelect';
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { WeekScheduleGrid } from '@/features/gym/components/WeekScheduleGrid';
+import { FORM_INPUT_CLASS } from '@/features/pro/lib/formStyles';
+import {
+  CLASS_TYPES,
+  createGymClass,
+  deleteGymClass,
+  listGymClasses,
+  updateGymClass,
+  type ClassType,
+  type GymClass,
+  type GymClassInput,
+} from '@/features/pro/services/planning';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { canAccessPro } from '@/lib/roles';
+
+const DURATIONS = [45, 60, 75, 90, 120] as const;
+
+const EMPTY_FORM: GymClassInput = {
+  title: '',
+  classType: 'wod',
+  weekday: 0,
+  startTime: '18:00',
+  durationMin: 60,
+  capacity: 16,
+  coachId: null,
+};
+
+function weekdayShort(locale: string, weekday: number): string {
+  return new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(
+    new Date(Date.UTC(2024, 0, 1 + weekday)),
+  );
+}
+
+function SlotForm({
+  initial,
+  busyLabel,
+  submitLabel,
+  onSubmit,
+  onClose,
+}: {
+  initial: GymClassInput;
+  busyLabel: string;
+  submitLabel: string;
+  onSubmit: (input: GymClassInput) => Promise<void>;
+  onClose: () => void;
+}) {
+  const t = useTranslations('pro.planning');
+  const tType = useTranslations('gym.schedule.type');
+  const locale = useLocale();
+  const [form, setForm] = useState<GymClassInput>(initial);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+
+  const canSubmit = form.title.trim().length >= 2 && !busy;
+
+  async function submit() {
+    if (!canSubmit) return;
+    setBusy(true);
+    setError(false);
+    try {
+      await onSubmit(form);
+    } catch {
+      setError(true);
+      setBusy(false);
+    }
+  }
+
+  const set = <K extends keyof GymClassInput>(key: K, value: GymClassInput[K]) =>
+    setForm((f) => ({ ...f, [key]: value }));
+
+  return (
+    <div className="space-y-4 rounded-md border border-border bg-card p-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.title')}
+          <input
+            value={form.title}
+            onChange={(e) => set('title', e.target.value)}
+            placeholder={t('form.titlePlaceholder')}
+            className={FORM_INPUT_CLASS}
+          />
+        </label>
+        <div className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.type')}
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {CLASS_TYPES.map((ct) => (
+              <button
+                key={ct}
+                type="button"
+                onClick={() => set('classType', ct as ClassType)}
+                className={`rounded-sm px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.12em] transition-colors ${
+                  form.classType === ct
+                    ? 'bg-primary text-primary-foreground'
+                    : 'border border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {tType(ct)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('form.weekday')}
+        <div className="mt-2 inline-flex overflow-hidden rounded-md border border-border">
+          {Array.from({ length: 7 }, (_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => set('weekday', i)}
+              className={`px-3 py-2 text-[10px] font-black uppercase tracking-[0.12em] transition-colors ${
+                i > 0 ? 'border-l border-border' : ''
+              } ${
+                form.weekday === i
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-background text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {weekdayShort(locale, i)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.startTime')}
+          <input
+            type="time"
+            value={form.startTime}
+            onChange={(e) => set('startTime', e.target.value)}
+            className={FORM_INPUT_CLASS}
+          />
+        </label>
+        <div className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.duration')}
+          <div className="mt-2">
+            <FilterSelect
+              value={String(form.durationMin)}
+              onChange={(v) => set('durationMin', Number(v) || 60)}
+              options={DURATIONS.map((d) => ({
+                value: String(d),
+                label: t('form.minutes', { min: d }),
+              }))}
+              allLabel={t('form.minutes', { min: 60 })}
+              ariaLabel={t('form.duration')}
+            />
+          </div>
+        </div>
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.capacity')}
+          <input
+            type="number"
+            min={1}
+            max={500}
+            value={form.capacity}
+            onChange={(e) => set('capacity', Math.max(1, Number(e.target.value) || 1))}
+            className={FORM_INPUT_CLASS}
+          />
+        </label>
+      </div>
+
+      {error ? <p className="text-xs font-semibold text-primary">{t('form.error')}</p> : null}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={!canSubmit}
+          onClick={submit}
+          className="rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? busyLabel : submitLabel}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onClose}
+          className="rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          {t('form.cancel')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function PlanningScreen() {
+  const t = useTranslations('pro.planning');
+  const profile = useOptionalAppProfile();
+  const gymId = profile?.affiliated_gym_id ?? null;
+  // Staff of the gym, or the platform/gym owner overseeing it — matches the RLS write policy.
+  const canManage = canAccessPro(profile);
+
+  const load = useCallback(() => listGymClasses(gymId ?? ''), [gymId]);
+  const { state, refetch } = useAsyncResource(load, [gymId ?? ''], { enabled: gymId !== null });
+  const [creating, setCreating] = useState(false);
+  const [editing, setEditing] = useState<GymClass | null>(null);
+
+  if (!gymId) {
+    return <p className="text-sm text-muted-foreground">{t('noGym')}</p>;
+  }
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error') {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+
+  const classes = state.data;
+
+  return (
+    <div className="space-y-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+        </div>
+        {canManage && !creating && !editing ? (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" aria-hidden />
+            {t('add')}
+          </button>
+        ) : null}
+      </header>
+
+      {creating ? (
+        <SlotForm
+          initial={EMPTY_FORM}
+          busyLabel={t('form.saving')}
+          submitLabel={t('form.create')}
+          onSubmit={async (input) => {
+            await createGymClass(gymId, input);
+            setCreating(false);
+            refetch();
+          }}
+          onClose={() => setCreating(false)}
+        />
+      ) : null}
+
+      {editing ? (
+        <SlotForm
+          initial={{
+            title: editing.title,
+            classType: editing.classType,
+            weekday: editing.weekday,
+            startTime: editing.startTime,
+            durationMin: editing.durationMin,
+            capacity: editing.capacity,
+            coachId: editing.coachId,
+          }}
+          busyLabel={t('form.saving')}
+          submitLabel={t('form.save')}
+          onSubmit={async (input) => {
+            await updateGymClass(editing.id, input);
+            setEditing(null);
+            refetch();
+          }}
+          onClose={() => setEditing(null)}
+        />
+      ) : null}
+
+      {classes.length === 0 && !creating ? (
+        <div className="space-y-4 rounded-md border border-dashed border-border bg-muted/20 p-8 text-center">
+          <p className="text-sm font-black uppercase tracking-[0.14em]">{t('emptyTitle')}</p>
+          <p className="mx-auto max-w-md text-sm text-muted-foreground">{t('emptyBody')}</p>
+          {canManage ? (
+            <button
+              type="button"
+              onClick={() => setCreating(true)}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90"
+            >
+              <Plus className="h-4 w-4" aria-hidden />
+              {t('add')}
+            </button>
+          ) : null}
+        </div>
+      ) : (
+        <WeekScheduleGrid
+          classes={classes}
+          onEdit={canManage ? (c) => setEditing(c) : undefined}
+          onDelete={
+            canManage
+              ? async (c) => {
+                  await deleteGymClass(c.id);
+                  refetch();
+                }
+              : undefined
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -73,7 +73,7 @@ export const PRO_NAV: readonly ProNavGroup[] = [
         path: '/app/pro/planning',
         icon: CalendarDays,
         labelKey: 'planning',
-        status: 'soon',
+        status: 'live',
       },
       { id: 'members', path: '/app/pro/members', icon: Users, labelKey: 'members', status: 'live' },
       {

--- a/src/features/pro/services/planning.ts
+++ b/src/features/pro/services/planning.ts
@@ -1,0 +1,124 @@
+import { supabase } from '@/lib/supabase';
+
+export const CLASS_TYPES = [
+  'wod',
+  'open_gym',
+  'hyrox',
+  'weightlifting',
+  'gymnastics',
+  'endurance',
+  'other',
+] as const;
+export type ClassType = (typeof CLASS_TYPES)[number];
+
+/** A recurring weekly class slot (template — see `gym_classes`). weekday: 0 = Monday … 6 = Sunday. */
+export type GymClass = {
+  id: string;
+  gymId: string;
+  title: string;
+  classType: ClassType;
+  weekday: number;
+  /** 'HH:MM' (seconds stripped). */
+  startTime: string;
+  durationMin: number;
+  capacity: number;
+  coachId: string | null;
+  isActive: boolean;
+};
+
+export type GymClassInput = {
+  title: string;
+  classType: ClassType;
+  weekday: number;
+  startTime: string;
+  durationMin: number;
+  capacity: number;
+  coachId: string | null;
+};
+
+type Row = {
+  id: string;
+  gym_id: string;
+  title: string;
+  class_type: ClassType;
+  weekday: number;
+  start_time: string;
+  duration_min: number;
+  capacity: number;
+  coach_id: string | null;
+  is_active: boolean;
+};
+
+const COLUMNS =
+  'id, gym_id, title, class_type, weekday, start_time, duration_min, capacity, coach_id, is_active';
+
+function fromRow(row: Row): GymClass {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    title: row.title,
+    classType: row.class_type,
+    weekday: row.weekday,
+    startTime: row.start_time.slice(0, 5),
+    durationMin: row.duration_min,
+    capacity: row.capacity,
+    coachId: row.coach_id,
+    isActive: row.is_active,
+  };
+}
+
+/** All slots of one gym, grid-ordered. RLS scopes reads; the explicit gym_id keeps admins scoped too. */
+export async function listGymClasses(gymId: string): Promise<GymClass[]> {
+  const { data, error } = await supabase
+    .from('gym_classes')
+    .select(COLUMNS)
+    .eq('gym_id', gymId)
+    .order('weekday')
+    .order('start_time');
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as Row[]).map(fromRow);
+}
+
+export async function createGymClass(gymId: string, input: GymClassInput): Promise<GymClass> {
+  const { data, error } = await supabase
+    .from('gym_classes')
+    .insert({
+      gym_id: gymId,
+      title: input.title,
+      class_type: input.classType,
+      weekday: input.weekday,
+      start_time: input.startTime,
+      duration_min: input.durationMin,
+      capacity: input.capacity,
+      coach_id: input.coachId,
+    })
+    .select(COLUMNS)
+    .single();
+  if (error) throw new Error(error.message);
+  return fromRow(data as Row);
+}
+
+export async function updateGymClass(id: string, input: GymClassInput): Promise<GymClass> {
+  const { data, error } = await supabase
+    .from('gym_classes')
+    .update({
+      title: input.title,
+      class_type: input.classType,
+      weekday: input.weekday,
+      start_time: input.startTime,
+      duration_min: input.durationMin,
+      capacity: input.capacity,
+      coach_id: input.coachId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .select(COLUMNS)
+    .single();
+  if (error) throw new Error(error.message);
+  return fromRow(data as Row);
+}
+
+export async function deleteGymClass(id: string): Promise<void> {
+  const { error } = await supabase.from('gym_classes').delete().eq('id', id);
+  if (error) throw new Error(error.message);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1375,7 +1375,33 @@
     "turkish_get_up": "Turkish Get-Up",
     "strict_ring_dip": "Strict Ring Dip"
   },
+  "myGym": {
+    "navLabel": "MY GYM",
+    "title": "My gym",
+    "kicker": "My gym",
+    "noGym": "You're not affiliated to a gym yet. Ask your box to join TrueGrynd!",
+    "loading": "Loading your gym…",
+    "error": "Could not load your gym.",
+    "publicPage": "Public page",
+    "scheduleTitle": "Weekly schedule",
+    "scheduleEmpty": "No classes scheduled yet — your gym is setting things up.",
+    "bookingSoon": "Booking from the app is coming next."
+  },
   "gym": {
+    "schedule": {
+      "popular": "Popular",
+      "edit": "Edit slot",
+      "delete": "Delete slot",
+      "type": {
+        "wod": "WOD",
+        "open_gym": "Open gym",
+        "hyrox": "Hyrox",
+        "weightlifting": "Weightlifting",
+        "gymnastics": "Gymnastics",
+        "endurance": "Endurance",
+        "other": "Other"
+      }
+    },
     "public": {
       "kicker": "Gym",
       "back": "Back",
@@ -1437,6 +1463,31 @@
       },
       "quickTitle": "Quick actions",
       "pendingCta": "Review now"
+    },
+    "planning": {
+      "title": "Planning",
+      "subtitle": "Your weekly class schedule — members see it in the app.",
+      "add": "Add a class",
+      "noGym": "Create your gym first.",
+      "loading": "Loading schedule…",
+      "error": "Could not load the schedule.",
+      "emptyTitle": "No classes yet",
+      "emptyBody": "Build your weekly schedule — WOD, open gym, Hyrox… Members will see it in their app, and booking arrives next.",
+      "form": {
+        "title": "Class name",
+        "titlePlaceholder": "WOD 18:00",
+        "type": "Type",
+        "weekday": "Day",
+        "startTime": "Start time",
+        "duration": "Duration",
+        "minutes": "{min} min",
+        "capacity": "Capacity",
+        "error": "Could not save — try again.",
+        "create": "Create class",
+        "save": "Save",
+        "saving": "Saving…",
+        "cancel": "Cancel"
+      }
     },
     "judge": {
       "intro": "Validate performances you witnessed on the floor — a validated score jumps to the verified ranking.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1375,7 +1375,33 @@
     "turkish_get_up": "Turkish Get-Up",
     "strict_ring_dip": "Dip strict aux anneaux"
   },
+  "myGym": {
+    "navLabel": "MA SALLE",
+    "title": "Ma salle",
+    "kicker": "Ma salle",
+    "noGym": "Tu n'es affilié à aucune salle pour le moment. Parle de TrueGrynd à ta box !",
+    "loading": "Chargement de ta salle…",
+    "error": "Impossible de charger ta salle.",
+    "publicPage": "Page publique",
+    "scheduleTitle": "Planning de la semaine",
+    "scheduleEmpty": "Pas encore de cours au planning — ta salle s'installe.",
+    "bookingSoon": "La réservation depuis l'app arrive bientôt."
+  },
   "gym": {
+    "schedule": {
+      "popular": "Populaire",
+      "edit": "Modifier le créneau",
+      "delete": "Supprimer le créneau",
+      "type": {
+        "wod": "WOD",
+        "open_gym": "Open gym",
+        "hyrox": "Hyrox",
+        "weightlifting": "Haltéro",
+        "gymnastics": "Gym",
+        "endurance": "Endurance",
+        "other": "Autre"
+      }
+    },
     "public": {
       "kicker": "Salle",
       "back": "Retour",
@@ -1437,6 +1463,31 @@
       },
       "quickTitle": "Actions rapides",
       "pendingCta": "Valider maintenant"
+    },
+    "planning": {
+      "title": "Planning",
+      "subtitle": "Le planning hebdo de tes cours — tes membres le voient dans l'app.",
+      "add": "Ajouter un cours",
+      "noGym": "Crée d'abord ta salle.",
+      "loading": "Chargement du planning…",
+      "error": "Impossible de charger le planning.",
+      "emptyTitle": "Aucun cours pour le moment",
+      "emptyBody": "Construis ton planning hebdo — WOD, open gym, Hyrox… Tes membres le verront dans leur app, et la réservation arrive juste après.",
+      "form": {
+        "title": "Nom du cours",
+        "titlePlaceholder": "WOD 18h",
+        "type": "Type",
+        "weekday": "Jour",
+        "startTime": "Heure de début",
+        "duration": "Durée",
+        "minutes": "{min} min",
+        "capacity": "Capacité",
+        "error": "Impossible d'enregistrer — réessaie.",
+        "create": "Créer le cours",
+        "save": "Enregistrer",
+        "saving": "Enregistrement…",
+        "cancel": "Annuler"
+      }
     },
     "judge": {
       "intro": "Valide les performances vues sur le floor — un score validé passe au ranking vérifié.",

--- a/supabase/migrations/050_gym_classes.sql
+++ b/supabase/migrations/050_gym_classes.sql
@@ -1,0 +1,93 @@
+-- V4-01 (#167): gym class schedule — recurring weekly slots ("Planning", Peppy DNA).
+-- A gym_class is a TEMPLATE (weekday + time + capacity + coach), not a dated instance;
+-- dated gym_sessions + bookings arrive with V4-02. Multi-tenant like every V3 table:
+-- keyed on gym_id, RLS-scoped to the gym's people.
+
+CREATE TABLE IF NOT EXISTS public.gym_classes (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gym_id       UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  title        TEXT        NOT NULL CHECK (length(btrim(title)) > 0),
+  class_type   TEXT        NOT NULL DEFAULT 'wod'
+    CHECK (class_type IN ('wod', 'open_gym', 'hyrox', 'weightlifting', 'gymnastics', 'endurance', 'other')),
+  -- 0 = Monday … 6 = Sunday (grid renders Monday-first, French convention).
+  weekday      INT         NOT NULL CHECK (weekday BETWEEN 0 AND 6),
+  start_time   TIME        NOT NULL,
+  duration_min INT         NOT NULL DEFAULT 60 CHECK (duration_min BETWEEN 15 AND 480),
+  capacity     INT         NOT NULL DEFAULT 16 CHECK (capacity BETWEEN 1 AND 500),
+  coach_id     UUID        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  is_active    BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.gym_classes IS
+  'V4-01: recurring weekly class slots (template). Dated instances (gym_sessions) + bookings come with V4-02.';
+
+CREATE INDEX IF NOT EXISTS idx_gym_classes_gym ON public.gym_classes (gym_id, weekday, start_time);
+
+ALTER TABLE public.gym_classes ENABLE ROW LEVEL SECURITY;
+
+-- READ: the gym's people (affiliated members), the gym owner, or a platform admin.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gym_classes'
+      AND policyname = 'Gym people can read their gym classes'
+  ) THEN
+    CREATE POLICY "Gym people can read their gym classes"
+      ON public.gym_classes FOR SELECT
+      TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_classes.gym_id
+        )
+        OR EXISTS (
+          SELECT 1 FROM public.gyms g
+          WHERE g.id = gym_classes.gym_id AND g.owner_id = auth.uid()
+        )
+      );
+  END IF;
+END $$;
+
+-- WRITE: staff of THAT gym (coach/gym_admin affiliated to it), the gym owner, or a platform admin.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'gym_classes'
+      AND policyname = 'Gym staff can manage their gym classes'
+  ) THEN
+    CREATE POLICY "Gym staff can manage their gym classes"
+      ON public.gym_classes FOR ALL
+      TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.affiliated_gym_id = gym_classes.gym_id
+            AND p.role IN ('coach', 'gym_admin')
+        )
+        OR EXISTS (
+          SELECT 1 FROM public.gyms g
+          WHERE g.id = gym_classes.gym_id AND g.owner_id = auth.uid()
+        )
+      )
+      WITH CHECK (
+        public.is_platform_admin()
+        OR EXISTS (
+          SELECT 1 FROM public.profiles p
+          WHERE p.id = auth.uid()
+            AND p.affiliated_gym_id = gym_classes.gym_id
+            AND p.role IN ('coach', 'gym_admin')
+        )
+        OR EXISTS (
+          SELECT 1 FROM public.gyms g
+          WHERE g.id = gym_classes.gym_id AND g.owner_id = auth.uid()
+        )
+      );
+  END IF;
+END $$;


### PR DESCRIPTION
## V4-01 — first gym-management slice (Closes #167)

**/pro/planning** (nav `soon` → **live**) — the gym builds its recurring weekly schedule:
- Monday→Sunday grid, slot cards: time range, title, **color-coded type badge** (WOD = red — the brand), capacity.
- Staff create/edit/delete via inline form: type chips, weekday segmented control, time input, duration select, capacity. `canManage` = `canAccessPro` (staff or platform admin), matching the RLS write policy.
- **Popular rule (Igor)**: a slot with **>10 bookings turns red** («&nbsp;POPULAIRE&nbsp;» chip + primary border + red count). The visual rule ships now; it lights up when V4-02 brings real `bookedCount`s.

**/app/my-gym — « Ma salle »** (new B2C section, affiliated athletes only):
- Gym header + link to the public gym page + the same weekly grid **read-only** + booking teaser.
- **MA SALLE** entry in the desktop nav.

**Backend** — migration **050** (applied to prod): `gym_classes` weekly slot templates, gym-scoped RLS (read = gym people; write = gym staff / owner / platform admin). Dated `gym_sessions` + `gym_bookings` intentionally deferred to **V4-02** where they're actually consumed.

### Smoke (live, Playwright)
- /pro/planning renders the seeded CROSSFIT MADEC week (8 slots, badges WOD/HYROX/HALTÉRO colored) ✓
- Form path: created “Gym skills” (type Gym, Thursday) via the UI → appears in the grid ✓
- /app/my-gym: MA SALLE nav active, same grid read-only, teaser note ✓

Note: the seeded weekly schedule stays on CROSSFIT MADEC — realistic pilot data for Igor's QA and V4-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)