### PR TITLE
feat(gym): V4-03 boucle résa ⇄ WOD — programmation quotidienne + leaderboard de classe (#169)

### DIFF
--- a/src/features/gym/components/MyGymScreen.tsx
+++ b/src/features/gym/components/MyGymScreen.tsx
@@ -6,6 +6,7 @@ import { useCallback, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { Leaderboard } from '@/features/challenges/components/Leaderboard';
 import { WeekScheduleGrid, type ScheduleSlot } from '@/features/gym/components/WeekScheduleGrid';
 import {
   bookSession,
@@ -13,7 +14,10 @@ import {
   getWeekBookings,
   mondayOf,
 } from '@/features/gym/services/bookings';
+import { getWeekWods, type GymWod } from '@/features/gym/services/wods';
+import { GYM_EVENT_VARIANTS } from '@/features/pro/services/events';
 import { listGymClasses } from '@/features/pro/services/planning';
+import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
 import { supabase } from '@/lib/supabase';
 
@@ -56,10 +60,11 @@ export function MyGymScreen() {
   const [actionError, setActionError] = useState(false);
 
   const load = useCallback(async () => {
-    const [gym, classes, bookings] = await Promise.all([
+    const [gym, classes, bookings, wods] = await Promise.all([
       getGymHeader(gymId ?? ''),
       listGymClasses(gymId ?? ''),
       getWeekBookings(monday),
+      getWeekWods(monday),
     ]);
     const slots: ScheduleSlot[] = classes
       .filter((c) => c.isActive)
@@ -74,7 +79,7 @@ export function MyGymScreen() {
           myBookingId: b?.myBookingId ?? null,
         };
       });
-    return { gym, slots };
+    return { gym, slots, wods };
   }, [gymId, monday]);
   const { state, refetch } = useAsyncResource(load, [gymId ?? '', monday], {
     enabled: gymId !== null,
@@ -115,8 +120,9 @@ export function MyGymScreen() {
     return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
   }
 
-  const { gym, slots } = state.data;
+  const { gym, slots, wods } = state.data;
   const today = todayIso();
+  const todayWod = wods.get(today) ?? null;
 
   const bookingFooter = (slot: ScheduleSlot) => {
     const date = slot.sessionDate ?? '';
@@ -232,9 +238,85 @@ export function MyGymScreen() {
             {t('scheduleEmpty')}
           </p>
         ) : (
-          <WeekScheduleGrid classes={slots} weekStart={monday} footer={bookingFooter} />
+          <WeekScheduleGrid
+            classes={slots}
+            weekStart={monday}
+            footer={bookingFooter}
+            dayBadge={(weekday) => {
+              const wod = wods.get(addDays(monday, weekday));
+              if (!wod) return null;
+              return (
+                <p
+                  className="truncate rounded-sm bg-primary/10 px-1.5 py-1 text-center text-[9px] font-black uppercase tracking-[0.1em] text-primary"
+                  title={wod.workout}
+                >
+                  {wod.title}
+                </p>
+              );
+            }}
+          />
         )}
       </div>
+
+      {todayWod ? <TodayWodPanel wod={todayWod} /> : null}
     </section>
+  );
+}
+
+/** The day's WOD: spec + score submission + the class/day leaderboard (the V4-03 loop). */
+function TodayWodPanel({ wod }: { wod: GymWod }) {
+  const t = useTranslations('myGym.wod');
+  const profile = useOptionalAppProfile();
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border border-border border-l-2 border-l-primary bg-card p-4">
+        <p className="text-[10px] font-black uppercase tracking-[0.18em] text-primary">
+          {t('todayTitle')}
+        </p>
+        <h2 className="mt-1 text-lg font-black uppercase tracking-tight">{wod.title}</h2>
+        {wod.workout && wod.workout !== wod.title ? (
+          <pre className="mt-2 whitespace-pre-wrap font-sans text-sm text-foreground">
+            {wod.workout}
+          </pre>
+        ) : null}
+
+        <div className="mt-4">
+          {done ? (
+            <p className="text-sm text-muted-foreground">{t('submitted')}</p>
+          ) : submitting ? (
+            <ScoreSubmissionForm
+              challengeId={wod.challengeId}
+              scoreType={wod.scoreType}
+              availableVariants={GYM_EVENT_VARIANTS}
+              onSubmitted={() => {
+                setSubmitting(false);
+                setDone(true);
+                setReloadKey((k) => k + 1);
+              }}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setSubmitting(true)}
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-3 text-sm font-black uppercase tracking-[0.18em] text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {t('submit')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <Leaderboard
+        key={`${wod.challengeId}-${reloadKey}-${profile?.id ?? ''}`}
+        challengeId={wod.challengeId}
+        scoreType={wod.scoreType}
+        availableVariants={GYM_EVENT_VARIANTS}
+        mode="full"
+      />
+    </div>
   );
 }

--- a/src/features/gym/components/WeekScheduleGrid.tsx
+++ b/src/features/gym/components/WeekScheduleGrid.tsx
@@ -54,6 +54,8 @@ type Props = {
   onCardClick?: (c: ScheduleSlot) => void;
   /** Per-card footer (e.g. the member booking button). */
   footer?: (c: ScheduleSlot) => React.ReactNode;
+  /** Rendered under each day header (e.g. the day's programmed WOD chip). */
+  dayBadge?: (weekday: number) => React.ReactNode;
 };
 
 /**
@@ -67,6 +69,7 @@ export function WeekScheduleGrid({
   onDelete,
   onCardClick,
   footer,
+  dayBadge,
 }: Props) {
   const locale = useLocale();
   const t = useTranslations('gym.schedule');
@@ -182,6 +185,7 @@ export function WeekScheduleGrid({
               {label}
               {date ? ` ${date.getDate()}` : ''}
             </p>
+            {dayBadge ? dayBadge(i) : null}
             {byDay[i].length === 0 ? (
               <p className="rounded-md border border-dashed border-border/60 p-2 text-center text-[10px] text-muted-foreground/60">
                 —

--- a/src/features/gym/services/wods.ts
+++ b/src/features/gym/services/wods.ts
@@ -1,0 +1,52 @@
+import { supabase } from '@/lib/supabase';
+import type { ScoreType } from '@/lib/types/database.types';
+
+/** The programmed WOD of one day (see `gym_wods` / V4-03). */
+export type GymWod = {
+  wodDate: string;
+  challengeId: string;
+  title: string;
+  workout: string;
+  scoreType: ScoreType;
+};
+
+type Row = {
+  wod_date: string;
+  challenge_id: string;
+  title: string;
+  workout: string;
+  score_type: ScoreType;
+};
+
+/** WODs of one week for the caller's gym, keyed by ISO date. */
+export async function getWeekWods(monday: string): Promise<Map<string, GymWod>> {
+  const { data, error } = await supabase.rpc('week_wods', { p_monday: monday });
+  if (error) throw new Error(error.message);
+  const map = new Map<string, GymWod>();
+  for (const r of (data ?? []) as Row[]) {
+    map.set(r.wod_date, {
+      wodDate: r.wod_date,
+      challengeId: r.challenge_id,
+      title: r.title,
+      workout: r.workout,
+      scoreType: r.score_type,
+    });
+  }
+  return map;
+}
+
+/** Program (or reprogram) the WOD of a day for the caller's gym. Staff-only server-side. */
+export async function programGymWod(input: {
+  wodDate: string;
+  title: string;
+  workout: string;
+  scoreType: ScoreType;
+}): Promise<void> {
+  const { error } = await supabase.rpc('program_gym_wod', {
+    p_wod_date: input.wodDate,
+    p_title: input.title,
+    p_workout: input.workout,
+    p_score_type: input.scoreType,
+  });
+  if (error) throw new Error(error.message);
+}

--- a/src/features/pro/components/PlanningScreen.tsx
+++ b/src/features/pro/components/PlanningScreen.tsx
@@ -8,6 +8,7 @@ import { FilterSelect } from '@/components/FilterSelect';
 import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { WeekScheduleGrid, type ScheduleSlot } from '@/features/gym/components/WeekScheduleGrid';
 import { getSessionRoster, getWeekBookings, mondayOf } from '@/features/gym/services/bookings';
+import { WodPlanner } from '@/features/pro/components/WodPlanner';
 import { FORM_INPUT_CLASS } from '@/features/pro/lib/formStyles';
 import {
   CLASS_TYPES,
@@ -312,6 +313,8 @@ export function PlanningScreen() {
           </button>
         ) : null}
       </header>
+
+      <WodPlanner monday={monday} canManage={canManage} />
 
       {creating ? (
         <SlotForm

--- a/src/features/pro/components/WodPlanner.tsx
+++ b/src/features/pro/components/WodPlanner.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { Dumbbell, Pencil, Plus } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { getWeekWods, programGymWod, type GymWod } from '@/features/gym/services/wods';
+import { FORM_INPUT_CLASS } from '@/features/pro/lib/formStyles';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import type { ScoreType } from '@/lib/types/database.types';
+
+function addDays(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00`);
+  d.setDate(d.getDate() + days);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function WodForm({
+  date,
+  initial,
+  onSaved,
+  onClose,
+}: {
+  date: string;
+  initial: GymWod | null;
+  onSaved: () => void;
+  onClose: () => void;
+}) {
+  const t = useTranslations('pro.planning.wod');
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [workout, setWorkout] = useState(initial?.workout ?? '');
+  const [scoreType, setScoreType] = useState<ScoreType>(initial?.scoreType ?? 'time');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function save() {
+    if (title.trim().length < 2) return;
+    setBusy(true);
+    setError(false);
+    try {
+      await programGymWod({ wodDate: date, title, workout, scoreType });
+      onSaved();
+    } catch {
+      setError(true);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-border border-l-2 border-l-primary bg-card p-4">
+      <p className="text-xs font-black uppercase tracking-[0.18em]">
+        {t('formTitle')} <span className="font-normal text-muted-foreground">{date}</span>
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={t('titlePlaceholder')}
+            className={FORM_INPUT_CLASS}
+          />
+        </label>
+        <div className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('scoreType')}
+          <div className="mt-2 flex gap-2">
+            {(['time', 'reps'] as const).map((st) => (
+              <button
+                key={st}
+                type="button"
+                onClick={() => setScoreType(st)}
+                className={`rounded-sm px-3 py-1.5 text-[10px] font-black uppercase tracking-[0.14em] ${
+                  scoreType === st
+                    ? 'bg-primary text-primary-foreground'
+                    : 'border border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {t(`scoreTypes.${st}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        {t('spec')}
+        <textarea
+          rows={4}
+          value={workout}
+          onChange={(e) => setWorkout(e.target.value)}
+          placeholder={t('specPlaceholder')}
+          className={`${FORM_INPUT_CLASS} resize-y`}
+        />
+      </label>
+      {error ? <p className="text-xs font-semibold text-primary">{t('error')}</p> : null}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy || title.trim().length < 2}
+          onClick={save}
+          className="rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? t('saving') : t('save')}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onClose}
+          className="rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          {t('cancel')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The week's WOD programming strip (/pro/planning): one cell per day — the programmed WOD
+ * or a "+ program" action. Booking cards & "Ma salle" read the same data (V4-03 loop).
+ */
+export function WodPlanner({ monday, canManage }: { monday: string; canManage: boolean }) {
+  const t = useTranslations('pro.planning.wod');
+  const locale = useLocale();
+  const load = useCallback(() => getWeekWods(monday), [monday]);
+  const { state, refetch } = useAsyncResource(load, [monday]);
+  const [editingDate, setEditingDate] = useState<string | null>(null);
+
+  const wods = state.status === 'ready' ? state.data : new Map<string, never>();
+  const dayLabel = (i: number) =>
+    new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(
+      new Date(`${addDays(monday, i)}T00:00:00`),
+    );
+
+  return (
+    <div className="space-y-3">
+      <h2 className="inline-flex items-center gap-2 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+        <Dumbbell className="h-4 w-4 text-primary" aria-hidden />
+        {t('stripTitle')}
+      </h2>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-7">
+        {Array.from({ length: 7 }, (_, i) => {
+          const date = addDays(monday, i);
+          const wod = wods.get(date) as GymWod | undefined;
+          return (
+            <div
+              key={date}
+              className={`rounded-md border p-2 ${
+                wod ? 'border-primary/40 bg-primary/5' : 'border-dashed border-border'
+              }`}
+            >
+              <p className="text-[9px] font-black uppercase tracking-[0.16em] text-muted-foreground">
+                {dayLabel(i)} {date.slice(8)}
+              </p>
+              {wod ? (
+                <div className="mt-1 flex items-center justify-between gap-1">
+                  <p className="truncate text-xs font-bold" title={wod.title}>
+                    {wod.title}
+                  </p>
+                  {canManage ? (
+                    <button
+                      type="button"
+                      onClick={() => setEditingDate(date)}
+                      aria-label={t('edit')}
+                      className="shrink-0 rounded-sm p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    >
+                      <Pencil className="h-3 w-3" aria-hidden />
+                    </button>
+                  ) : null}
+                </div>
+              ) : canManage ? (
+                <button
+                  type="button"
+                  onClick={() => setEditingDate(date)}
+                  className="mt-1 inline-flex items-center gap-1 text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-primary"
+                >
+                  <Plus className="h-3 w-3" aria-hidden />
+                  {t('program')}
+                </button>
+              ) : (
+                <p className="mt-1 text-[10px] text-muted-foreground/60">—</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {editingDate ? (
+        <WodForm
+          date={editingDate}
+          initial={(wods.get(editingDate) as GymWod | undefined) ?? null}
+          onSaved={() => {
+            setEditingDate(null);
+            refetch();
+          }}
+          onClose={() => setEditingDate(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1396,6 +1396,11 @@
       "nextWeek": "Next week",
       "prevWeek": "Previous week",
       "error": "Booking failed — try again."
+    },
+    "wod": {
+      "todayTitle": "Today's WOD",
+      "submit": "Post my score",
+      "submitted": "Score submitted — it lands on the class leaderboard once validated."
     }
   },
   "gym": {
@@ -1484,6 +1489,25 @@
       "error": "Could not load the schedule.",
       "emptyTitle": "No classes yet",
       "emptyBody": "Build your weekly schedule — WOD, open gym, Hyrox… Members will see it in their app, and booking arrives next.",
+      "wod": {
+        "stripTitle": "WODs of the week",
+        "program": "Program",
+        "edit": "Edit the WOD",
+        "formTitle": "WOD of",
+        "title": "WOD name",
+        "titlePlaceholder": "Fran, Murph, EMOM 20…",
+        "scoreType": "Scored by",
+        "scoreTypes": {
+          "time": "Time",
+          "reps": "Reps"
+        },
+        "spec": "Workout",
+        "specPlaceholder": "21-15-9\nThrusters 42,5/30 kg\nPull-ups",
+        "error": "Could not save — try again.",
+        "save": "Save WOD",
+        "saving": "Saving…",
+        "cancel": "Cancel"
+      },
       "roster": {
         "close": "Close",
         "loading": "Loading roster…",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1396,6 +1396,11 @@
       "nextWeek": "Semaine prochaine",
       "prevWeek": "Semaine précédente",
       "error": "La réservation a échoué — réessaie."
+    },
+    "wod": {
+      "todayTitle": "WOD du jour",
+      "submit": "Poster mon score",
+      "submitted": "Score envoyé — il rejoint le classement du cours une fois validé."
     }
   },
   "gym": {
@@ -1484,6 +1489,25 @@
       "error": "Impossible de charger le planning.",
       "emptyTitle": "Aucun cours pour le moment",
       "emptyBody": "Construis ton planning hebdo — WOD, open gym, Hyrox… Tes membres le verront dans leur app, et la réservation arrive juste après.",
+      "wod": {
+        "stripTitle": "WODs de la semaine",
+        "program": "Programmer",
+        "edit": "Modifier le WOD",
+        "formTitle": "WOD du",
+        "title": "Nom du WOD",
+        "titlePlaceholder": "Fran, Murph, EMOM 20…",
+        "scoreType": "Scoré en",
+        "scoreTypes": {
+          "time": "Temps",
+          "reps": "Reps"
+        },
+        "spec": "Workout",
+        "specPlaceholder": "21-15-9\nThrusters 42,5/30 kg\nPull-ups",
+        "error": "Impossible d'enregistrer — réessaie.",
+        "save": "Enregistrer le WOD",
+        "saving": "Enregistrement…",
+        "cancel": "Annuler"
+      },
       "roster": {
         "close": "Fermer",
         "loading": "Chargement du roster…",

--- a/supabase/migrations/052_gym_wods.sql
+++ b/supabase/migrations/052_gym_wods.sql
@@ -1,0 +1,140 @@
+-- V4-03 (#169): the booking ⇄ WOD loop. A gym programs ONE WOD per day (classic box
+-- programming — SugarWOD DNA); it shows on the booking cards, and scores flow through the
+-- core challenge pipeline (proof levels → Judge Console → leaderboard → realtime), exactly
+-- like gym events (migration 036). The day's leaderboard IS the class leaderboard.
+
+CREATE TABLE IF NOT EXISTS public.gym_wods (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gym_id       UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  wod_date     DATE        NOT NULL,
+  challenge_id UUID        NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  created_by   UUID        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (gym_id, wod_date)
+);
+
+COMMENT ON TABLE public.gym_wods IS
+  'V4-03: daily WOD programming. One WOD per gym per day, backed by a gym-scoped challenge (same pattern as gym_events).';
+
+CREATE INDEX IF NOT EXISTS idx_gym_wods_gym_date ON public.gym_wods (gym_id, wod_date DESC);
+
+ALTER TABLE public.gym_wods ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'gym_wods'
+      AND policyname = 'Gym people can read their gym wods'
+  ) THEN
+    CREATE POLICY "Gym people can read their gym wods"
+      ON public.gym_wods FOR SELECT TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_wods.gym_id)
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_wods.gym_id AND g.owner_id = auth.uid())
+      );
+  END IF;
+END $$;
+
+-- Writes via RPC only.
+
+-- Program (or reprogram) the WOD of a given day for the caller's gym. Staff-only.
+-- First call materializes a gym-scoped challenge (approved, off-arena) + its 'standard'
+-- variant; a second call on the same date UPDATES that challenge in place (free edit,
+-- already-posted scores stay attached).
+CREATE OR REPLACE FUNCTION public.program_gym_wod(
+  p_wod_date   date,
+  p_title      text,
+  p_workout    text,
+  p_score_type text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller    uuid := auth.uid();
+  v_gym       uuid;
+  v_staff     boolean;
+  v_owner     boolean;
+  v_existing  uuid;
+  v_challenge uuid;
+BEGIN
+  SELECT affiliated_gym_id, (role IN ('coach', 'gym_admin'))
+    INTO v_gym, v_staff
+  FROM public.profiles WHERE id = v_caller;
+
+  IF v_gym IS NULL THEN
+    RAISE EXCEPTION 'no_gym';
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = v_gym AND g.owner_id = v_caller)
+    INTO v_owner;
+  IF NOT (COALESCE(v_staff, false) OR v_owner OR public.is_platform_admin()) THEN
+    RAISE EXCEPTION 'not_gym_staff';
+  END IF;
+  IF p_score_type NOT IN ('time', 'reps') THEN
+    RAISE EXCEPTION 'bad_score_type';
+  END IF;
+  IF length(btrim(p_title)) < 2 THEN
+    RAISE EXCEPTION 'bad_title';
+  END IF;
+
+  SELECT challenge_id INTO v_existing
+  FROM public.gym_wods WHERE gym_id = v_gym AND wod_date = p_wod_date;
+
+  IF v_existing IS NOT NULL THEN
+    UPDATE public.challenges
+    SET title = btrim(p_title),
+        description = coalesce(nullif(btrim(p_workout), ''), btrim(p_title)),
+        rules = coalesce(nullif(btrim(p_workout), ''), btrim(p_title)),
+        score_type = p_score_type
+    WHERE id = v_existing;
+    RETURN jsonb_build_object('challenge_id', v_existing, 'updated', true);
+  END IF;
+
+  INSERT INTO public.challenges (title, description, rules, score_type, gym_id, creator_id,
+                                 is_official, status, ends_at)
+  VALUES (btrim(p_title), coalesce(nullif(btrim(p_workout), ''), btrim(p_title)),
+          coalesce(nullif(btrim(p_workout), ''), btrim(p_title)), p_score_type, v_gym, v_caller,
+          false, 'approved',
+          ((p_wod_date + 1)::timestamp AT TIME ZONE 'Europe/Paris'))
+  RETURNING id INTO v_challenge;
+
+  INSERT INTO public.challenge_variants (challenge_id, variant)
+  VALUES (v_challenge, 'standard')
+  ON CONFLICT (challenge_id, variant) DO NOTHING;
+
+  INSERT INTO public.gym_wods (gym_id, wod_date, challenge_id, created_by)
+  VALUES (v_gym, p_wod_date, v_challenge, v_caller);
+
+  RETURN jsonb_build_object('challenge_id', v_challenge, 'updated', false);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.program_gym_wod(date, text, text, text) TO authenticated;
+
+-- One week of the caller's gym WOD programming (drives the planning strip + booking cards).
+CREATE OR REPLACE FUNCTION public.week_wods(p_monday date)
+RETURNS TABLE (
+  wod_date     date,
+  challenge_id uuid,
+  title        text,
+  workout      text,
+  score_type   text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT w.wod_date, w.challenge_id, c.title, c.rules, c.score_type
+  FROM public.gym_wods w
+  JOIN public.challenges c ON c.id = w.challenge_id
+  JOIN public.profiles caller ON caller.id = auth.uid() AND caller.affiliated_gym_id = w.gym_id
+  WHERE w.wod_date BETWEEN p_monday AND p_monday + 6
+  ORDER BY w.wod_date;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.week_wods(date) TO authenticated;


### PR DESCRIPTION
## V4-03 — la chaîne qu'aucun outil de résa ne peut copier (Closes #169)

**Je réserve le 18h → je vois le WOD du jour → je viens → je poste mon score → il atterrit sur le classement du cours, validé par le coach sur le floor.**

### Backend — migration 052 (en prod)
- `gym_wods` : **UN WOD programmé par salle par jour** (ADN SugarWOD), adossé à un challenge gym-scopé exactement comme les events (mig 036) → les scores empruntent le pipeline cœur : proof levels → **Judge Console** → leaderboard → realtime.
- `program_gym_wod` (staff-only ; reprogrammer la même date met à jour le challenge en place, les scores déjà postés restent) · `week_wods`.

### /pro/planning
- Bande **« WODs de la semaine »** au-dessus de la grille : une cellule par jour — WOD programmé ou « + Programmer » (form inline : nom, workout libre, scoré temps/reps).

### « Ma salle »
- **Chip du WOD du jour** sous chaque en-tête de jour de la grille (visible en réservant).
- Panel **« WOD du jour »** : spec + **Poster mon score** + le **classement du cours**.

### Smoke — boucle complète en live
1. « Fran » programmé via la bande (21-15-9, For Time) ✓
2. Chip FRAN sous MAR. 7 dans « Ma salle » ✓
3. Panel WOD du jour avec le spec + POSTER MON SCORE ✓
4. Score **3:12** soumis ✓
5. → **le score est dans la Judge Console** : `Fran · HONOR · 03:12 · VALIDER` ✓ (le juge le valide → il devient vérifié sur le classement du cours)

Score de test purgé ; le WOD « Fran » du jour reste comme donnée pilote. Migrations prod = **052**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)