### PR TITLE
feat(pro): V4-09 imports — wizard CSV, invitations en masse, auto-affiliation (#176)

### DIFF
--- a/src/app/[locale]/app/pro/members/import/page.tsx
+++ b/src/app/[locale]/app/pro/members/import/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ImportMembersScreen } from '@/features/pro/components/ImportMembersScreen';
+
+export default function ImportMembersPage() {
+  return <ImportMembersScreen />;
+}

--- a/src/features/pro/components/ImportMembersScreen.tsx
+++ b/src/features/pro/components/ImportMembersScreen.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { ArrowLeft, FileUp, Send, Trash2, Upload } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useMemo, useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { FilterSelect } from '@/components/FilterSelect';
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
+import {
+  addImports,
+  deleteImport,
+  inviteAllPending,
+  listImports,
+  type MemberImportInput,
+} from '@/features/pro/services/imports';
+import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { parseCsv, type ParsedCsv } from '@/lib/csv';
+
+type Mapping = { email: string; name: string; sex: string; age: string };
+
+/** Guess columns from common header names (Peppy / Hustle Up / Resawod / generic exports). */
+function guessMapping(headers: string[]): Mapping {
+  const find = (re: RegExp) => {
+    const i = headers.findIndex((h) => re.test(h.trim()));
+    return i === -1 ? '' : String(i);
+  };
+  return {
+    email: find(/mail|courriel/i),
+    name: find(/^(nom complet|full ?name|name|nom|pr[ée]nom)/i),
+    sex: find(/sexe?$|genre|gender/i),
+    age: find(/^(age|âge)$/i),
+  };
+}
+
+function normalizeSex(raw: string): 'male' | 'female' | null {
+  const v = raw.trim().toLowerCase();
+  if (/^(m|h|homme|male|man)$/.test(v)) return 'male';
+  if (/^(f|femme|female|woman)$/.test(v)) return 'female';
+  return null;
+}
+
+function toInputs(csv: ParsedCsv, map: Mapping): MemberImportInput[] {
+  const idx = (s: string) => (s === '' ? -1 : Number(s));
+  const [ei, ni, si, ai] = [idx(map.email), idx(map.name), idx(map.sex), idx(map.age)];
+  const seen = new Set<string>();
+  const out: MemberImportInput[] = [];
+  for (const row of csv.rows) {
+    const email = (row[ei] ?? '').trim().toLowerCase();
+    if (!email.includes('@') || seen.has(email)) continue;
+    seen.add(email);
+    const age = ai >= 0 ? Number((row[ai] ?? '').replace(/\D/g, '')) : NaN;
+    out.push({
+      email,
+      fullName: ni >= 0 ? (row[ni] ?? '').trim() || null : null,
+      sex: si >= 0 ? normalizeSex(row[si] ?? '') : null,
+      age: Number.isFinite(age) && age >= 10 && age <= 100 ? age : null,
+    });
+  }
+  return out;
+}
+
+const STATUS_PILL: Record<string, string> = {
+  pending: 'bg-amber-500/20 text-amber-500',
+  invited: 'bg-sky-500/15 text-sky-400',
+  joined: 'bg-emerald-500/15 text-emerald-500',
+};
+
+export function ImportMembersScreen() {
+  const t = useTranslations('pro.membersImport');
+  const locale = useLocale();
+  const profile = useOptionalAppProfile();
+  const gymId = profile?.affiliated_gym_id ?? null;
+
+  const load = useCallback(() => listImports(gymId ?? ''), [gymId]);
+  const { state, refetch } = useAsyncResource(load, [gymId ?? ''], { enabled: gymId !== null });
+
+  const [csv, setCsv] = useState<ParsedCsv | null>(null);
+  const [mapping, setMapping] = useState<Mapping>({ email: '', name: '', sex: '', age: '' });
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  const parsed = useMemo(
+    () => (csv && mapping.email !== '' ? toInputs(csv, mapping) : []),
+    [csv, mapping],
+  );
+
+  async function onFile(file: File) {
+    const text = await file.text();
+    const result = parseCsv(text);
+    setCsv(result);
+    setMapping(guessMapping(result.headers));
+    setNotice(null);
+  }
+
+  async function doImport() {
+    if (!gymId || parsed.length === 0) return;
+    setBusy(true);
+    setError(false);
+    try {
+      const { inserted, skipped } = await addImports(gymId, parsed);
+      setNotice(t('imported', { inserted, skipped }));
+      setCsv(null);
+      refetch();
+    } catch {
+      setError(true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function doInvite() {
+    setBusy(true);
+    setError(false);
+    try {
+      const { invited, joined, failed } = await inviteAllPending();
+      setNotice(t('invitedResult', { invited, joined, failed }));
+      refetch();
+    } catch {
+      setError(true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!gymId) return <p className="text-sm text-muted-foreground">{t('noGym')}</p>;
+
+  const imports = state.status === 'ready' ? state.data : [];
+  const pendingCount = imports.filter((i) => i.status === 'pending').length;
+  const headerOptions = (csv?.headers ?? []).map((h, i) => ({ value: String(i), label: h }));
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <Link
+        href={`/${locale}/app/pro/members`}
+        className="inline-flex items-center gap-1 text-xs font-black uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        {t('back')}
+      </Link>
+
+      <header className="space-y-1">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      {notice ? (
+        <p className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-500">
+          {notice}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-semibold text-primary">
+          {t('error')}
+        </p>
+      ) : null}
+
+      {!csv ? (
+        <label className="flex cursor-pointer flex-col items-center gap-3 rounded-md border border-dashed border-border bg-muted/20 p-10 text-center hover:border-primary/60">
+          <FileUp className="h-8 w-8 text-muted-foreground" aria-hidden />
+          <span className="text-sm font-black uppercase tracking-[0.14em]">{t('dropTitle')}</span>
+          <span className="max-w-md text-xs text-muted-foreground">{t('dropBody')}</span>
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            className="sr-only"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void onFile(f);
+            }}
+          />
+        </label>
+      ) : (
+        <div className="space-y-4 rounded-md border border-border border-l-2 border-l-primary bg-card p-4">
+          <p className="text-xs font-black uppercase tracking-[0.18em]">
+            {t('mapTitle', { rows: csv.rows.length })}
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {(['email', 'name', 'sex', 'age'] as const).map((field) => (
+              <div
+                key={field}
+                className="text-[10px] font-black uppercase tracking-[0.16em] text-muted-foreground"
+              >
+                {t(`fields.${field}`)}
+                <div className="mt-1.5">
+                  <FilterSelect
+                    value={mapping[field]}
+                    onChange={(v) => setMapping((m) => ({ ...m, [field]: v }))}
+                    options={headerOptions}
+                    allLabel={t('ignore')}
+                    ariaLabel={t(`fields.${field}`)}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {mapping.email === '' ? (
+            <p className="text-xs font-semibold text-primary">{t('emailRequired')}</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              {t('previewCount', { count: parsed.length })}
+              {parsed
+                .slice(0, 3)
+                .map((p) => ` · ${p.email}`)
+                .join('')}
+            </p>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={busy || parsed.length === 0}
+              onClick={doImport}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              <Upload className="h-3.5 w-3.5" aria-hidden />
+              {busy ? t('importing') : t('importCta', { count: parsed.length })}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setCsv(null)}
+              className="rounded-md border border-border px-4 py-2 text-xs font-black uppercase tracking-[0.12em] text-muted-foreground hover:text-foreground disabled:opacity-50"
+            >
+              {t('cancel')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-xs font-black uppercase tracking-[0.18em] text-muted-foreground">
+            {t('listTitle', { count: imports.length })}
+          </h2>
+          {pendingCount > 0 ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={doInvite}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-[10px] font-black uppercase tracking-[0.14em] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              <Send className="h-3.5 w-3.5" aria-hidden />
+              {t('inviteCta', { count: pendingCount })}
+            </button>
+          ) : null}
+        </div>
+
+        {imports.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+            {t('listEmpty')}
+          </p>
+        ) : (
+          <ul className="rounded-md border border-border bg-card">
+            {imports.map((imp) => (
+              <li
+                key={imp.id}
+                className="flex items-center gap-3 border-b border-border px-4 py-2.5 last:border-b-0"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-bold">{imp.email}</span>
+                  {imp.fullName ? (
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {imp.fullName}
+                    </span>
+                  ) : null}
+                </span>
+                <span
+                  className={`shrink-0 rounded-full px-2 py-0.5 text-[9px] font-black uppercase tracking-[0.12em] ${STATUS_PILL[imp.status]}`}
+                >
+                  {t(`status.${imp.status}`)}
+                </span>
+                {imp.status === 'pending' ? (
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      await deleteImport(imp.id);
+                      refetch();
+                    }}
+                    aria-label={t('delete')}
+                    className="shrink-0 rounded-sm p-1.5 text-muted-foreground hover:bg-muted hover:text-primary"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                  </button>
+                ) : (
+                  <span className="w-6 shrink-0" />
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">{t('conciergeNote')}</p>
+    </div>
+  );
+}

--- a/src/features/pro/components/MembersList.tsx
+++ b/src/features/pro/components/MembersList.tsx
@@ -6,8 +6,10 @@ import { useMemo, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { FilterSelect } from '@/components/FilterSelect';
+import { useOptionalAppProfile } from '@/features/appshell/context/AppProfileContext';
 import { listGymMembers, type GymMember } from '@/features/pro/services/members';
 import { useAsyncResource } from '@/hooks/useAsyncResource';
+import { canAccessPro } from '@/lib/roles';
 
 function initials(name: string | null): string {
   return name ? name.slice(0, 2).toUpperCase() : '?';
@@ -132,6 +134,8 @@ function MemberRow({ member }: { member: GymMember }) {
 
 export function MembersList() {
   const t = useTranslations('pro.members');
+  const locale = useLocale();
+  const profile = useOptionalAppProfile();
   const { state } = useAsyncResource(listGymMembers, []);
   const [query, setQuery] = useState('');
   const [sexFilter, setSexFilter] = useState<SexFilter>('all');
@@ -172,9 +176,19 @@ export function MembersList() {
   }
 
   const header = (
-    <header className="space-y-1">
-      <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
-      <p className="text-sm text-muted-foreground">{t('intro')}</p>
+    <header className="flex flex-wrap items-start justify-between gap-3">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-black uppercase tracking-tight md:text-3xl">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('intro')}</p>
+      </div>
+      {canAccessPro(profile) ? (
+        <Link
+          href={`/${locale}/app/pro/members/import`}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-4 py-2.5 text-xs font-black uppercase tracking-[0.12em] text-foreground hover:bg-muted"
+        >
+          {t('importCta')}
+        </Link>
+      ) : null}
     </header>
   );
 

--- a/src/features/pro/services/imports.ts
+++ b/src/features/pro/services/imports.ts
@@ -1,0 +1,88 @@
+import { callEdgeFunction } from '@/lib/edgeFunction';
+import { supabase } from '@/lib/supabase';
+
+export type ImportStatus = 'pending' | 'invited' | 'joined';
+
+/** One imported roster row (see `gym_member_imports` / V4-09). */
+export type MemberImport = {
+  id: string;
+  email: string;
+  fullName: string | null;
+  sex: string | null;
+  age: number | null;
+  status: ImportStatus;
+};
+
+export type MemberImportInput = {
+  email: string;
+  fullName: string | null;
+  sex: 'male' | 'female' | null;
+  age: number | null;
+};
+
+type Row = {
+  id: string;
+  email: string;
+  full_name: string | null;
+  sex: string | null;
+  age: number | null;
+  status: ImportStatus;
+};
+
+export async function listImports(gymId: string): Promise<MemberImport[]> {
+  const { data, error } = await supabase
+    .from('gym_member_imports')
+    .select('id, email, full_name, sex, age, status')
+    .eq('gym_id', gymId)
+    .order('created_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as Row[]).map((r) => ({
+    id: r.id,
+    email: r.email,
+    fullName: r.full_name,
+    sex: r.sex,
+    age: r.age,
+    status: r.status,
+  }));
+}
+
+/** Insert parsed rows; duplicates (same gym+email) are skipped, not errors. */
+export async function addImports(
+  gymId: string,
+  rows: MemberImportInput[],
+): Promise<{ inserted: number; skipped: number }> {
+  let inserted = 0;
+  let skipped = 0;
+  // upsert with ignoreDuplicates so re-importing the same file is idempotent.
+  const { data, error } = await supabase
+    .from('gym_member_imports')
+    .upsert(
+      rows.map((r) => ({
+        gym_id: gymId,
+        email: r.email.toLowerCase(),
+        full_name: r.fullName,
+        sex: r.sex,
+        age: r.age,
+      })),
+      { onConflict: 'gym_id,email', ignoreDuplicates: true },
+    )
+    .select('id');
+  if (error) throw new Error(error.message);
+  inserted = (data ?? []).length;
+  skipped = rows.length - inserted;
+  return { inserted, skipped };
+}
+
+export async function deleteImport(id: string): Promise<void> {
+  const { error } = await supabase.from('gym_member_imports').delete().eq('id', id);
+  if (error) throw new Error(error.message);
+}
+
+/** Send invites for every pending row of the caller's gym (Edge Function, batches of 50). */
+export async function inviteAllPending(): Promise<{
+  invited: number;
+  joined: number;
+  failed: number;
+}> {
+  return callEdgeFunction('invite-members', {});
+}

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,62 @@
+/**
+ * Minimal CSV parser for the member-import wizard: auto-detects `,` vs `;` (French exports
+ * from Peppy/Resawod are usually `;`), handles quoted fields with embedded delimiters and
+ * doubled quotes, CRLF/CR line ends. Good enough for roster exports; not a full RFC engine.
+ */
+export type ParsedCsv = { headers: string[]; rows: string[][] };
+
+function detectDelimiter(firstLine: string): string {
+  const commas = (firstLine.match(/,/g) ?? []).length;
+  const semis = (firstLine.match(/;/g) ?? []).length;
+  return semis > commas ? ';' : ',';
+}
+
+export function parseCsv(text: string): ParsedCsv {
+  const clean = text.replace(/^﻿/, '');
+  const firstNewline = clean.indexOf('\n');
+  const delimiter = detectDelimiter(firstNewline === -1 ? clean : clean.slice(0, firstNewline));
+
+  const rows: string[][] = [];
+  let field = '';
+  let row: string[] = [];
+  let inQuotes = false;
+
+  const pushField = () => {
+    row.push(field.trim());
+    field = '';
+  };
+  const pushRow = () => {
+    if (row.length > 1 || (row.length === 1 && row[0] !== '')) rows.push(row);
+    row = [];
+  };
+
+  for (let i = 0; i < clean.length; i += 1) {
+    const ch = clean[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (clean[i + 1] === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === delimiter) {
+      pushField();
+    } else if (ch === '\n') {
+      pushField();
+      pushRow();
+    } else if (ch !== '\r') {
+      field += ch;
+    }
+  }
+  pushField();
+  pushRow();
+
+  const [headers = [], ...data] = rows;
+  return { headers, rows: data };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1636,7 +1636,8 @@
         "all": "All",
         "active": "Active 30d",
         "inactive": "Inactive 30d"
-      }
+      },
+      "importCta": "Import"
     },
     "billing": {
       "loading": "Loading…",
@@ -1845,6 +1846,40 @@
         "cancel": "Cancel"
       },
       "connectNote": "v1 is declarative tracking. Member payments (Stripe) land in the next slice — 0% commission, you only pay Stripe fees."
+    },
+    "membersImport": {
+      "back": "Back to members",
+      "title": "Import members",
+      "subtitle": "Move your roster over from Peppy, Hustle Up, Resawod or any CSV export — invites go out, members land affiliated to your box.",
+      "noGym": "Create your gym first.",
+      "error": "Something failed — try again.",
+      "dropTitle": "Upload a CSV file",
+      "dropBody": "Export your member list from your current tool (Peppy → Members → Export, Hustle Up, Resawod…) and drop the .csv here. We auto-detect columns.",
+      "mapTitle": "Map the columns — {rows} rows detected",
+      "fields": {
+        "email": "Email (required)",
+        "name": "Name",
+        "sex": "Sex",
+        "age": "Age"
+      },
+      "ignore": "— ignore —",
+      "emailRequired": "Pick the email column to continue.",
+      "previewCount": "{count} valid members ready",
+      "importCta": "Import {count} members",
+      "importing": "Importing…",
+      "cancel": "Cancel",
+      "imported": "{inserted} imported, {skipped} duplicates skipped.",
+      "listTitle": "{count, plural, =0 {No imported rows} one {# imported row} other {# imported rows}}",
+      "listEmpty": "Nothing imported yet.",
+      "inviteCta": "Send invites ({count})",
+      "invitedResult": "{invited} invites sent · {joined} existing accounts affiliated directly · {failed} failed.",
+      "status": {
+        "pending": "Pending",
+        "invited": "Invited",
+        "joined": "Joined"
+      },
+      "delete": "Remove",
+      "conciergeNote": "Prefer white-glove? Send us your export and we run the migration for you — concierge@truegrynd.com."
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1636,7 +1636,8 @@
         "all": "Tous",
         "active": "Actifs 30j",
         "inactive": "Inactifs 30j"
-      }
+      },
+      "importCta": "Importer"
     },
     "billing": {
       "loading": "Chargement…",
@@ -1845,6 +1846,40 @@
         "cancel": "Annuler"
       },
       "connectNote": "v1 = suivi déclaratif. L'encaissement des membres (Stripe) arrive dans la slice suivante — 0% de commission, tu ne paies que les frais Stripe."
+    },
+    "membersImport": {
+      "back": "Retour aux membres",
+      "title": "Importer des membres",
+      "subtitle": "Rapatrie ton roster depuis Peppy, Hustle Up, Resawod ou n'importe quel export CSV — les invitations partent, les membres arrivent affiliés à ta box.",
+      "noGym": "Crée d'abord ta salle.",
+      "error": "Un truc a échoué — réessaie.",
+      "dropTitle": "Charge un fichier CSV",
+      "dropBody": "Exporte ta liste de membres depuis ton outil actuel (Peppy → Membres → Export, Hustle Up, Resawod…) et dépose le .csv ici. On détecte les colonnes automatiquement.",
+      "mapTitle": "Associe les colonnes — {rows} lignes détectées",
+      "fields": {
+        "email": "Email (requis)",
+        "name": "Nom",
+        "sex": "Sexe",
+        "age": "Âge"
+      },
+      "ignore": "— ignorer —",
+      "emailRequired": "Choisis la colonne email pour continuer.",
+      "previewCount": "{count} membres valides prêts",
+      "importCta": "Importer {count} membres",
+      "importing": "Import…",
+      "cancel": "Annuler",
+      "imported": "{inserted} importés, {skipped} doublons ignorés.",
+      "listTitle": "{count, plural, =0 {Aucune ligne importée} one {# ligne importée} other {# lignes importées}}",
+      "listEmpty": "Rien d'importé pour le moment.",
+      "inviteCta": "Envoyer les invitations ({count})",
+      "invitedResult": "{invited} invitations envoyées · {joined} comptes existants affiliés directement · {failed} échecs.",
+      "status": {
+        "pending": "En attente",
+        "invited": "Invité",
+        "joined": "Inscrit"
+      },
+      "delete": "Retirer",
+      "conciergeNote": "Tu préfères qu'on s'en occupe ? Envoie-nous ton export et on fait la migration pour toi — concierge@truegrynd.com."
     }
   }
 }

--- a/supabase/functions/invite-members/index.ts
+++ b/supabase/functions/invite-members/index.ts
@@ -1,0 +1,127 @@
+// V4-09: batch-invite imported members. Staff-only. For every 'pending' import row of the
+// caller's gym: if the email already has an account → affiliate that profile directly and
+// flip the row to 'joined'; otherwise send a Supabase invite email (magic link) and flip it
+// to 'invited'. Auto-affiliation at signup is handled by the DB trigger (migration 056).
+
+import { createClient } from 'npm:@supabase/supabase-js@2';
+
+import { corsHeaders } from '../_shared/cors.ts';
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+const BATCH_CAP = 50;
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+  if (req.method !== 'POST') {
+    return jsonResponse({ code: 'method_not_allowed' }, 405);
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !anonKey || !serviceKey) {
+    return jsonResponse({ code: 'server_misconfigured' }, 500);
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return jsonResponse({ code: 'unauthorized' }, 401);
+  }
+
+  const authed = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+  const {
+    data: { user },
+    error: userErr,
+  } = await authed.auth.getUser();
+  if (userErr || !user) {
+    return jsonResponse({ code: 'unauthorized' }, 401);
+  }
+
+  const service = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+
+  // Caller must be staff (coach/gym_admin), the gym owner, or a platform admin — and affiliated.
+  const { data: caller } = await service
+    .from('profiles')
+    .select('affiliated_gym_id, role, is_admin')
+    .eq('id', user.id)
+    .maybeSingle();
+  const gymId = caller?.affiliated_gym_id as string | null;
+  if (!gymId) {
+    return jsonResponse({ code: 'no_gym' }, 400);
+  }
+  const isStaff = caller?.role === 'coach' || caller?.role === 'gym_admin';
+  const isAdmin = caller?.role === 'platform_admin' || caller?.is_admin === true;
+  let isOwner = false;
+  if (!isStaff && !isAdmin) {
+    const { data: gym } = await service
+      .from('gyms')
+      .select('owner_id')
+      .eq('id', gymId)
+      .maybeSingle();
+    isOwner = gym?.owner_id === user.id;
+  }
+  if (!isStaff && !isAdmin && !isOwner) {
+    return jsonResponse({ code: 'not_gym_staff' }, 403);
+  }
+
+  const { data: pending, error: pendingErr } = await service
+    .from('gym_member_imports')
+    .select('id, email')
+    .eq('gym_id', gymId)
+    .eq('status', 'pending')
+    .limit(BATCH_CAP);
+  if (pendingErr) {
+    return jsonResponse({ code: 'db_error' }, 500);
+  }
+  if (!pending || pending.length === 0) {
+    return jsonResponse({ invited: 0, joined: 0, failed: 0 });
+  }
+
+  let invited = 0;
+  let joined = 0;
+  let failed = 0;
+
+  for (const row of pending) {
+    const email = String(row.email).trim().toLowerCase();
+
+    // Already has an account? Affiliate directly — no email needed.
+    const { data: existing } = await service.rpc('get_user_id_by_email', { p_email: email });
+    const existingId = (existing as string | null) ?? null;
+
+    if (existingId) {
+      await service.from('profiles').update({ affiliated_gym_id: gymId }).eq('id', existingId);
+      await service
+        .from('gym_member_imports')
+        .update({ status: 'joined', joined_user_id: existingId })
+        .eq('id', row.id);
+      joined += 1;
+      continue;
+    }
+
+    const { error: inviteErr } = await service.auth.admin.inviteUserByEmail(email);
+    if (inviteErr) {
+      failed += 1;
+      continue;
+    }
+    await service
+      .from('gym_member_imports')
+      .update({ status: 'invited', invited_at: new Date().toISOString() })
+      .eq('id', row.id);
+    invited += 1;
+  }
+
+  return jsonResponse({ invited, joined, failed });
+});

--- a/supabase/migrations/056_gym_member_imports.sql
+++ b/supabase/migrations/056_gym_member_imports.sql
@@ -1,0 +1,107 @@
+-- V4-09 (#176): import & migration from incumbents (Peppy, Hustle Up, Resawod, CSV…).
+-- Staff imports a member list → rows land here as 'pending' → invites go out (Edge Function
+-- invite-members, service role) → when the person signs up (or already has an account),
+-- they are AUTO-AFFILIATED to the gym and the row flips to 'joined'. This is the switching
+---cost killer: a box moves its whole roster over in one upload.
+
+CREATE TABLE IF NOT EXISTS public.gym_member_imports (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  gym_id         UUID        NOT NULL REFERENCES public.gyms(id) ON DELETE CASCADE,
+  email          TEXT        NOT NULL CHECK (position('@' in email) > 1),
+  full_name      TEXT        NULL,
+  sex            TEXT        NULL CHECK (sex IS NULL OR sex IN ('male', 'female', 'other')),
+  age            INT         NULL CHECK (age IS NULL OR age BETWEEN 10 AND 100),
+  status         TEXT        NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'invited', 'joined')),
+  invited_at     TIMESTAMPTZ NULL,
+  joined_user_id UUID        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_by     UUID        NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (gym_id, email)
+);
+
+COMMENT ON TABLE public.gym_member_imports IS
+  'V4-09: imported roster rows (CSV from Peppy/Hustle Up/…). pending → invited → joined (auto-affiliation trigger).';
+
+CREATE INDEX IF NOT EXISTS idx_gym_member_imports_gym ON public.gym_member_imports (gym_id, status);
+CREATE INDEX IF NOT EXISTS idx_gym_member_imports_email ON public.gym_member_imports (lower(email));
+
+ALTER TABLE public.gym_member_imports ENABLE ROW LEVEL SECURITY;
+
+-- Staff/owner/platform-admin of the gym manage their import list (insert normalizes email
+-- client-side; unique(gym_id, email) dedupes).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='gym_member_imports' AND policyname='Gym staff manage imports') THEN
+    CREATE POLICY "Gym staff manage imports"
+      ON public.gym_member_imports FOR ALL TO authenticated
+      USING (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_member_imports.gym_id AND p.role IN ('coach', 'gym_admin'))
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_member_imports.gym_id AND g.owner_id = auth.uid())
+      )
+      WITH CHECK (
+        public.is_platform_admin()
+        OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.affiliated_gym_id = gym_member_imports.gym_id AND p.role IN ('coach', 'gym_admin'))
+        OR EXISTS (SELECT 1 FROM public.gyms g WHERE g.id = gym_member_imports.gym_id AND g.owner_id = auth.uid())
+      );
+  END IF;
+END $$;
+
+-- Auto-affiliation: when a profile appears (signup), match the signup email against the
+-- import list → affiliate to the gym, prefill sex/age if absent, flip the row to 'joined'.
+CREATE OR REPLACE FUNCTION public.match_gym_import()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email text;
+  imp     public.gym_member_imports;
+BEGIN
+  SELECT email INTO v_email FROM auth.users WHERE id = NEW.id;
+  IF v_email IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO imp FROM public.gym_member_imports
+  WHERE lower(email) = lower(v_email) AND status IN ('pending', 'invited')
+  ORDER BY created_at DESC
+  LIMIT 1;
+  IF imp.id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE public.profiles
+  SET affiliated_gym_id = imp.gym_id,
+      sex = COALESCE(sex, imp.sex),
+      age = COALESCE(age, imp.age)
+  WHERE id = NEW.id;
+
+  UPDATE public.gym_member_imports
+  SET status = 'joined', joined_user_id = NEW.id
+  WHERE id = imp.id;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_profile_created_match_import ON public.profiles;
+CREATE TRIGGER on_profile_created_match_import
+  AFTER INSERT ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.match_gym_import();
+
+-- Service-role helper for the invite-members Edge Function: does this email already have an
+-- account? (auth.users is not reachable through PostgREST otherwise.) NOT for clients.
+CREATE OR REPLACE FUNCTION public.get_user_id_by_email(p_email text)
+RETURNS uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM auth.users WHERE lower(email) = lower(p_email) LIMIT 1;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_user_id_by_email(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_id_by_email(text) TO service_role;


### PR DESCRIPTION
## V4-09 — Import & migration depuis les incumbents (Closes #176)

**Le tueur de switching cost : une box rapatrie tout son roster en un upload.**

### Backend — migration 056 (en prod) + Edge Function déployée
- `gym_member_imports` (pending → invited → joined, unique salle×email) + RLS staff.
- **Trigger `match_gym_import`** : quand un email importé s'inscrit → le profil est **auto-affilié à la box** (sexe/âge préremplis depuis l'import) et la ligne passe à `joined`.
- **Edge `invite-members`** (staff-only) : pour chaque ligne pending — **compte existant → affiliation directe** (zéro email) ; sinon **invitation Supabase (magic link)**. Batchs de 50, tolérance d'échec par ligne.
- `get_user_id_by_email` service-role only.

