### PR TITLE
feat(gym): V4-02 réservations — booking, waitlist, roster coach avec niveau (#168)

### DIFF
--- a/src/features/gym/components/MyGymScreen.tsx
+++ b/src/features/gym/components/MyGymScreen.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import { CalendarDays, ExternalLink } from 'lucide-react';
+import { CalendarDays, Check, ChevronLeft, ChevronRight, Clock, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
-import { WeekScheduleGrid } from '@/features/gym/components/WeekScheduleGrid';
+import { WeekScheduleGrid, type ScheduleSlot } from '@/features/gym/components/WeekScheduleGrid';
+import {
+  bookSession,
+  cancelBooking,
+  getWeekBookings,
+  mondayOf,
+} from '@/features/gym/services/bookings';
 import { listGymClasses } from '@/features/pro/services/planning';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
 import { supabase } from '@/lib/supabase';
@@ -24,21 +30,73 @@ async function getGymHeader(gymId: string): Promise<GymHeader> {
   return data;
 }
 
-/** Member view of their own gym: weekly schedule (read-only). Booking arrives with V4-02. */
+function addDays(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00`);
+  d.setDate(d.getDate() + days);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function todayIso(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Member view of their own gym: weekly schedule with live booking (V4-02). */
 export function MyGymScreen() {
   const t = useTranslations('myGym');
   const locale = useLocale();
   const profile = useOptionalAppProfile();
   const gymId = profile?.affiliated_gym_id ?? null;
+  // 0 = current week, 1 = next week (booking horizon is 14 days server-side).
+  const [weekOffset, setWeekOffset] = useState(0);
+  const monday = addDays(mondayOf(new Date()), weekOffset * 7);
+  const [busySlot, setBusySlot] = useState<string | null>(null);
+  const [actionError, setActionError] = useState(false);
 
   const load = useCallback(async () => {
-    const [gym, classes] = await Promise.all([
+    const [gym, classes, bookings] = await Promise.all([
       getGymHeader(gymId ?? ''),
       listGymClasses(gymId ?? ''),
+      getWeekBookings(monday),
     ]);
-    return { gym, classes: classes.filter((c) => c.isActive) };
-  }, [gymId]);
-  const { state } = useAsyncResource(load, [gymId ?? ''], { enabled: gymId !== null });
+    const slots: ScheduleSlot[] = classes
+      .filter((c) => c.isActive)
+      .map((c) => {
+        const b = bookings.get(c.id);
+        return {
+          ...c,
+          bookedCount: b?.bookedCount ?? 0,
+          waitlistCount: b?.waitlistCount ?? 0,
+          sessionDate: b?.sessionDate ?? addDays(monday, c.weekday),
+          myStatus: b?.myStatus ?? null,
+          myBookingId: b?.myBookingId ?? null,
+        };
+      });
+    return { gym, slots };
+  }, [gymId, monday]);
+  const { state, refetch } = useAsyncResource(load, [gymId ?? '', monday], {
+    enabled: gymId !== null,
+  });
+
+  const act = useCallback(
+    async (slot: ScheduleSlot, action: 'book' | 'cancel') => {
+      if (!slot.sessionDate) return;
+      setBusySlot(slot.id);
+      setActionError(false);
+      try {
+        if (action === 'book') await bookSession(slot.id, slot.sessionDate);
+        else if (slot.myBookingId) await cancelBooking(slot.myBookingId);
+        refetch();
+      } catch {
+        setActionError(true);
+      } finally {
+        setBusySlot(null);
+      }
+    },
+    [refetch],
+  );
 
   if (!gymId) {
     return (
@@ -57,7 +115,64 @@ export function MyGymScreen() {
     return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
   }
 
-  const { gym, classes } = state.data;
+  const { gym, slots } = state.data;
+  const today = todayIso();
+
+  const bookingFooter = (slot: ScheduleSlot) => {
+    const date = slot.sessionDate ?? '';
+    if (date < today) return null;
+    // Today's slots whose start time already passed can't be booked (server rejects too).
+    if (date === today) {
+      const now = new Date();
+      const nowHm = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+      if (slot.startTime <= nowHm && !slot.myStatus) return null;
+    }
+    const busy = busySlot === slot.id;
+    const full = (slot.bookedCount ?? 0) >= slot.capacity;
+
+    if (slot.myStatus === 'confirmed') {
+      return (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => act(slot, 'cancel')}
+          className="inline-flex w-full items-center justify-center gap-1 rounded-sm bg-emerald-600/90 px-2 py-1.5 text-[10px] font-black uppercase tracking-[0.1em] text-white hover:opacity-90 disabled:opacity-50"
+          title={t('booking.cancelHint')}
+        >
+          <Check className="h-3 w-3" aria-hidden />
+          {busy ? t('booking.busy') : t('booking.booked')}
+        </button>
+      );
+    }
+    if (slot.myStatus === 'waitlisted') {
+      return (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => act(slot, 'cancel')}
+          className="inline-flex w-full items-center justify-center gap-1 rounded-sm bg-amber-500/20 px-2 py-1.5 text-[10px] font-black uppercase tracking-[0.1em] text-amber-500 hover:opacity-80 disabled:opacity-50"
+          title={t('booking.cancelHint')}
+        >
+          <Clock className="h-3 w-3" aria-hidden />
+          {busy ? t('booking.busy') : t('booking.waitlisted')}
+        </button>
+      );
+    }
+    return (
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => act(slot, 'book')}
+        className={`w-full rounded-sm px-2 py-1.5 text-[10px] font-black uppercase tracking-[0.1em] disabled:opacity-50 ${
+          full
+            ? 'border border-border text-muted-foreground hover:text-foreground'
+            : 'bg-primary text-primary-foreground hover:opacity-90'
+        }`}
+      >
+        {busy ? t('booking.busy') : full ? t('booking.joinWaitlist') : t('booking.book')}
+      </button>
+    );
+  };
 
   return (
     <section className="space-y-5">
@@ -78,18 +193,47 @@ export function MyGymScreen() {
       </header>
 
       <div className="space-y-3">
-        <h2 className="inline-flex items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
-          <CalendarDays className="h-4 w-4" aria-hidden />
-          {t('scheduleTitle')}
-        </h2>
-        {classes.length === 0 ? (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="inline-flex items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            <CalendarDays className="h-4 w-4" aria-hidden />
+            {t('scheduleTitle')}
+          </h2>
+          <div className="inline-flex items-center gap-1 rounded-md border border-border">
+            <button
+              type="button"
+              disabled={weekOffset === 0}
+              onClick={() => setWeekOffset(0)}
+              aria-label={t('booking.prevWeek')}
+              className="p-2 text-muted-foreground hover:text-foreground disabled:opacity-30"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden />
+            </button>
+            <span className="min-w-[9rem] text-center text-[10px] font-black uppercase tracking-[0.14em]">
+              {weekOffset === 0 ? t('booking.thisWeek') : t('booking.nextWeek')}
+            </span>
+            <button
+              type="button"
+              disabled={weekOffset === 1}
+              onClick={() => setWeekOffset(1)}
+              aria-label={t('booking.nextWeek')}
+              className="p-2 text-muted-foreground hover:text-foreground disabled:opacity-30"
+            >
+              <ChevronRight className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </div>
+
+        {actionError ? (
+          <p className="text-xs font-semibold text-primary">{t('booking.error')}</p>
+        ) : null}
+
+        {slots.length === 0 ? (
           <p className="rounded-md border border-dashed border-border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
             {t('scheduleEmpty')}
           </p>
         ) : (
-          <WeekScheduleGrid classes={classes} />
+          <WeekScheduleGrid classes={slots} weekStart={monday} footer={bookingFooter} />
         )}
-        <p className="text-xs text-muted-foreground">{t('bookingSoon')}</p>
       </div>
     </section>
   );

--- a/src/features/gym/components/WeekScheduleGrid.tsx
+++ b/src/features/gym/components/WeekScheduleGrid.tsx
@@ -34,24 +34,53 @@ const TYPE_BADGE: Record<ClassType, string> = {
 /** A slot with more bookings than this is "popular" → red highlight (Igor's rule). */
 const POPULAR_THRESHOLD = 10;
 
-/** Booked counts arrive with V4-02 (gym_bookings); until then cards show capacity only. */
-export type ScheduleSlot = GymClass & { bookedCount?: number };
+/** A class occurrence in the rendered week, with live booking state when available. */
+export type ScheduleSlot = GymClass & {
+  bookedCount?: number;
+  waitlistCount?: number;
+  sessionDate?: string;
+  myStatus?: 'confirmed' | 'waitlisted' | null;
+  myBookingId?: string | null;
+};
 
 type Props = {
   classes: ScheduleSlot[];
+  /** ISO Monday of the rendered week → day headers show real dates, past days dim. */
+  weekStart?: string;
   /** Staff-only row actions; omit for the member read-only view. */
   onEdit?: (c: GymClass) => void;
   onDelete?: (c: GymClass) => void;
+  /** Makes cards clickable (e.g. coach roster panel). */
+  onCardClick?: (c: ScheduleSlot) => void;
+  /** Per-card footer (e.g. the member booking button). */
+  footer?: (c: ScheduleSlot) => React.ReactNode;
 };
 
 /**
  * Monday→Sunday weekly schedule grid (Peppy DNA, TrueGrynd skin). 7 columns on lg+,
  * stacked day sections below. Shared by /pro/planning (editable) and "Ma salle" (read-only).
  */
-export function WeekScheduleGrid({ classes, onEdit, onDelete }: Props) {
+export function WeekScheduleGrid({
+  classes,
+  weekStart,
+  onEdit,
+  onDelete,
+  onCardClick,
+  footer,
+}: Props) {
   const locale = useLocale();
   const t = useTranslations('gym.schedule');
   const days = weekdayLabels(locale);
+
+  // Real dates of the rendered week + which columns are already past.
+  const weekDates: (Date | null)[] = Array.from({ length: 7 }, (_, i) => {
+    if (!weekStart) return null;
+    const d = new Date(`${weekStart}T00:00:00`);
+    d.setDate(d.getDate() + i);
+    return d;
+  });
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
   const byDay: ScheduleSlot[][] = Array.from({ length: 7 }, () => []);
   for (const c of classes) byDay[c.weekday]?.push(c);
@@ -61,9 +90,23 @@ export function WeekScheduleGrid({ classes, onEdit, onDelete }: Props) {
     return (
       <div
         key={c.id}
+        role={onCardClick ? 'button' : undefined}
+        tabIndex={onCardClick ? 0 : undefined}
+        onClick={onCardClick ? () => onCardClick(c) : undefined}
+        onKeyDown={
+          onCardClick
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') onCardClick(c);
+              }
+            : undefined
+        }
         className={`space-y-1.5 rounded-md border p-2.5 ${
           popular ? 'border-primary bg-primary/10' : 'border-border bg-card'
-        } ${c.isActive ? '' : 'opacity-50'}`}
+        } ${c.isActive ? '' : 'opacity-50'} ${
+          onCardClick
+            ? 'cursor-pointer transition-colors hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+            : ''
+        }`}
       >
         <div className="flex items-center justify-between gap-1">
           <p className="text-xs font-black tabular-nums">
@@ -94,6 +137,7 @@ export function WeekScheduleGrid({ classes, onEdit, onDelete }: Props) {
             {c.bookedCount != null ? `${c.bookedCount}/${c.capacity}` : c.capacity}
           </span>
         </div>
+        {footer ? footer(c) : null}
         {onEdit || onDelete ? (
           <div className="flex justify-end gap-1 border-t border-border pt-1.5">
             {onEdit ? (
@@ -124,20 +168,30 @@ export function WeekScheduleGrid({ classes, onEdit, onDelete }: Props) {
 
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-7 lg:gap-2">
-      {days.map((label, i) => (
-        <div key={label} className="space-y-2">
-          <p className="rounded-sm bg-muted/50 px-2 py-1.5 text-center text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">
-            {label}
-          </p>
-          {byDay[i].length === 0 ? (
-            <p className="rounded-md border border-dashed border-border/60 p-2 text-center text-[10px] text-muted-foreground/60">
-              —
+      {days.map((label, i) => {
+        const date = weekDates[i];
+        const isPast = date !== null && date < today;
+        const isToday = date !== null && date.getTime() === today.getTime();
+        return (
+          <div key={label} className={`space-y-2 ${isPast ? 'opacity-45' : ''}`}>
+            <p
+              className={`rounded-sm px-2 py-1.5 text-center text-[10px] font-black uppercase tracking-[0.18em] ${
+                isToday ? 'bg-primary text-primary-foreground' : 'bg-muted/50 text-muted-foreground'
+              }`}
+            >
+              {label}
+              {date ? ` ${date.getDate()}` : ''}
             </p>
-          ) : (
-            byDay[i].map(card)
-          )}
-        </div>
-      ))}
+            {byDay[i].length === 0 ? (
+              <p className="rounded-md border border-dashed border-border/60 p-2 text-center text-[10px] text-muted-foreground/60">
+                —
+              </p>
+            ) : (
+              byDay[i].map(card)
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/features/gym/services/bookings.ts
+++ b/src/features/gym/services/bookings.ts
@@ -1,0 +1,103 @@
+import { supabase } from '@/lib/supabase';
+
+export type BookingStatus = 'confirmed' | 'waitlisted';
+
+/** Live state of one class occurrence in a given week (see `week_bookings`). */
+export type WeekSlotBooking = {
+  classId: string;
+  sessionDate: string;
+  bookedCount: number;
+  waitlistCount: number;
+  myStatus: BookingStatus | null;
+  myBookingId: string | null;
+};
+
+type WeekRow = {
+  class_id: string;
+  session_date: string;
+  booked_count: number;
+  waitlist_count: number;
+  my_status: BookingStatus | null;
+  my_booking_id: string | null;
+};
+
+/** ISO `YYYY-MM-DD` of the Monday of the week containing `d` (local time). */
+export function mondayOf(d: Date): string {
+  const day = (d.getDay() + 6) % 7; // 0 = Monday
+  const monday = new Date(d);
+  monday.setDate(d.getDate() - day);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${monday.getFullYear()}-${pad(monday.getMonth() + 1)}-${pad(monday.getDate())}`;
+}
+
+export async function getWeekBookings(monday: string): Promise<Map<string, WeekSlotBooking>> {
+  const { data, error } = await supabase.rpc('week_bookings', { p_monday: monday });
+  if (error) throw new Error(error.message);
+  const map = new Map<string, WeekSlotBooking>();
+  for (const r of (data ?? []) as WeekRow[]) {
+    map.set(r.class_id, {
+      classId: r.class_id,
+      sessionDate: r.session_date,
+      bookedCount: Number(r.booked_count ?? 0),
+      waitlistCount: Number(r.waitlist_count ?? 0),
+      myStatus: r.my_status,
+      myBookingId: r.my_booking_id,
+    });
+  }
+  return map;
+}
+
+export async function bookSession(classId: string, sessionDate: string): Promise<BookingStatus> {
+  const { data, error } = await supabase.rpc('book_session', {
+    p_class_id: classId,
+    p_session_date: sessionDate,
+  });
+  if (error) throw new Error(error.message);
+  return (data as { status: BookingStatus }).status;
+}
+
+export async function cancelBooking(bookingId: string): Promise<void> {
+  const { error } = await supabase.rpc('cancel_booking', { p_booking_id: bookingId });
+  if (error) throw new Error(error.message);
+}
+
+/** One athlete on a session's roster, with athletic context for the coach. */
+export type RosterEntry = {
+  bookingId: string;
+  userId: string;
+  username: string | null;
+  division: string | null;
+  faction: string | null;
+  rating: number | null;
+  status: BookingStatus;
+};
+
+type RosterRow = {
+  booking_id: string;
+  user_id: string;
+  username: string | null;
+  division: string | null;
+  faction: string | null;
+  rating: number | null;
+  status: BookingStatus;
+};
+
+export async function getSessionRoster(
+  classId: string,
+  sessionDate: string,
+): Promise<RosterEntry[]> {
+  const { data, error } = await supabase.rpc('session_roster', {
+    p_class_id: classId,
+    p_session_date: sessionDate,
+  });
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as RosterRow[]).map((r) => ({
+    bookingId: r.booking_id,
+    userId: r.user_id,
+    username: r.username,
+    division: r.division,
+    faction: r.faction,
+    rating: r.rating == null ? null : Number(r.rating),
+    status: r.status,
+  }));
+}

--- a/src/features/pro/components/PlanningScreen.tsx
+++ b/src/features/pro/components/PlanningScreen.tsx
@@ -6,7 +6,8 @@ import { useLocale, useTranslations } from 'next-intl';
 
 import { FilterSelect } from '@/components/FilterSelect';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
-import { WeekScheduleGrid } from '@/features/gym/components/WeekScheduleGrid';
+import { WeekScheduleGrid, type ScheduleSlot } from '@/features/gym/components/WeekScheduleGrid';
+import { getSessionRoster, getWeekBookings, mondayOf } from '@/features/gym/services/bookings';
 import { FORM_INPUT_CLASS } from '@/features/pro/lib/formStyles';
 import {
   CLASS_TYPES,
@@ -193,17 +194,93 @@ function SlotForm({
   );
 }
 
+function RosterPanel({ slot, onClose }: { slot: ScheduleSlot; onClose: () => void }) {
+  const t = useTranslations('pro.planning.roster');
+  const date = slot.sessionDate ?? '';
+  const load = useCallback(() => getSessionRoster(slot.id, date), [slot.id, date]);
+  const { state } = useAsyncResource(load, [slot.id, date]);
+
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-black uppercase tracking-[0.18em]">
+          {slot.title} · {slot.startTime}
+          <span className="ml-2 font-normal normal-case text-muted-foreground">{date}</span>
+        </p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-sm border border-border px-2 py-1 text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground"
+        >
+          {t('close')}
+        </button>
+      </div>
+      {state.status === 'loading' || state.status === 'idle' ? (
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
+      ) : state.status === 'error' ? (
+        <p className="text-sm font-semibold text-primary">{t('error')}</p>
+      ) : state.data.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-center text-sm text-muted-foreground">
+          {t('empty')}
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {state.data.map((r) => (
+            <li key={r.bookingId} className="flex items-center gap-3 py-2">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-black">
+                {(r.username ?? '?').slice(0, 2).toUpperCase()}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-sm font-bold">{r.username ?? '—'}</span>
+              {r.division ? (
+                <span className="hidden shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground sm:block">
+                  {r.division}
+                </span>
+              ) : null}
+              <span className="w-14 shrink-0 text-right text-sm font-black tabular-nums">
+                {r.rating ?? '—'}
+              </span>
+              <span
+                className={`w-24 shrink-0 text-right text-[10px] font-black uppercase tracking-[0.12em] ${
+                  r.status === 'confirmed' ? 'text-emerald-500' : 'text-amber-500'
+                }`}
+              >
+                {t(`status.${r.status}`)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 export function PlanningScreen() {
   const t = useTranslations('pro.planning');
   const profile = useOptionalAppProfile();
   const gymId = profile?.affiliated_gym_id ?? null;
   // Staff of the gym, or the platform/gym owner overseeing it — matches the RLS write policy.
   const canManage = canAccessPro(profile);
+  const monday = mondayOf(new Date());
 
-  const load = useCallback(() => listGymClasses(gymId ?? ''), [gymId]);
+  const load = useCallback(async () => {
+    const [classes, bookings] = await Promise.all([
+      listGymClasses(gymId ?? ''),
+      getWeekBookings(monday),
+    ]);
+    return classes.map((c): ScheduleSlot => {
+      const b = bookings.get(c.id);
+      return {
+        ...c,
+        bookedCount: b?.bookedCount ?? 0,
+        waitlistCount: b?.waitlistCount ?? 0,
+        sessionDate: b?.sessionDate,
+      };
+    });
+  }, [gymId, monday]);
   const { state, refetch } = useAsyncResource(load, [gymId ?? ''], { enabled: gymId !== null });
   const [creating, setCreating] = useState(false);
   const [editing, setEditing] = useState<GymClass | null>(null);
+  const [selected, setSelected] = useState<ScheduleSlot | null>(null);
 
   if (!gymId) {
     return <p className="text-sm text-muted-foreground">{t('noGym')}</p>;
@@ -288,18 +365,23 @@ export function PlanningScreen() {
           ) : null}
         </div>
       ) : (
-        <WeekScheduleGrid
-          classes={classes}
-          onEdit={canManage ? (c) => setEditing(c) : undefined}
-          onDelete={
-            canManage
-              ? async (c) => {
-                  await deleteGymClass(c.id);
-                  refetch();
-                }
-              : undefined
-          }
-        />
+        <>
+          <WeekScheduleGrid
+            classes={classes}
+            weekStart={monday}
+            onCardClick={canManage ? (c) => setSelected(c) : undefined}
+            onEdit={canManage ? (c) => setEditing(c) : undefined}
+            onDelete={
+              canManage
+                ? async (c) => {
+                    await deleteGymClass(c.id);
+                    refetch();
+                  }
+                : undefined
+            }
+          />
+          {selected ? <RosterPanel slot={selected} onClose={() => setSelected(null)} /> : null}
+        </>
       )}
     </div>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1385,7 +1385,18 @@
     "publicPage": "Public page",
     "scheduleTitle": "Weekly schedule",
     "scheduleEmpty": "No classes scheduled yet — your gym is setting things up.",
-    "bookingSoon": "Booking from the app is coming next."
+    "booking": {
+      "book": "Book",
+      "booked": "Booked",
+      "waitlisted": "Waitlisted",
+      "joinWaitlist": "Join waitlist",
+      "busy": "…",
+      "cancelHint": "Click to cancel",
+      "thisWeek": "This week",
+      "nextWeek": "Next week",
+      "prevWeek": "Previous week",
+      "error": "Booking failed — try again."
+    }
   },
   "gym": {
     "schedule": {
@@ -1473,6 +1484,16 @@
       "error": "Could not load the schedule.",
       "emptyTitle": "No classes yet",
       "emptyBody": "Build your weekly schedule — WOD, open gym, Hyrox… Members will see it in their app, and booking arrives next.",
+      "roster": {
+        "close": "Close",
+        "loading": "Loading roster…",
+        "error": "Could not load the roster.",
+        "empty": "No bookings for this session yet.",
+        "status": {
+          "confirmed": "Confirmed",
+          "waitlisted": "Waitlist"
+        }
+      },
       "form": {
         "title": "Class name",
         "titlePlaceholder": "WOD 18:00",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1385,7 +1385,18 @@
     "publicPage": "Page publique",
     "scheduleTitle": "Planning de la semaine",
     "scheduleEmpty": "Pas encore de cours au planning — ta salle s'installe.",
-    "bookingSoon": "La réservation depuis l'app arrive bientôt."
+    "booking": {
+      "book": "Réserver",
+      "booked": "Réservé",
+      "waitlisted": "En attente",
+      "joinWaitlist": "Liste d'attente",
+      "busy": "…",
+      "cancelHint": "Clique pour annuler",
+      "thisWeek": "Cette semaine",
+      "nextWeek": "Semaine prochaine",
+      "prevWeek": "Semaine précédente",
+      "error": "La réservation a échoué — réessaie."
+    }
   },
   "gym": {
     "schedule": {
@@ -1473,6 +1484,16 @@
       "error": "Impossible de charger le planning.",
       "emptyTitle": "Aucun cours pour le moment",
       "emptyBody": "Construis ton planning hebdo — WOD, open gym, Hyrox… Tes membres le verront dans leur app, et la réservation arrive juste après.",
+      "roster": {
+        "close": "Fermer",
+        "loading": "Chargement du roster…",
+        "error": "Impossible de charger le roster.",
+        "empty": "Aucune réservation sur cette session pour l'instant.",
+        "status": {
+          "confirmed": "Confirmé",
+          "waitlisted": "Attente"
+        }
+      },
       "form": {
         "title": "Nom du cours",
         "titlePlaceholder": "WOD 18h",

--- a/supabase/migrations/051_gym_bookings.sql
+++ b/supabase/migrations/051_gym_bookings.sql
@@ -1,0 +1,309 @@
+-- V4-02 (#168): reservations. gym_sessions = dated instances of a gym_class (lazily
+-- materialized on first booking); gym_bookings = a member's spot (confirmed / waitlisted /
+-- cancelled). Booking is transactional (session row locked) so capacity can never be
+-- oversold; cancelling a confirmed spot auto-promotes the oldest waitlisted member.
+-- Timezone: v1 assumes Europe/Paris (French boxes); a per-gym setting comes with V4 Settings.
+
+CREATE TABLE IF NOT EXISTS public.gym_sessions (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gym_id       UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  class_id     UUID        NOT NULL REFERENCES public.gym_classes(id) ON DELETE CASCADE,
+  session_date DATE        NOT NULL,
+  starts_at    TIMESTAMPTZ NOT NULL,
+  ends_at      TIMESTAMPTZ NOT NULL,
+  capacity     INT         NOT NULL CHECK (capacity BETWEEN 1 AND 500),
+  status       TEXT        NOT NULL DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'cancelled')),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (class_id, session_date)
+);
+
+COMMENT ON TABLE public.gym_sessions IS
+  'V4-02: dated instance of a gym_class, materialized on first booking.';
+
+CREATE INDEX IF NOT EXISTS idx_gym_sessions_gym_date ON public.gym_sessions (gym_id, session_date);
+
+CREATE TABLE IF NOT EXISTS public.gym_bookings (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id   UUID        NOT NULL REFERENCES public.gym_sessions(id) ON DELETE CASCADE,
+  user_id      UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status       TEXT        NOT NULL DEFAULT 'confirmed'
+    CHECK (status IN ('confirmed', 'waitlisted', 'cancelled')),
+  late_cancel  BOOLEAN     NOT NULL DEFAULT FALSE,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  cancelled_at TIMESTAMPTZ NULL,
+  UNIQUE (session_id, user_id)
+);
+
+COMMENT ON TABLE public.gym_bookings IS
+  'V4-02: a member''s spot in a session. late_cancel = cancelled a confirmed spot <2h before start (feeds no-show reputation later).';
+
+CREATE INDEX IF NOT EXISTS idx_gym_bookings_session ON public.gym_bookings (session_id, status, created_at);
+CREATE INDEX IF NOT EXISTS idx_gym_bookings_user ON public.gym_bookings (user_id, created_at DESC);
+
+ALTER TABLE public.gym_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gym_bookings ENABLE ROW LEVEL SECURITY;
+
+-- READ sessions: the gym's people / owner / platform admin (same shape as gym_classes).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'gym_sessions'
+      AND policyname = 'Gym people can read their gym sessions'
+  ) THEN
+    CREATE POLICY "Gym people can read their gym sessions"
+      ON public.gym_sessions FOR SELECT TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_sessions.gym_id)
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_sessions.gym_id AND g.owner_id = auth.uid())
+      );
+  END IF;
+END $$;
+
+-- READ bookings: your own, or staff/owner/admin of the session's gym.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'gym_bookings'
+      AND policyname = 'Own bookings or gym staff'
+  ) THEN
+    CREATE POLICY "Own bookings or gym staff"
+      ON public.gym_bookings FOR SELECT TO authenticated
+      USING (
+        user_id = auth.uid()
+        OR public.is_platform_admin()
+        OR EXISTS (
+          SELECT 1
+          FROM public.gym_sessions s
+          JOIN public.profiles p ON p.id = auth.uid()
+          WHERE s.id = gym_bookings.session_id
+            AND p.affiliated_gym_id = s.gym_id
+            AND p.role IN ('coach', 'gym_admin')
+        )
+        OR EXISTS (
+          SELECT 1 FROM public.gym_sessions s JOIN public.gyms g ON g.id = s.gym_id
+          WHERE s.id = gym_bookings.session_id AND g.owner_id = auth.uid()
+        )
+      );
+  END IF;
+END $$;
+
+-- All writes go through the RPCs below (no INSERT/UPDATE policies).
+
+-- Book a spot. Locks the session row → capacity can never be oversold. Full → waitlist.
+CREATE OR REPLACE FUNCTION public.book_session(p_class_id uuid, p_session_date date)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller    uuid := auth.uid();
+  v_gym       uuid;
+  c           public.gym_classes;
+  v_starts    timestamptz;
+  v_session   public.gym_sessions;
+  v_existing  public.gym_bookings;
+  v_confirmed int;
+  v_status    text;
+BEGIN
+  SELECT affiliated_gym_id INTO v_gym FROM public.profiles WHERE id = v_caller;
+  SELECT * INTO c FROM public.gym_classes WHERE id = p_class_id;
+
+  IF c.id IS NULL OR v_gym IS NULL OR c.gym_id <> v_gym THEN
+    RAISE EXCEPTION 'not_your_gym';
+  END IF;
+  IF NOT c.is_active THEN
+    RAISE EXCEPTION 'class_inactive';
+  END IF;
+  -- Our weekday: 0 = Monday … 6 = Sunday; ISODOW: 1 = Monday … 7 = Sunday.
+  IF EXTRACT(ISODOW FROM p_session_date)::int - 1 <> c.weekday THEN
+    RAISE EXCEPTION 'bad_date';
+  END IF;
+  IF p_session_date < CURRENT_DATE OR p_session_date > CURRENT_DATE + 14 THEN
+    RAISE EXCEPTION 'bad_date';
+  END IF;
+
+  v_starts := (p_session_date::timestamp + c.start_time) AT TIME ZONE 'Europe/Paris';
+  IF v_starts < NOW() THEN
+    RAISE EXCEPTION 'session_past';
+  END IF;
+
+  INSERT INTO public.gym_sessions (gym_id, class_id, session_date, starts_at, ends_at, capacity)
+  VALUES (c.gym_id, c.id, p_session_date, v_starts,
+          v_starts + make_interval(mins => c.duration_min), c.capacity)
+  ON CONFLICT (class_id, session_date) DO NOTHING;
+
+  SELECT * INTO v_session FROM public.gym_sessions
+  WHERE class_id = c.id AND session_date = p_session_date
+  FOR UPDATE;
+
+  IF v_session.status <> 'scheduled' THEN
+    RAISE EXCEPTION 'session_cancelled';
+  END IF;
+
+  SELECT * INTO v_existing FROM public.gym_bookings
+  WHERE session_id = v_session.id AND user_id = v_caller;
+  IF v_existing.id IS NOT NULL AND v_existing.status <> 'cancelled' THEN
+    RAISE EXCEPTION 'already_booked';
+  END IF;
+
+  SELECT count(*) INTO v_confirmed FROM public.gym_bookings
+  WHERE session_id = v_session.id AND status = 'confirmed';
+
+  v_status := CASE WHEN v_confirmed < v_session.capacity THEN 'confirmed' ELSE 'waitlisted' END;
+
+  IF v_existing.id IS NOT NULL THEN
+    UPDATE public.gym_bookings
+    SET status = v_status, created_at = NOW(), cancelled_at = NULL, late_cancel = FALSE
+    WHERE id = v_existing.id;
+  ELSE
+    INSERT INTO public.gym_bookings (session_id, user_id, status)
+    VALUES (v_session.id, v_caller, v_status);
+  END IF;
+
+  RETURN jsonb_build_object('status', v_status);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.book_session(uuid, date) TO authenticated;
+
+-- Cancel a booking (owner of the booking, or gym staff). Cancelling a confirmed spot
+-- promotes the oldest waitlisted member; <2h before start flags late_cancel.
+CREATE OR REPLACE FUNCTION public.cancel_booking(p_booking_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller   uuid := auth.uid();
+  b          public.gym_bookings;
+  s          public.gym_sessions;
+  v_is_staff boolean;
+  v_late     boolean := FALSE;
+  v_promoted uuid;
+BEGIN
+  SELECT * INTO b FROM public.gym_bookings WHERE id = p_booking_id;
+  IF b.id IS NULL THEN
+    RAISE EXCEPTION 'not_found';
+  END IF;
+
+  SELECT * INTO s FROM public.gym_sessions WHERE id = b.session_id FOR UPDATE;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = v_caller AND p.affiliated_gym_id = s.gym_id AND p.role IN ('coach', 'gym_admin')
+  ) OR EXISTS (
+    SELECT 1 FROM public.gyms g WHERE g.id = s.gym_id AND g.owner_id = v_caller
+  ) OR public.is_platform_admin()
+  INTO v_is_staff;
+
+  IF b.user_id <> v_caller AND NOT v_is_staff THEN
+    RAISE EXCEPTION 'not_allowed';
+  END IF;
+  IF b.status = 'cancelled' THEN
+    RETURN jsonb_build_object('status', 'cancelled');
+  END IF;
+
+  v_late := b.status = 'confirmed' AND s.starts_at - NOW() < interval '2 hours';
+
+  UPDATE public.gym_bookings
+  SET status = 'cancelled', cancelled_at = NOW(), late_cancel = v_late
+  WHERE id = b.id;
+
+  IF b.status = 'confirmed' THEN
+    SELECT id INTO v_promoted FROM public.gym_bookings
+    WHERE session_id = s.id AND status = 'waitlisted'
+    ORDER BY created_at
+    LIMIT 1;
+    IF v_promoted IS NOT NULL THEN
+      UPDATE public.gym_bookings SET status = 'confirmed' WHERE id = v_promoted;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object('status', 'cancelled', 'late', v_late, 'promoted', v_promoted IS NOT NULL);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.cancel_booking(uuid) TO authenticated;
+
+-- One week of the caller's gym schedule with live counts + the caller's own booking state.
+-- p_monday = the Monday of the requested week. Drives both "Ma salle" and /pro/planning.
+CREATE OR REPLACE FUNCTION public.week_bookings(p_monday date)
+RETURNS TABLE (
+  class_id       uuid,
+  session_date   date,
+  booked_count   int,
+  waitlist_count int,
+  my_status      text,
+  my_booking_id  uuid
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    c.id,
+    (p_monday + c.weekday)::date,
+    COALESCE(cnt.confirmed, 0)::int,
+    COALESCE(cnt.waitlisted, 0)::int,
+    mine.status,
+    mine.id
+  FROM public.gym_classes c
+  JOIN public.profiles caller ON caller.id = auth.uid() AND caller.affiliated_gym_id = c.gym_id
+  LEFT JOIN public.gym_sessions s
+    ON s.class_id = c.id AND s.session_date = (p_monday + c.weekday)::date
+  LEFT JOIN LATERAL (
+    SELECT
+      count(*) FILTER (WHERE gb.status = 'confirmed')  AS confirmed,
+      count(*) FILTER (WHERE gb.status = 'waitlisted') AS waitlisted
+    FROM public.gym_bookings gb WHERE gb.session_id = s.id
+  ) cnt ON TRUE
+  LEFT JOIN public.gym_bookings mine
+    ON mine.session_id = s.id AND mine.user_id = auth.uid() AND mine.status <> 'cancelled'
+  WHERE c.is_active;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.week_bookings(date) TO authenticated;
+
+-- Roster of one session for the coach: who's in (with athletic context), who waits.
+-- Staff / owner / platform admin of the gym only.
+CREATE OR REPLACE FUNCTION public.session_roster(p_class_id uuid, p_session_date date)
+RETURNS TABLE (
+  booking_id uuid,
+  user_id    uuid,
+  username   text,
+  division   text,
+  faction    text,
+  rating     numeric,
+  status     text,
+  booked_at  timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT gb.id, p.id, p.username, p.division, p.faction,
+         pr.rating_global, gb.status, gb.created_at
+  FROM public.gym_sessions s
+  JOIN public.gym_bookings gb ON gb.session_id = s.id AND gb.status <> 'cancelled'
+  JOIN public.profiles p ON p.id = gb.user_id
+  LEFT JOIN public.profile_ratings pr ON pr.user_id = p.id
+  WHERE s.class_id = p_class_id
+    AND s.session_date = p_session_date
+    AND (
+      EXISTS (
+        SELECT 1 FROM public.profiles me
+        WHERE me.id = auth.uid() AND me.affiliated_gym_id = s.gym_id
+          AND me.role IN ('coach', 'gym_admin')
+      )
+      OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = s.gym_id AND g.owner_id = auth.uid())
+      OR public.is_platform_admin()
+    )
+  ORDER BY (gb.status = 'confirmed') DESC, gb.created_at;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.session_roster(uuid, date) TO authenticated;


### PR DESCRIPTION
## V4-02 — Réservations (Closes #168)

**Backend — migration 051** (en prod) :
- `gym_sessions` (instances datées, matérialisées au 1er booking) + `gym_bookings` (confirmed / waitlisted / cancelled, flag `late_cancel` <2h → nourrira la réputation no-show).
- **`book_session` transactionnel** : la session est verrouillée (FOR UPDATE) → **le surbooking est impossible** ; complet → liste d'attente automatique.
- **`cancel_booking`** : annuler une place confirmée **promeut automatiquement le premier de la waitlist**.
- `week_bookings` (compteurs live + état du caller pour une semaine) · `session_roster` (staff-only).

**« Ma salle » (membre)** :
- Semaine réservable : **RÉSERVER** (rouge) / **RÉSERVÉ ✓** (vert, clic = annuler) / **LISTE D'ATTENTE** si complet / **EN ATTENTE**.
- Navigation cette semaine ↔ semaine prochaine (horizon 14j côté serveur).
- Aujourd'hui surligné, jours passés grisés, heures passées du jour masquées.
- Occupancy `X/N` sur chaque carte → **la règle « populaire » d'Igor (>10 = rouge) tourne sur du réel**.

**`/pro/planning` (coach)** :
- Compteurs live sur la grille.
- **Clic sur un cours → roster de la session** : chaque athlète avec **division + rating global + statut** — le différenciateur #5 (Resawod donne des noms, nous on donne le niveau).

### Smoke (live, Playwright + REST)
- Guards RPC : re-book → `already_booked` ✓ · mauvais jour → `bad_date` ✓ · heure passée → `session_past` ✓ · cancel ✓
- UI : RÉSERVER → RÉSERVÉ vert, compteur 1/16 ✓ · roster : `TestGrynd · SAVAGE · 68.59 · CONFIRMÉ` ✓
- Données de test purgées (bookings/sessions), planning conservé.

Migrations prod = **051**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)