### PR TITLE
feat(pro): V4-05 abonnements — formules de la salle, assignation, vue membre (#171)

### DIFF
--- a/src/app/[locale]/app/pro/subscriptions/page.tsx
+++ b/src/app/[locale]/app/pro/subscriptions/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { SubscriptionsScreen } from '@/features/pro/components/SubscriptionsScreen';
+
+export default function ProSubscriptionsPage() {
+  return <SubscriptionsScreen />;
+}

--- a/src/features/gym/components/MyGymScreen.tsx
+++ b/src/features/gym/components/MyGymScreen.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/features/gym/services/bookings';
 import { getWeekWods, type GymWod } from '@/features/gym/services/wods';
 import { GYM_EVENT_VARIANTS } from '@/features/pro/services/events';
+import { getMyPlan } from '@/features/pro/services/memberships';
 import { listGymClasses } from '@/features/pro/services/planning';
 import { ScoreSubmissionForm } from '@/features/submission/components/ScoreSubmissionForm';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
@@ -60,11 +61,12 @@ export function MyGymScreen() {
   const [actionError, setActionError] = useState(false);
 
   const load = useCallback(async () => {
-    const [gym, classes, bookings, wods] = await Promise.all([
+    const [gym, classes, bookings, wods, myPlan] = await Promise.all([
       getGymHeader(gymId ?? ''),
       listGymClasses(gymId ?? ''),
       getWeekBookings(monday),
       getWeekWods(monday),
+      getMyPlan(),
     ]);
     const slots: ScheduleSlot[] = classes
       .filter((c) => c.isActive)
@@ -79,7 +81,7 @@ export function MyGymScreen() {
           myBookingId: b?.myBookingId ?? null,
         };
       });
-    return { gym, slots, wods };
+    return { gym, slots, wods, myPlan };
   }, [gymId, monday]);
   const { state, refetch } = useAsyncResource(load, [gymId ?? '', monday], {
     enabled: gymId !== null,
@@ -120,7 +122,7 @@ export function MyGymScreen() {
     return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
   }
 
-  const { gym, slots, wods } = state.data;
+  const { gym, slots, wods, myPlan } = state.data;
   const today = todayIso();
   const todayWod = wods.get(today) ?? null;
 
@@ -196,6 +198,21 @@ export function MyGymScreen() {
             <ExternalLink className="h-3.5 w-3.5" aria-hidden />
           </Link>
         </div>
+        {myPlan ? (
+          <p className="inline-flex flex-wrap items-center gap-x-2 rounded-md border border-border bg-card px-3 py-2 text-xs">
+            <span className="font-black uppercase tracking-[0.12em]">{myPlan.planName}</span>
+            {myPlan.creditsLeft != null ? (
+              <span className="text-muted-foreground">
+                {t('plan.creditsLeft', { count: myPlan.creditsLeft })}
+              </span>
+            ) : null}
+            {myPlan.expiresAt ? (
+              <span className="text-muted-foreground">
+                {t('plan.until', { date: myPlan.expiresAt })}
+              </span>
+            ) : null}
+          </p>
+        ) : null}
       </header>
 
       <div className="space-y-3">

--- a/src/features/pro/components/SubscriptionsScreen.tsx
+++ b/src/features/pro/components/SubscriptionsScreen.tsx
@@ -1,0 +1,382 @@
+'use client';
+
+import { Infinity as InfinityIcon, Plus, Ticket, UserPlus, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { FilterSelect } from '@/components/FilterSelect';
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import { FORM_INPUT_CLASS } from '@/features/pro/lib/formStyles';
+import { listGymMembers } from '@/features/pro/services/members';
+import {
+  assignPlan,
+  cancelMemberPlan,
+  createPlan,
+  listMemberPlans,
+  listPlans,
+  PLAN_KINDS,
+  togglePlan,
+  type MembershipPlan,
+  type MembershipPlanInput,
+  type PlanKind,
+} from '@/features/pro/services/memberships';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+
+function priceLabel(cents: number | null, locale: string): string | null {
+  if (cents == null) return null;
+  return new Intl.NumberFormat(locale, { style: 'currency', currency: 'EUR' }).format(cents / 100);
+}
+
+function PlanForm({ onSaved, onClose }: { onSaved: () => void; onClose: () => void }) {
+  const t = useTranslations('pro.subscriptions');
+  const profile = useOptionalAppProfile();
+  const [form, setForm] = useState<MembershipPlanInput>({
+    name: '',
+    kind: 'unlimited',
+    priceCents: null,
+    credits: 10,
+    validityDays: 30,
+  });
+  const [price, setPrice] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+
+  async function save() {
+    if (form.name.trim().length < 2 || !profile?.affiliated_gym_id) return;
+    setBusy(true);
+    setError(false);
+    try {
+      const cents = price.trim() === '' ? null : Math.round(Number(price.replace(',', '.')) * 100);
+      await createPlan(profile.affiliated_gym_id, {
+        ...form,
+        priceCents: Number.isFinite(cents) ? cents : null,
+      });
+      onSaved();
+    } catch {
+      setError(true);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4 rounded-md border border-border bg-card p-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.name')}
+          <input
+            value={form.name}
+            onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            placeholder={t('form.namePlaceholder')}
+            className={FORM_INPUT_CLASS}
+          />
+        </label>
+        <div className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.kind')}
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {PLAN_KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => setForm((f) => ({ ...f, kind: k as PlanKind }))}
+                className={`rounded-sm px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.12em] ${
+                  form.kind === k
+                    ? 'bg-primary text-primary-foreground'
+                    : 'border border-border text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {t(`kinds.${k}`)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.price')}
+          <input
+            type="text"
+            inputMode="decimal"
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+            placeholder="79,90"
+            className={FORM_INPUT_CLASS}
+          />
+        </label>
+        {form.kind === 'credits' ? (
+          <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('form.credits')}
+            <input
+              type="number"
+              min={1}
+              max={1000}
+              value={form.credits ?? 10}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, credits: Math.max(1, Number(e.target.value) || 1) }))
+              }
+              className={FORM_INPUT_CLASS}
+            />
+          </label>
+        ) : null}
+        <label className="block text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('form.validity')}
+          <input
+            type="number"
+            min={1}
+            max={730}
+            value={form.validityDays ?? 30}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, validityDays: Math.max(1, Number(e.target.value) || 30) }))
+            }
+            className={FORM_INPUT_CLASS}
+          />
+        </label>
+      </div>
+      {error ? <p className="text-xs font-semibold text-primary">{t('form.error')}</p> : null}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={busy || form.name.trim().length < 2}
+          onClick={save}
+          className="rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {busy ? t('form.saving') : t('form.create')}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onClose}
+          className="rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          {t('form.cancel')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SubscriptionsScreen() {
+  const t = useTranslations('pro.subscriptions');
+  const locale = useLocale();
+  const profile = useOptionalAppProfile();
+  const gymId = profile?.affiliated_gym_id ?? null;
+
+  const load = useCallback(async () => {
+    const [plans, memberPlans, members] = await Promise.all([
+      listPlans(gymId ?? ''),
+      listMemberPlans(gymId ?? ''),
+      listGymMembers(),
+    ]);
+    return { plans, memberPlans, members };
+  }, [gymId]);
+  const { state, refetch } = useAsyncResource(load, [gymId ?? ''], { enabled: gymId !== null });
+  const [creating, setCreating] = useState(false);
+  const [assigning, setAssigning] = useState<MembershipPlan | null>(null);
+  const [assignee, setAssignee] = useState('');
+  const [actionError, setActionError] = useState(false);
+
+  if (!gymId) return <p className="text-sm text-muted-foreground">{t('noGym')}</p>;
+  if (state.status === 'loading' || state.status === 'idle') {
+    return <p className="text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+  if (state.status === 'error') {
+    return <p className="text-sm font-semibold text-primary">{t('error')}</p>;
+  }
+
+  const { plans, memberPlans, members } = state.data;
+  const assignedIds = new Set(memberPlans.map((mp) => mp.userId));
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+        </div>
+        {!creating ? (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" aria-hidden />
+            {t('addPlan')}
+          </button>
+        ) : null}
+      </header>
+
+      {creating ? (
+        <PlanForm
+          onSaved={() => {
+            setCreating(false);
+            refetch();
+          }}
+          onClose={() => setCreating(false)}
+        />
+      ) : null}
+
+      {plans.length === 0 && !creating ? (
+        <div className="space-y-4 rounded-md border border-dashed border-border bg-muted/20 p-8 text-center">
+          <p className="text-sm font-black uppercase tracking-[0.14em]">{t('emptyTitle')}</p>
+          <p className="mx-auto max-w-md text-sm text-muted-foreground">{t('emptyBody')}</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {plans.map((p) => (
+            <div
+              key={p.id}
+              className={`space-y-3 rounded-md border border-border bg-card p-4 ${p.isActive ? '' : 'opacity-50'}`}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm font-black uppercase tracking-[0.12em]">{p.name}</p>
+                <span className="inline-flex items-center gap-1 rounded-sm bg-muted px-1.5 py-0.5 text-[9px] font-black uppercase tracking-[0.1em] text-muted-foreground">
+                  {p.kind === 'unlimited' ? (
+                    <InfinityIcon className="h-3 w-3" aria-hidden />
+                  ) : (
+                    <Ticket className="h-3 w-3" aria-hidden />
+                  )}
+                  {t(`kinds.${p.kind}`)}
+                </span>
+              </div>
+              <p className="text-2xl font-black tabular-nums">
+                {priceLabel(p.priceCents, locale) ?? '—'}
+                {p.validityDays ? (
+                  <span className="text-xs font-semibold text-muted-foreground">
+                    {' '}
+                    / {t('days', { days: p.validityDays })}
+                  </span>
+                ) : null}
+              </p>
+              {p.kind === 'credits' && p.credits ? (
+                <p className="text-xs text-muted-foreground">
+                  {t('creditsIncluded', { count: p.credits })}
+                </p>
+              ) : null}
+              <div className="flex gap-2 border-t border-border pt-3">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAssigning(p);
+                    setAssignee('');
+                  }}
+                  className="inline-flex items-center gap-1 rounded-sm bg-primary px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90"
+                >
+                  <UserPlus className="h-3 w-3" aria-hidden />
+                  {t('assign')}
+                </button>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await togglePlan(p.id, !p.isActive);
+                    refetch();
+                  }}
+                  className="rounded-sm border border-border px-2.5 py-1.5 text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground"
+                >
+                  {p.isActive ? t('deactivate') : t('activate')}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {assigning ? (
+        <div className="space-y-3 rounded-md border border-border border-l-2 border-l-primary bg-card p-4">
+          <p className="text-xs font-black uppercase tracking-[0.18em]">
+            {t('assignTitle', { plan: assigning.name })}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <FilterSelect
+              value={assignee}
+              onChange={setAssignee}
+              options={members
+                .filter((m) => m.username && !assignedIds.has(m.id))
+                .map((m) => ({ value: m.id, label: m.username ?? m.id }))}
+              allLabel={t('assignPlaceholder')}
+              ariaLabel={t('assignTitle', { plan: assigning.name })}
+              className="w-64"
+            />
+            <button
+              type="button"
+              disabled={!assignee}
+              onClick={async () => {
+                setActionError(false);
+                try {
+                  await assignPlan(gymId, assigning, assignee);
+                  setAssigning(null);
+                  refetch();
+                } catch {
+                  setActionError(true);
+                }
+              }}
+              className="rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {t('assignConfirm')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setAssigning(null)}
+              className="rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground"
+            >
+              {t('form.cancel')}
+            </button>
+          </div>
+          {actionError ? (
+            <p className="text-xs font-semibold text-primary">{t('assignError')}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+          {t('assignedTitle', { count: memberPlans.length })}
+        </h2>
+        {memberPlans.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-center text-sm text-muted-foreground">
+            {t('assignedEmpty')}
+          </p>
+        ) : (
+          <ul className="rounded-md border border-border bg-card">
+            {memberPlans.map((mp) => (
+              <li
+                key={mp.id}
+                className="flex items-center gap-3 border-b border-border px-4 py-3 last:border-b-0"
+              >
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-black">
+                  {(mp.username ?? '?').slice(0, 2).toUpperCase()}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-bold">
+                  {mp.username ?? '—'}
+                </span>
+                <span className="hidden shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-black uppercase tracking-[0.12em] text-muted-foreground sm:block">
+                  {mp.planName}
+                </span>
+                {mp.creditsLeft != null ? (
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {t('creditsLeft', { count: mp.creditsLeft })}
+                  </span>
+                ) : null}
+                <span className="hidden w-24 shrink-0 text-right text-xs text-muted-foreground md:block">
+                  {mp.expiresAt ?? '∞'}
+                </span>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await cancelMemberPlan(mp.id);
+                    refetch();
+                  }}
+                  aria-label={t('unassign')}
+                  title={t('unassign')}
+                  className="shrink-0 rounded-sm p-1.5 text-muted-foreground hover:bg-muted hover:text-primary"
+                >
+                  <X className="h-3.5 w-3.5" aria-hidden />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">{t('connectNote')}</p>
+    </div>
+  );
+}

--- a/src/features/pro/lib/proNav.ts
+++ b/src/features/pro/lib/proNav.ts
@@ -81,7 +81,7 @@ export const PRO_NAV: readonly ProNavGroup[] = [
         path: '/app/pro/subscriptions',
         icon: Ticket,
         labelKey: 'subscriptions',
-        status: 'soon',
+        status: 'live',
         managerOnly: true,
       },
       {

--- a/src/features/pro/services/memberships.ts
+++ b/src/features/pro/services/memberships.ts
@@ -1,0 +1,192 @@
+import { supabase } from '@/lib/supabase';
+
+export const PLAN_KINDS = ['unlimited', 'credits', 'dropin'] as const;
+export type PlanKind = (typeof PLAN_KINDS)[number];
+
+/** One of the gym's own offers (see `gym_membership_plans` / V4-05). */
+export type MembershipPlan = {
+  id: string;
+  gymId: string;
+  name: string;
+  kind: PlanKind;
+  priceCents: number | null;
+  currency: string;
+  credits: number | null;
+  validityDays: number | null;
+  isActive: boolean;
+};
+
+export type MembershipPlanInput = {
+  name: string;
+  kind: PlanKind;
+  priceCents: number | null;
+  credits: number | null;
+  validityDays: number | null;
+};
+
+type PlanRow = {
+  id: string;
+  gym_id: string;
+  name: string;
+  kind: PlanKind;
+  price_cents: number | null;
+  currency: string;
+  credits: number | null;
+  validity_days: number | null;
+  is_active: boolean;
+};
+
+const PLAN_COLUMNS =
+  'id, gym_id, name, kind, price_cents, currency, credits, validity_days, is_active';
+
+function planFromRow(r: PlanRow): MembershipPlan {
+  return {
+    id: r.id,
+    gymId: r.gym_id,
+    name: r.name,
+    kind: r.kind,
+    priceCents: r.price_cents,
+    currency: r.currency,
+    credits: r.credits,
+    validityDays: r.validity_days,
+    isActive: r.is_active,
+  };
+}
+
+export async function listPlans(gymId: string): Promise<MembershipPlan[]> {
+  const { data, error } = await supabase
+    .from('gym_membership_plans')
+    .select(PLAN_COLUMNS)
+    .eq('gym_id', gymId)
+    .order('created_at');
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as PlanRow[]).map(planFromRow);
+}
+
+export async function createPlan(gymId: string, input: MembershipPlanInput): Promise<void> {
+  const { error } = await supabase.from('gym_membership_plans').insert({
+    gym_id: gymId,
+    name: input.name,
+    kind: input.kind,
+    price_cents: input.priceCents,
+    credits: input.kind === 'credits' ? input.credits : null,
+    validity_days: input.validityDays,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function togglePlan(id: string, isActive: boolean): Promise<void> {
+  const { error } = await supabase
+    .from('gym_membership_plans')
+    .update({ is_active: isActive })
+    .eq('id', id);
+  if (error) throw new Error(error.message);
+}
+
+/** A member's assigned plan (joined for the managers' list). */
+export type MemberPlan = {
+  id: string;
+  userId: string;
+  username: string | null;
+  planId: string;
+  planName: string;
+  kind: PlanKind;
+  status: 'active' | 'expired' | 'cancelled';
+  creditsLeft: number | null;
+  startedAt: string;
+  expiresAt: string | null;
+};
+
+type MemberPlanRow = {
+  id: string;
+  user_id: string;
+  plan_id: string;
+  status: 'active' | 'expired' | 'cancelled';
+  credits_left: number | null;
+  started_at: string;
+  expires_at: string | null;
+  gym_membership_plans: { name: string; kind: PlanKind } | null;
+  profiles: { username: string | null } | null;
+};
+
+export async function listMemberPlans(gymId: string): Promise<MemberPlan[]> {
+  const { data, error } = await supabase
+    .from('gym_member_plans')
+    .select(
+      'id, user_id, plan_id, status, credits_left, started_at, expires_at, gym_membership_plans(name, kind), profiles(username)',
+    )
+    .eq('gym_id', gymId)
+    .eq('status', 'active')
+    .order('created_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as unknown as MemberPlanRow[]).map((r) => ({
+    id: r.id,
+    userId: r.user_id,
+    username: r.profiles?.username ?? null,
+    planId: r.plan_id,
+    planName: r.gym_membership_plans?.name ?? '—',
+    kind: r.gym_membership_plans?.kind ?? 'unlimited',
+    status: r.status,
+    creditsLeft: r.credits_left,
+    startedAt: r.started_at,
+    expiresAt: r.expires_at,
+  }));
+}
+
+/** Assign a plan to a member (one active plan per member — cancels nothing, DB enforces). */
+export async function assignPlan(
+  gymId: string,
+  plan: MembershipPlan,
+  userId: string,
+): Promise<void> {
+  const expires =
+    plan.validityDays == null
+      ? null
+      : new Date(Date.now() + plan.validityDays * 24 * 3600 * 1000).toISOString().slice(0, 10);
+  const { error } = await supabase.from('gym_member_plans').insert({
+    gym_id: gymId,
+    plan_id: plan.id,
+    user_id: userId,
+    credits_left: plan.kind === 'credits' ? plan.credits : null,
+    expires_at: expires,
+  });
+  if (error) throw new Error(error.message);
+}
+
+export async function cancelMemberPlan(id: string): Promise<void> {
+  const { error } = await supabase
+    .from('gym_member_plans')
+    .update({ status: 'cancelled' })
+    .eq('id', id);
+  if (error) throw new Error(error.message);
+}
+
+/** The caller's own active plan (member view, "Ma salle"). */
+export async function getMyPlan(): Promise<MemberPlan | null> {
+  const { data: auth } = await supabase.auth.getUser();
+  const uid = auth.user?.id;
+  if (!uid) return null;
+  const { data, error } = await supabase
+    .from('gym_member_plans')
+    .select(
+      'id, user_id, plan_id, status, credits_left, started_at, expires_at, gym_membership_plans(name, kind), profiles(username)',
+    )
+    .eq('user_id', uid)
+    .eq('status', 'active')
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+  const r = data as unknown as MemberPlanRow;
+  return {
+    id: r.id,
+    userId: r.user_id,
+    username: r.profiles?.username ?? null,
+    planId: r.plan_id,
+    planName: r.gym_membership_plans?.name ?? '—',
+    kind: r.gym_membership_plans?.kind ?? 'unlimited',
+    status: r.status,
+    creditsLeft: r.credits_left,
+    startedAt: r.started_at,
+    expiresAt: r.expires_at,
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1401,6 +1401,10 @@
       "todayTitle": "Today's WOD",
       "submit": "Post my score",
       "submitted": "Score submitted — it lands on the class leaderboard once validated."
+    },
+    "plan": {
+      "creditsLeft": "· {count} sessions left",
+      "until": "· until {date}"
     }
   },
   "gym": {
@@ -1798,6 +1802,47 @@
         "registry_unreachable": "The business registry is unreachable right now — try again shortly.",
         "registry_error": "The business registry returned an error — try again shortly."
       }
+    },
+    "subscriptions": {
+      "title": "Memberships",
+      "subtitle": "Your gym's own plans & passes — assign them to members. Collection via Stripe arrives next.",
+      "noGym": "Create your gym first.",
+      "loading": "Loading plans…",
+      "error": "Could not load plans.",
+      "addPlan": "Add a plan",
+      "emptyTitle": "No plans yet",
+      "emptyBody": "Create your offers — unlimited monthly, 10-pack, drop-in — and assign them to your members.",
+      "kinds": {
+        "unlimited": "Unlimited",
+        "credits": "Pass",
+        "dropin": "Drop-in"
+      },
+      "days": "{days} d",
+      "creditsIncluded": "{count} sessions included",
+      "creditsLeft": "{count} left",
+      "assign": "Assign",
+      "assignTitle": "Assign « {plan} »",
+      "assignPlaceholder": "Pick a member…",
+      "assignConfirm": "Confirm",
+      "assignError": "Could not assign — the member may already have an active plan.",
+      "assignedTitle": "{count, plural, =0 {No active memberships} one {# active membership} other {# active memberships}}",
+      "assignedEmpty": "Nobody is on a plan yet.",
+      "unassign": "Cancel this membership",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "form": {
+        "name": "Plan name",
+        "namePlaceholder": "Unlimited monthly",
+        "kind": "Type",
+        "price": "Price (€)",
+        "credits": "Sessions",
+        "validity": "Validity (days)",
+        "error": "Could not save — try again.",
+        "create": "Create plan",
+        "saving": "Saving…",
+        "cancel": "Cancel"
+      },
+      "connectNote": "v1 is declarative tracking. Member payments (Stripe) land in the next slice — 0% commission, you only pay Stripe fees."
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1401,6 +1401,10 @@
       "todayTitle": "WOD du jour",
       "submit": "Poster mon score",
       "submitted": "Score envoyé — il rejoint le classement du cours une fois validé."
+    },
+    "plan": {
+      "creditsLeft": "· {count} séances restantes",
+      "until": "· jusqu'au {date}"
     }
   },
   "gym": {
@@ -1798,6 +1802,47 @@
         "registry_unreachable": "Le registre des entreprises est injoignable pour le moment — réessaie bientôt.",
         "registry_error": "Le registre des entreprises a renvoyé une erreur — réessaie bientôt."
       }
+    },
+    "subscriptions": {
+      "title": "Abonnements",
+      "subtitle": "Les formules de TA salle — assigne-les à tes membres. L'encaissement Stripe arrive juste après.",
+      "noGym": "Crée d'abord ta salle.",
+      "loading": "Chargement des formules…",
+      "error": "Impossible de charger les formules.",
+      "addPlan": "Ajouter une formule",
+      "emptyTitle": "Aucune formule",
+      "emptyBody": "Crée tes offres — illimité mensuel, carnet de 10, drop-in — et assigne-les à tes membres.",
+      "kinds": {
+        "unlimited": "Illimité",
+        "credits": "Carnet",
+        "dropin": "Drop-in"
+      },
+      "days": "{days} j",
+      "creditsIncluded": "{count} séances incluses",
+      "creditsLeft": "{count} restantes",
+      "assign": "Assigner",
+      "assignTitle": "Assigner « {plan} »",
+      "assignPlaceholder": "Choisir un membre…",
+      "assignConfirm": "Confirmer",
+      "assignError": "Impossible d'assigner — le membre a peut-être déjà une formule active.",
+      "assignedTitle": "{count, plural, =0 {Aucun abonnement actif} one {# abonnement actif} other {# abonnements actifs}}",
+      "assignedEmpty": "Personne n'a encore de formule.",
+      "unassign": "Résilier cet abonnement",
+      "deactivate": "Désactiver",
+      "activate": "Activer",
+      "form": {
+        "name": "Nom de la formule",
+        "namePlaceholder": "Illimité mensuel",
+        "kind": "Type",
+        "price": "Prix (€)",
+        "credits": "Séances",
+        "validity": "Validité (jours)",
+        "error": "Impossible d'enregistrer — réessaie.",
+        "create": "Créer la formule",
+        "saving": "Enregistrement…",
+        "cancel": "Annuler"
+      },
+      "connectNote": "v1 = suivi déclaratif. L'encaissement des membres (Stripe) arrive dans la slice suivante — 0% de commission, tu ne paies que les frais Stripe."
     }
   }
 }

--- a/supabase/migrations/054_gym_memberships.sql
+++ b/supabase/migrations/054_gym_memberships.sql
@@ -1,0 +1,100 @@
+-- V4-05 (#171): the gym's own membership plans & passes, assigned to members. v1 is
+-- DECLARATIVE (tracking who's on what plan) — real collection arrives with V4-06 (Stripe
+-- Connect), which will drive gym_member_plans.status from webhooks. Multi-tenant as usual.
+
+CREATE TABLE IF NOT EXISTS public.gym_membership_plans (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gym_id        UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  name          TEXT        NOT NULL CHECK (length(btrim(name)) > 0),
+  kind          TEXT        NOT NULL DEFAULT 'unlimited' CHECK (kind IN ('unlimited', 'credits', 'dropin')),
+  price_cents   INT         NULL CHECK (price_cents IS NULL OR price_cents >= 0),
+  currency      TEXT        NOT NULL DEFAULT 'EUR',
+  credits       INT         NULL CHECK (credits IS NULL OR credits BETWEEN 1 AND 1000),
+  validity_days INT         NULL CHECK (validity_days IS NULL OR validity_days BETWEEN 1 AND 730),
+  is_active     BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.gym_membership_plans IS
+  'V4-05: a gym''s own offers (unlimited monthly, 10-pack, drop-in…). Collection via Stripe Connect = V4-06.';
+
+CREATE INDEX IF NOT EXISTS idx_gym_membership_plans_gym ON public.gym_membership_plans (gym_id, is_active);
+
+CREATE TABLE IF NOT EXISTS public.gym_member_plans (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gym_id       UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  plan_id      UUID        NOT NULL REFERENCES public.gym_membership_plans(id) ON DELETE CASCADE,
+  user_id      UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status       TEXT        NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'expired', 'cancelled')),
+  credits_left INT         NULL,
+  started_at   DATE        NOT NULL DEFAULT CURRENT_DATE,
+  expires_at   DATE        NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.gym_member_plans IS
+  'V4-05: a member''s assigned plan. One active plan per member (partial unique index).';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_gym_member_plans_active
+  ON public.gym_member_plans (user_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_gym_member_plans_gym ON public.gym_member_plans (gym_id, status);
+
+ALTER TABLE public.gym_membership_plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gym_member_plans ENABLE ROW LEVEL SECURITY;
+
+-- Plans: readable by the gym's people; managed by gym_admin / owner / platform admin.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='gym_membership_plans' AND policyname='Gym people can read plans') THEN
+    CREATE POLICY "Gym people can read plans"
+      ON public.gym_membership_plans FOR SELECT TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_membership_plans.gym_id)
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_membership_plans.gym_id AND g.owner_id = auth.uid())
+      );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='gym_membership_plans' AND policyname='Gym managers can manage plans') THEN
+    CREATE POLICY "Gym managers can manage plans"
+      ON public.gym_membership_plans FOR ALL TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_membership_plans.gym_id AND p.role = 'gym_admin')
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_membership_plans.gym_id AND g.owner_id = auth.uid())
+      )
+      WITH CHECK (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_membership_plans.gym_id AND p.role = 'gym_admin')
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_membership_plans.gym_id AND g.owner_id = auth.uid())
+      );
+  END IF;
+END $$;
+
+-- Member plans: a member reads their own; managers read/manage the gym's.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='gym_member_plans' AND policyname='Own plan or gym managers') THEN
+    CREATE POLICY "Own plan or gym managers"
+      ON public.gym_member_plans FOR SELECT TO authenticated
+      USING (
+        user_id = auth.uid()
+        OR public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_member_plans.gym_id AND p.role IN ('coach', 'gym_admin'))
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_member_plans.gym_id AND g.owner_id = auth.uid())
+      );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='gym_member_plans' AND policyname='Gym managers can manage member plans') THEN
+    CREATE POLICY "Gym managers can manage member plans"
+      ON public.gym_member_plans FOR ALL TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_member_plans.gym_id AND p.role = 'gym_admin')
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_member_plans.gym_id AND g.owner_id = auth.uid())
+      )
+      WITH CHECK (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_member_plans.gym_id AND p.role = 'gym_admin')
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_member_plans.gym_id AND g.owner_id = auth.uid())
+      );
+  END IF;
+END $$;


### PR DESCRIPTION
## V4-05 — Abos & carnets (Closes #171)

La salle définit **ses** formules (illimité, carnet, drop-in) et sait qui est sur quoi. v1 déclaratif — l'encaissement réel (**Stripe Connect, 0% de commission**) arrive en V4-06 et pilotera les statuts via webhooks.

### Backend — migration 054 (en prod)
- `gym_membership_plans` (illimité / carnet / drop-in, prix, validité) + `gym_member_plans` (**une seule formule active par membre** — index unique partiel ; crédits restants, expiration). RLS : formules lisibles par la salle, gérées par gym_admin/owner ; l'abo d'un membre lisible par lui + le staff.

### `/pro/subscriptions` (nav `soon` → **live**, managers)
- Cartes formules (badge type, prix en gros, séances/validité), création, activer/désactiver.
- **Assignation** : FilterSelect sur le roster (membres déjà couverts exclus) → liste des abonnements actifs avec résiliation.

### « Ma salle »
- Le membre voit sa formule (nom, séances restantes, valable jusqu'au) dans le header.

### Smoke (live)
- Formule « Illimité mensuel » **89 €/30 j** créée via le form ✓ → assignée (« 1 abonnement actif ») ✓ → chip visible côté membre ✓. Assignation de test purgée, la formule reste en donnée pilote.

Migrations prod = **054**. 🤖 Generated with [Claude Code](https://claude.com/claude-code)