### Wizard (`/pro/members/import` + bouton **Importer** sur le roster)
1. **Upload CSV** — délimiteur auto (`;` des exports FR), parser maison (quotes/CRLF).
2. **Mapping colonnes** auto-deviné (email/nom/sexe/âge, headers FR & EN — presets Peppy/Hustle Up/Resawod par nature), FilterSelect par champ, préview.
3. **Import** dédupliqué et idempotent (ré-uploader le même fichier = 0 doublon).
4. Liste avec pills **EN ATTENTE / INVITÉ / INSCRIT**, suppression, bouton « Envoyer les invitations (N) ».
5. Note **concierge** (« envoie ton export, on migre pour toi »).

### Smoke (live, bout en bout)
- CSV façon Peppy (`Prénom;Nom;Email;Sexe;Age`) → colonnes devinées → « **3 importés, 0 doublons** » ✓
- Invitations : ligne domaine bidon → **échec propre** (reste pending) ✓ · ligne **compte existant → affilié direct + INSCRIT** (vérifié en DB : profil affilié, statut joined) ✓
- Ré-import du même fichier = idempotent ✓ (upsert ignoreDuplicates)

Données de test purgées. Migrations prod = **056**. Prochain enrichissement : vrais exports Peppy/Hustle Up d'Igor comme presets exacts + import historique de scores (niveau « tracked »).

🤖 Generated with [Claude Code](https://claude.com/claude-code)