### PR TITLE
feat(pro): V4-04 rétention — dashboard membres à risque + filtre churn (#170)

### DIFF
--- a/src/features/pro/components/AtRiskPanel.tsx
+++ b/src/features/pro/components/AtRiskPanel.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { AlertTriangle, Mail } from 'lucide-react';
+import { useEffect } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { listAtRiskMembers, type AtRiskMember } from '@/features/pro/services/retention';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+
+function lastSeen(iso: string | null, locale: string): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(locale, { day: 'numeric', month: 'short' });
+}
+
+function NudgeButton({ member }: { member: AtRiskMember }) {
+  const t = useTranslations('pro.dashboard.atRisk');
+  if (!member.email) return null;
+  const subject = encodeURIComponent(t('nudgeSubject'));
+  const body = encodeURIComponent(t('nudgeBody', { name: member.username ?? '' }));
+  return (
+    <a
+      href={`mailto:${member.email}?subject=${subject}&body=${body}`}
+      onClick={() =>
+        trackEvent(ANALYTICS_EVENTS.retentionNudgeClicked, {
+          risk: member.risk,
+          daysInactive: member.daysInactive,
+        })
+      }
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+    >
+      <Mail className="h-3 w-3" aria-hidden />
+      {t('nudge')}
+    </a>
+  );
+}
+
+/**
+ * V4-04 — the retention block: members who used to train and have gone quiet.
+ * Incumbents tell you who paid; this tells you who you're about to lose.
+ */
+export function AtRiskPanel() {
+  const t = useTranslations('pro.dashboard.atRisk');
+  const locale = useLocale();
+  const { state } = useAsyncResource(listAtRiskMembers, []);
+
+  const count = state.status === 'ready' ? state.data.length : 0;
+  useEffect(() => {
+    if (state.status === 'ready') {
+      trackEvent(ANALYTICS_EVENTS.retentionDashboardViewed, { count });
+    }
+  }, [state.status, count]);
+
+  if (state.status !== 'ready') return null;
+
+  if (state.data.length === 0) {
+    return (
+      <div className="rounded-md border border-border bg-card p-4">
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('title')}
+        </p>
+        <p className="mt-1 text-sm text-emerald-500">{t('allGood')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-primary/40 bg-primary/5 p-4">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 text-primary" aria-hidden />
+        <p className="text-xs font-black uppercase tracking-[0.18em] text-primary">
+          {t('titleCount', { count: state.data.length })}
+        </p>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">{t('intro')}</p>
+
+      <ul className="mt-3 divide-y divide-border/60">
+        {state.data.slice(0, 6).map((m) => (
+          <li key={m.userId} className="flex items-center gap-3 py-2.5">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-black">
+              {(m.username ?? '?').slice(0, 2).toUpperCase()}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-bold">{m.username ?? '—'}</span>
+              <span className="block text-xs text-muted-foreground">
+                {t('inactiveFor', { days: m.daysInactive })} · {t('lastSeen')}{' '}
+                {lastSeen(m.lastActivityAt, locale)}
+              </span>
+            </span>
+            <span
+              className={`shrink-0 rounded-full px-2 py-0.5 text-[9px] font-black uppercase tracking-[0.12em] ${
+                m.risk === 'high'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-amber-500/20 text-amber-500'
+              }`}
+            >
+              {t(`risk.${m.risk}`)}
+            </span>
+            <NudgeButton member={m} />
+          </li>
+        ))}
+      </ul>
+      {state.data.length > 6 ? (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          {t('more', { count: state.data.length - 6 })}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -28,6 +28,15 @@ type SexFilter = (typeof SEX_FILTERS)[number];
 const PROOF_FILTERS = ['all', 'verified'] as const;
 type ProofFilter = (typeof PROOF_FILTERS)[number];
 
+/** Churn lens: active = trained in the last 30 days. */
+const ACTIVITY_FILTERS = ['all', 'active', 'inactive'] as const;
+type ActivityFilter = (typeof ACTIVITY_FILTERS)[number];
+
+function isActive30d(lastActivityAt: string | null): boolean {
+  if (!lastActivityAt) return false;
+  return Date.now() - new Date(lastActivityAt).getTime() < 30 * 24 * 3600 * 1000;
+}
+
 /** Hyrox-style age buckets — the same cuts event divisions will use later. */
 const AGE_CATS = ['u24', 'a2534', 'a3544', 'm45'] as const;
 type AgeCat = (typeof AGE_CATS)[number];
@@ -127,6 +136,7 @@ export function MembersList() {
   const [query, setQuery] = useState('');
   const [sexFilter, setSexFilter] = useState<SexFilter>('all');
   const [proofFilter, setProofFilter] = useState<ProofFilter>('all');
+  const [activityFilter, setActivityFilter] = useState<ActivityFilter>('all');
   const [divisionFilter, setDivisionFilter] = useState('');
   const [ageFilter, setAgeFilter] = useState('');
 
@@ -145,11 +155,13 @@ export function MembersList() {
         if (q && !(m.username ?? '').toLowerCase().includes(q)) return false;
         if (sexFilter !== 'all' && m.sex !== sexFilter) return false;
         if (proofFilter === 'verified' && m.verifiedCount === 0) return false;
+        if (activityFilter === 'active' && !isActive30d(m.lastActivityAt)) return false;
+        if (activityFilter === 'inactive' && isActive30d(m.lastActivityAt)) return false;
         if (divisionFilter && m.division !== divisionFilter) return false;
         if (ageFilter && ageCategory(m.age) !== ageFilter) return false;
         return true;
       }),
-    [members, q, sexFilter, proofFilter, divisionFilter, ageFilter],
+    [members, q, sexFilter, proofFilter, activityFilter, divisionFilter, ageFilter],
   );
 
   if (state.status === 'loading' || state.status === 'idle') {
@@ -225,6 +237,28 @@ export function MembersList() {
               >
                 {f === 'verified' ? <BadgeCheck className="h-3 w-3" aria-hidden /> : null}
                 {t(`filterProof.${f}`)}
+              </button>
+            ))}
+          </div>
+          <div
+            role="group"
+            aria-label={t('filterActivityLabel')}
+            className="inline-flex overflow-hidden rounded-md border border-border"
+          >
+            {ACTIVITY_FILTERS.map((f, i) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setActivityFilter(f)}
+                className={`px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] transition-colors ${
+                  i > 0 ? 'border-l border-border' : ''
+                } ${
+                  activityFilter === f
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-background text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {t(`filterActivity.${f}`)}
               </button>
             ))}
           </div>

--- a/src/features/pro/components/ProDashboard.tsx
+++ b/src/features/pro/components/ProDashboard.tsx
@@ -4,6 +4,7 @@ import { Gavel, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { AtRiskPanel } from '@/features/pro/components/AtRiskPanel';
 import { fetchGymOverview } from '@/features/pro/services/dashboard';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
 
@@ -62,6 +63,8 @@ export function ProDashboard() {
           );
         })}
       </ul>
+
+      <AtRiskPanel />
 
       <div className="space-y-3">
         <p className="text-[10px] font-black uppercase tracking-[0.18em] text-muted-foreground">

--- a/src/features/pro/services/retention.ts
+++ b/src/features/pro/services/retention.ts
@@ -1,0 +1,44 @@
+import { supabase } from '@/lib/supabase';
+
+export type RiskLevel = 'high' | 'watch';
+
+/** A member who used to train and has gone quiet (see `gym_at_risk_members` / V4-04). */
+export type AtRiskMember = {
+  userId: string;
+  username: string | null;
+  division: string | null;
+  faction: string | null;
+  email: string | null;
+  lastActivityAt: string | null;
+  daysInactive: number;
+  prevScores: number;
+  risk: RiskLevel;
+};
+
+type Row = {
+  user_id: string;
+  username: string | null;
+  division: string | null;
+  faction: string | null;
+  email: string | null;
+  last_activity_at: string | null;
+  days_inactive: number;
+  prev_scores: number;
+  risk: RiskLevel;
+};
+
+export async function listAtRiskMembers(): Promise<AtRiskMember[]> {
+  const { data, error } = await supabase.rpc('gym_at_risk_members');
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as Row[]).map((r) => ({
+    userId: r.user_id,
+    username: r.username,
+    division: r.division,
+    faction: r.faction,
+    email: r.email,
+    lastActivityAt: r.last_activity_at,
+    daysInactive: Number(r.days_inactive ?? 0),
+    prevScores: Number(r.prev_scores ?? 0),
+    risk: r.risk,
+  }));
+}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -8,6 +8,8 @@ export const ANALYTICS_EVENTS = {
   monetizationCosmeticsViewed: 'monetization_cosmetics_teaser_viewed',
   monetizationCosmeticsInterest: 'monetization_cosmetics_interest',
   plgGymRequested: 'plg_gym_request_submitted',
+  retentionDashboardViewed: 'retention_at_risk_viewed',
+  retentionNudgeClicked: 'retention_nudge_clicked',
 } as const;
 
 export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS];

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1478,7 +1478,23 @@
         "active7d": "Trained in the last 7 days"
       },
       "quickTitle": "Quick actions",
-      "pendingCta": "Review now"
+      "pendingCta": "Review now",
+      "atRisk": {
+        "title": "At-risk members",
+        "titleCount": "{count, plural, one {# at-risk member} other {# at-risk members}}",
+        "allGood": "Nobody is drifting away — the whole box is training. 💪",
+        "intro": "They used to train and have gone quiet. Reach out before they cancel.",
+        "inactiveFor": "{days} days inactive",
+        "lastSeen": "last seen",
+        "risk": {
+          "high": "At risk",
+          "watch": "Watch"
+        },
+        "nudge": "Reach out",
+        "nudgeSubject": "We miss you at the box!",
+        "nudgeBody": "Hey {name},\n\nWe haven't seen you at the box in a while — the crew (and the whiteboard) miss you. Come crush a WOD this week?\n\nSee you soon!",
+        "more": "+ {count} more in the members roster (Inactive filter)."
+      }
     },
     "planning": {
       "title": "Planning",
@@ -1608,6 +1624,12 @@
         "a2534": "25–34",
         "a3544": "35–44",
         "m45": "Masters 45+"
+      },
+      "filterActivityLabel": "Filter by activity",
+      "filterActivity": {
+        "all": "All",
+        "active": "Active 30d",
+        "inactive": "Inactive 30d"
       }
     },
     "billing": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1478,7 +1478,23 @@
         "active7d": "Entraînés ces 7 derniers jours"
       },
       "quickTitle": "Actions rapides",
-      "pendingCta": "Valider maintenant"
+      "pendingCta": "Valider maintenant",
+      "atRisk": {
+        "title": "Membres à risque",
+        "titleCount": "{count, plural, one {# membre à risque} other {# membres à risque}}",
+        "allGood": "Personne ne décroche — toute la box s'entraîne. 💪",
+        "intro": "Ils s'entraînaient et ne viennent plus. Relance-les avant qu'ils résilient.",
+        "inactiveFor": "{days} j d'inactivité",
+        "lastSeen": "vu le",
+        "risk": {
+          "high": "À risque",
+          "watch": "À surveiller"
+        },
+        "nudge": "Relancer",
+        "nudgeSubject": "On ne te voit plus à la box !",
+        "nudgeBody": "Salut {name},\n\nÇa fait un moment qu'on ne t'a pas vu à la box — l'équipe (et le tableau) te réclament. Tu passes taper un WOD cette semaine ?\n\nÀ très vite !",
+        "more": "+ {count} autres dans le roster Membres (filtre Inactifs)."
+      }
     },
     "planning": {
       "title": "Planning",
@@ -1608,6 +1624,12 @@
         "a2534": "25–34",
         "a3544": "35–44",
         "m45": "Masters 45+"
+      },
+      "filterActivityLabel": "Filtrer par activité",
+      "filterActivity": {
+        "all": "Tous",
+        "active": "Actifs 30j",
+        "inactive": "Inactifs 30j"
       }
     },
     "billing": {

--- a/supabase/migrations/053_gym_at_risk.sql
+++ b/supabase/migrations/053_gym_at_risk.sql
@@ -1,0 +1,56 @@
+-- V4-04 (#170): the retention engine — the lead sales argument. Incumbents tell a gym who
+-- paid; we tell them WHO THEY ARE ABOUT TO LOSE. v1 keeps the signal simple & explainable:
+-- a member who used to train (activity in the 30→60d window) and has gone quiet ≥14 days.
+--   'high'  = inactive ≥ 30 days
+--   'watch' = inactive 14–29 days
+-- Email is exposed to gym staff for the manual re-engagement nudge (normal gym-management
+-- data — Peppy/Resawod show it too). Staff/owner/platform-admin only, scoped to their gym.
+
+CREATE OR REPLACE FUNCTION public.gym_at_risk_members()
+RETURNS TABLE (
+  user_id          uuid,
+  username         text,
+  division         text,
+  faction          text,
+  email            text,
+  last_activity_at timestamptz,
+  days_inactive    int,
+  prev_scores      int,
+  risk             text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    p.id,
+    p.username,
+    p.division,
+    p.faction,
+    u.email,
+    p.last_activity_at,
+    (CURRENT_DATE - p.last_activity_at::date)::int,
+    (SELECT count(*)::int FROM public.scores s
+      WHERE s.user_id = p.id AND s.is_hidden = false
+        AND s.submitted_at >= NOW() - interval '60 days'
+        AND s.submitted_at <  NOW() - interval '30 days') AS prev_scores,
+    CASE WHEN p.last_activity_at < NOW() - interval '30 days' THEN 'high' ELSE 'watch' END
+  FROM public.profiles p
+  JOIN auth.users u ON u.id = p.id
+  JOIN public.profiles caller ON caller.id = auth.uid()
+  WHERE p.affiliated_gym_id = caller.affiliated_gym_id
+    AND caller.affiliated_gym_id IS NOT NULL
+    AND (
+      caller.role IN ('coach', 'gym_admin')
+      OR public.is_platform_admin()
+      OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = caller.affiliated_gym_id AND g.owner_id = caller.id)
+    )
+    AND p.id <> caller.id
+    AND p.last_activity_at IS NOT NULL
+    AND p.last_activity_at < NOW() - interval '14 days'
+  ORDER BY p.last_activity_at ASC
+  LIMIT 100;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gym_at_risk_members() TO authenticated;


### PR DESCRIPTION
## V4-04 — l'argument de vente (Closes #170)

**Peppy/Resawod te disent qui a payé. TrueGrynd te dit qui tu es en train de perdre.**

### Backend — migration 053 (en prod)
- `gym_at_risk_members` : membres qui s'entraînaient et ont décroché ≥14 j — **`watch`** (14-29 j) / **`high`** (≥30 j), avec jours d'inactivité, activité du mois précédent et email (staff de la salle uniquement, scopé). Signal v1 simple et explicable.

### Dashboard
- Bloc **« Membres à risque »** : carte alerte rouge — avatar, X j d'inactivité, vu le…, pill À RISQUE/À SURVEILLER, bouton **RELANCER** (mailto pré-rempli). État vert « personne ne décroche 💪 » sinon.

### Roster Membres
- Segmented **Tous / Actifs 30j / Inactifs 30j** — la lentille churn.

### Analytics
- `retention_at_risk_viewed` (count) + `retention_nudge_clicked` (risk, daysInactive).

### Smoke (live, activité backdatée via le guard `server_managed_update`)
- Dashboard : « 2 MEMBRES À RISQUE » — 45 j → À RISQUE, 20 j → À SURVEILLER, RELANCER ✓
- KPI Actifs(7j) passe 4 → 2 (cohérent) ✓
- Filtre « Inactifs 30j » → isole le bon membre ✓

Migrations prod = **053**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)